### PR TITLE
Rename base to shares

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
@@ -76,11 +76,11 @@ export function OpenShortForm({
       current.getMonth() + convertMillisecondsToMonths(market.termLengthMS),
     ),
   );
-  const shortToken = {
-    symbol: "Shares",
+  const bondToken = {
+    symbol: "Bonds",
     address: "0x0",
     decimals: 18,
-    name: "Shares",
+    name: "Bonds",
   } as Token;
   return (
     <div className="flex flex-col gap-10">
@@ -88,7 +88,7 @@ export function OpenShortForm({
       <div className="space-y-4 text-base-content">
         <h5>Amount to short</h5>
         <TokenInput
-          token={shortToken}
+          token={bondToken}
           value={amount ?? ""}
           onChange={(newAmount) => setAmount(newAmount)}
           showBalance={false}


### PR DESCRIPTION
TokenInput only uses the symbol from the Token object, so should be okay to replace on the openshort form.
![image](https://github.com/delvtech/hyperdrive-monorepo/assets/22210106/4ef1344d-266b-41a0-b7a0-d6bc26d69437)
