### PR TITLE
make secondary text 3 lumens brighter for better WCAG compliance

### DIFF
--- a/apps/fixed-borrow/tailwind.config.js
+++ b/apps/fixed-borrow/tailwind.config.js
@@ -38,7 +38,7 @@ module.exports = {
           DEFAULT: "#2A325A",
           hover: "#374681",
         },
-        secondaryText: "#8792BB",
+        secondaryText: "#A4ABC6",
         lightText: "#DADEED",
         lightButton: {
           DEFAULT: "#576CBD",


### PR DESCRIPTION
Now with More Accessibility!

|Before|After|
|--|--|
|<img width="589" alt="image" src="https://user-images.githubusercontent.com/4524175/226950509-400df2b2-983f-4465-87c6-6de82218c3b7.png">|<img width="606" alt="image" src="https://user-images.githubusercontent.com/4524175/226950206-ed55fb3d-d573-436b-886e-3a4b9d065a70.png">|