### PR TITLE
Adds tests for poolInfo and fixedapr

### DIFF
--- a/packages/hyperdrive/src/amm/getFixedAPR.test.ts
+++ b/packages/hyperdrive/src/amm/getFixedAPR.test.ts
@@ -3,13 +3,13 @@ import { ALICE } from "src/testing/accounts";
 import { publicClient } from "src/testing/utils";
 import { parseUnits } from "viem";
 import { expect, test } from "vitest";
-import { HyperdriveABI } from "..";
-import { getFixedAPR } from "./getFixedAPR";
-import { getPoolConfig } from "./getPoolConfig/getPoolConfig";
-import { getPoolInfo } from "./getPoolInfo";
-import { setupMintTokensAndApproveHyperdrive } from "./testing/setupMintTokensAndApproveHyperdrive";
+import { HyperdriveABI } from "src/abis/Hyperdrive";
+import { getFixedAPR } from "src/amm/getFixedAPR";
+import { getPoolConfig } from "src/amm/getPoolConfig/getPoolConfig";
+import { getPoolInfo } from "src/amm/getPoolInfo";
+import { setupMintTokensAndApproveHyperdrive } from "src/amm/testing/setupMintTokensAndApproveHyperdrive";
 
-test("gets the fixed APR and verifies its change after opening a long position", async () => {
+test("should verify APR decreases after opening a long position", async () => {
   const mockHyperdriveAddress = TestAddresses.mockHyperdrive;
   const mockHyperdriveMathAddress = TestAddresses.mockHyperdriveMath;
 
@@ -69,7 +69,7 @@ test("gets the fixed APR and verifies its change after opening a long position",
   expect(aprFinish).toBeLessThan(aprStart);
 });
 
-test("gets the fixed APR and verifies its change after opening a short position", async () => {
+test("should verify APR increases after opening a short position", async () => {
   const mockHyperdriveAddress = TestAddresses.mockHyperdrive;
   const mockHyperdriveMathAddress = TestAddresses.mockHyperdriveMath;
 

--- a/packages/hyperdrive/src/amm/getPoolInfo.test.ts
+++ b/packages/hyperdrive/src/amm/getPoolInfo.test.ts
@@ -4,9 +4,9 @@ import { ALICE } from "src/testing/accounts";
 import { publicClient } from "src/testing/utils";
 import { expect, test } from "vitest";
 import { HyperdriveABI, getPoolInfo } from "..";
-import { setupMintTokensAndApproveHyperdrive } from "./testing/setupMintTokensAndApproveHyperdrive";
+import { setupMintTokensAndApproveHyperdrive } from "src/amm/testing/setupMintTokensAndApproveHyperdrive";
 
-test("poolInfo changes after a trade", async () => {
+test("should observe an increase in longsOutstanding after executing two trades", async () => {
   // Constants
   const baseAmountIn = parseUnits("100", 18);
   const minAmountOut = 1n;


### PR DESCRIPTION
This PR adds tests for getFixedAPR and getPoolInfo. For getPoolInfo, eventually, it could be useful to create tests for each value on the object, but to get things started I created one for `longsOutstanding`.