### PR TITLE
Fix broken production deploy of Fixed Borrow

### DIFF
--- a/apps/fixed-borrow/vite.config.ts
+++ b/apps/fixed-borrow/vite.config.ts
@@ -5,10 +5,4 @@ import tsconfigPaths from "vite-tsconfig-paths";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react(), tsconfigPaths()],
-  build: {
-    // Update the entry point to match the new location of the main.tsx file
-    rollupOptions: {
-      input: "/src/ui/main.tsx",
-    },
-  },
 });


### PR DESCRIPTION
`vite build` does not generate a working dist/ folder with this option. We can remove this and everything works in both prod and dev, so I guess it wasn't needed after all!