### PR TITLE
hotfix: Re-order chains so that foundry network works

### DIFF
--- a/apps/hyperdrive-trading/src/network/wagmiClient.ts
+++ b/apps/hyperdrive-trading/src/network/wagmiClient.ts
@@ -1,7 +1,5 @@
 import { getDefaultWallets } from "@rainbow-me/rainbowkit";
-// Something very strange is happening with the types, where if you don't import
-// Chain from wagmi then the return type of createConfig cannot be inferred.
-import { Chain, configureChains, createConfig } from "wagmi";
+import { configureChains, createConfig } from "wagmi";
 import { foundry, goerli } from "wagmi/chains";
 import { alchemyProvider } from "wagmi/providers/alchemy";
 import { jsonRpcProvider } from "wagmi/providers/jsonRpc";
@@ -10,23 +8,19 @@ const {
   VITE_LOCALHOST_NODE_RPC_URL: LOCALHOST_NODE_RPC_URL,
 } = import.meta.env;
 
-// Hack: An unused reference so that eslint doesn't automatically fixup the
-// Chain import.
-type UnusedChain = Chain;
-
 if (!ALCHEMY_GOERLI_RPC_KEY) {
   throw new Error("Provide an ALCHEMY_GOERLI_RPC_KEY variable in .env");
 }
 
 const { chains, publicClient, webSocketPublicClient } = configureChains(
-  [goerli, foundry],
+  [foundry, goerli],
   [
-    alchemyProvider({ apiKey: ALCHEMY_GOERLI_RPC_KEY }),
     jsonRpcProvider({
       rpc: () => ({
         http: LOCALHOST_NODE_RPC_URL,
       }),
     }),
+    alchemyProvider({ apiKey: ALCHEMY_GOERLI_RPC_KEY }),
   ],
 );
 

--- a/apps/hyperdrive-trading/src/ui/appconfig/useAppConfig.ts
+++ b/apps/hyperdrive-trading/src/ui/appconfig/useAppConfig.ts
@@ -1,5 +1,6 @@
 import { HyperdriveGoerliAddresses } from "@hyperdrive/core";
 import { useQuery } from "@tanstack/react-query";
+import assertNever from "assert-never";
 import { SupportedChainId } from "src/appconfig/chains/supportedChains";
 import { getAppConfig } from "src/appconfig/getAppConfig";
 import { AppConfig } from "src/appconfig/types";
@@ -11,12 +12,12 @@ export function useAppConfig(): {
   appConfig: AppConfig | undefined;
   appConfigStatus: "idle" | "error" | "loading" | "success";
 } {
-  const chainId = useChainId();
+  const chainId = useChainId() as SupportedChainId;
   const publicClient = usePublicClient();
   const { data: appConfig, status: appConfigStatus } = useQuery({
     queryKey: ["app-config", { chainId }],
     queryFn: async () => {
-      switch (chainId as SupportedChainId) {
+      switch (chainId) {
         case 5:
           return getAppConfig(HyperdriveGoerliAddresses, publicClient);
 
@@ -34,9 +35,7 @@ export function useAppConfig(): {
           );
 
         default:
-          throw new Error(
-            `No app config found for the currently connected chain: ${chainId}`,
-          );
+          assertNever(chainId);
       }
     },
     // The config never changes, so it can be cached forever


### PR DESCRIPTION
By listing `foundry` first, we fetch the devnet appconfig instead of the goerli one. The goerli contracts are all out-of-date with the latest ABIs, which was causing the app to break at the very top of the bootstrapping process.

Now, if you're connected to the wrong chain and you show up to the app, it'll load with devnet data and tell you Wrong Network instead, as you'd expect!

<img width="1728" alt="image" src="https://github.com/delvtech/hyperdrive-monorepo/assets/4524175/03c558e8-5ac4-459f-ab40-9c31c54fb21e">
