### PR TITLE
Adds createHyperdriveMathContract

### DIFF
--- a/packages/hyperdrive-viem/src/utils/createHyperdriveContract.ts
+++ b/packages/hyperdrive-viem/src/utils/createHyperdriveContract.ts
@@ -3,7 +3,7 @@ import { ViemCachedReadContract } from "src/contract/ViemCachedReadContract";
 import { ViemCachedReadWriteContract } from "src/contract/ViemCachedReadWriteContract";
 import { Address, PublicClient, WalletClient } from "viem";
 
-export interface CreateHyperdriveContractOptions {
+interface CreateHyperdriveContractOptions {
   address: Address;
   publicClient: PublicClient;
   walletClient?: WalletClient;

--- a/packages/hyperdrive-viem/src/utils/createHyperdriveMathContract.ts
+++ b/packages/hyperdrive-viem/src/utils/createHyperdriveMathContract.ts
@@ -1,9 +1,14 @@
-import { HyperdriveMathABI } from "@hyperdrive/sdk";
+import { HyperdriveMathABI, SimpleCache } from "@hyperdrive/sdk";
 import { ViemCachedReadContract } from "src/contract/ViemCachedReadContract";
-import { CreateHyperdriveContractOptions } from "src/utils/createHyperdriveContract";
+import { Address, PublicClient } from "viem";
 
+interface CreateHyperdriveMathContractOptions {
+  address: Address;
+  publicClient: PublicClient;
+  cache?: SimpleCache;
+}
 export function createHyperdriveMathContract<
-  TOptions extends CreateHyperdriveContractOptions,
+  TOptions extends CreateHyperdriveMathContractOptions,
 >({ address, publicClient, cache }: TOptions): ViemHyperdriveMathContract {
   return new ViemCachedReadContract({
     abi: HyperdriveMathABI,


### PR DESCRIPTION
Quick one to add a `createHyperdriveMathContract` like we do for `createHyperdriveContract`. Doesn't take a wallet client because all the functions are pure on this abi.