### PR TITLE
Use PropsWithChildren generic on CardProps

### DIFF
--- a/apps/fixed-borrow/src/ui/base/Card/Card.tsx
+++ b/apps/fixed-borrow/src/ui/base/Card/Card.tsx
@@ -1,10 +1,8 @@
-import { ReactElement, ReactNode } from "react";
+import { PropsWithChildren, ReactElement } from "react";
 
-interface CardProps {
-  children: ReactNode;
-}
+interface CardProps {}
 
-export function Card({ children }: CardProps): ReactElement {
+export function Card({ children }: PropsWithChildren<CardProps>): ReactElement {
   return (
     <div className="rounded-lg bg-dawn py-10 px-12 text-white shadow-[0_4px_14px_rgb(4,9,26)]">
       {children}


### PR DESCRIPTION
Using the generic so react itself handles the type for children and to remove "children" from the component's  props API.