### PR TITLE
Switch from @hyperdrive/core to @hyperdrive/sdk

### DIFF
--- a/apps/hyperdrive-trading/src/appconfig/hyperdrives/getMockHyperdrive.ts
+++ b/apps/hyperdrive-trading/src/appconfig/hyperdrives/getMockHyperdrive.ts
@@ -1,4 +1,4 @@
-import { HyperdriveABI } from "@hyperdrive/core";
+import { HyperdriveABI } from "@hyperdrive/sdk";
 import { Hyperdrive } from "src/appconfig/types";
 import { Address, PublicClient } from "viem";
 import { erc20ABI } from "wagmi";

--- a/apps/hyperdrive-trading/src/base/makeQueryKey.ts
+++ b/apps/hyperdrive-trading/src/base/makeQueryKey.ts
@@ -1,12 +1,13 @@
 import { QueryKey } from "@tanstack/query-core";
 /**
- * This is a factory function for generating query keys. By using this function,
- * we enforce a consistent namespacing across our queries and prevent a
- * potential collision with existing queries within the application.
+ * This is a factory function for generating application-level query keys. By
+ * using this function, we enforce a consistent namespacing across our app's
+ * queries and prevent a potential collision with other queries from other
+ * libraries, like the SDK.
 
- * Recommended use: All queries should leverage this function for query key
+ * Recommended use: All app queries should leverage this function for query key
  * creation to maintain namespace integrity.
  */
 export function makeQueryKey<T>(queryName: string, options: T): QueryKey {
-  return ["@hyperdrive/core", queryName, options];
+  return ["app", queryName, options];
 }

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongForm/CloseLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongForm/CloseLongForm.tsx
@@ -1,5 +1,4 @@
-import { adjustAmountByPercentage } from "@hyperdrive/core";
-import { Long } from "@hyperdrive/sdk";
+import { Long, adjustAmountByPercentage } from "@hyperdrive/sdk";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
 import { MouseEvent, ReactElement } from "react";
 import { Hyperdrive } from "src/appconfig/types";

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
@@ -1,5 +1,5 @@
 import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/outline";
-import { adjustAmountByPercentage } from "@hyperdrive/core";
+import { adjustAmountByPercentage } from "@hyperdrive/sdk";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
 import { ethers } from "ethers";
 import { ReactElement } from "react";

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
@@ -1,4 +1,4 @@
-import { adjustAmountByPercentage } from "@hyperdrive/core";
+import { adjustAmountByPercentage } from "@hyperdrive/sdk";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
 import { MouseEvent, ReactElement } from "react";
 import { Hyperdrive } from "src/appconfig/types";

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useClosedLpShares.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useClosedLpShares.ts
@@ -1,4 +1,4 @@
-import { ClosedLpShares } from "@hyperdrive/core";
+import { ClosedLpShares } from "@hyperdrive/sdk";
 import { QueryStatus, useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useRedeemedWithdrawalShares.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useRedeemedWithdrawalShares.ts
@@ -1,4 +1,4 @@
-import { RedeemedWithdrawalShares } from "@hyperdrive/core";
+import { RedeemedWithdrawalShares } from "@hyperdrive/sdk";
 import { QueryStatus, useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortForm/CloseShortForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortForm/CloseShortForm.tsx
@@ -1,4 +1,4 @@
-import { adjustAmountByPercentage, OpenShort } from "@hyperdrive/core";
+import { adjustAmountByPercentage, OpenShort } from "@hyperdrive/sdk";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
 import { MouseEvent, ReactElement } from "react";
 import { Hyperdrive } from "src/appconfig/types";

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortModalButton/CloseShortModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortModalButton/CloseShortModalButton.tsx
@@ -1,5 +1,5 @@
 import { XMarkIcon } from "@heroicons/react/24/solid";
-import { OpenShort } from "@hyperdrive/core";
+import { OpenShort } from "@hyperdrive/sdk";
 import { ReactElement } from "react";
 import { Hyperdrive } from "src/appconfig/types";
 import { Modal } from "src/ui/base/components/Modal/Modal";

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useCloseShort.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useCloseShort.ts
@@ -1,4 +1,4 @@
-import { Short } from "@hyperdrive/core";
+import { Short } from "@hyperdrive/sdk";
 import { useAddRecentTransaction } from "@rainbow-me/rainbowkit";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useReadWriteHyperdrive } from "src/ui/hyperdrive/hooks/useReadWriteHyperdrive";

--- a/apps/hyperdrive-trading/src/ui/portfolio/ClosedShortsTable/useClosedShortRows.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/ClosedShortsTable/useClosedShortRows.tsx
@@ -1,4 +1,4 @@
-import { ClosedShort } from "@hyperdrive/core";
+import { ClosedShort } from "@hyperdrive/sdk";
 import { QueryStatus } from "@tanstack/react-query";
 import { Hyperdrive } from "src/appconfig/types";
 import { Row } from "src/ui/base/components/tables/SortableGridTable";

--- a/apps/hyperdrive-trading/src/ui/portfolio/OpenLpPosition/OpenLpPosition.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/OpenLpPosition/OpenLpPosition.tsx
@@ -1,4 +1,4 @@
-import { multiplyBigInt } from "@hyperdrive/core";
+import { multiplyBigInt } from "@hyperdrive/sdk";
 import { ReactElement } from "react";
 import Skeleton from "react-loading-skeleton";
 import { Hyperdrive } from "src/appconfig/types";

--- a/apps/hyperdrive-trading/src/ui/portfolio/OpenShortsTable/useOpenShortRows.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/OpenShortsTable/useOpenShortRows.tsx
@@ -1,4 +1,4 @@
-import { OpenShort } from "@hyperdrive/core";
+import { OpenShort } from "@hyperdrive/sdk";
 import { Hyperdrive } from "src/appconfig/types";
 import { Row } from "src/ui/base/components/tables/SortableGridTable";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";

--- a/apps/hyperdrive-trading/src/ui/token/hooks/useMintBaseToken.ts
+++ b/apps/hyperdrive-trading/src/ui/token/hooks/useMintBaseToken.ts
@@ -1,4 +1,4 @@
-import { ERC20MintableABI } from "@hyperdrive/core";
+import { ERC20MintableABI } from "@hyperdrive/sdk";
 import { useAddRecentTransaction } from "@rainbow-me/rainbowkit";
 import { Address, formatUnits } from "viem";
 import {

--- a/apps/hyperdrive-trading/src/ui/token/hooks/useTokenAllowance.ts
+++ b/apps/hyperdrive-trading/src/ui/token/hooks/useTokenAllowance.ts
@@ -1,4 +1,4 @@
-import { ERC20_ABI } from "@hyperdrive/core";
+import { ERC20_ABI } from "@hyperdrive/sdk";
 import { Address, useContractRead } from "wagmi";
 
 interface UseTokenAllowanceOptions {

--- a/packages/hyperdrive-sdk/src/contract/cached/CachedReadContract.test.ts
+++ b/packages/hyperdrive-sdk/src/contract/cached/CachedReadContract.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "vitest";
-import { HyperdriveABI } from "@hyperdrive/core";
 import { ContractEvent } from "src/contract/Contract";
 import { ReadContractStub } from "src/contract/stubs/ReadContractStub";
 import { CachedReadContract } from "src/contract/cached/CachedReadContract";
+import { HyperdriveABI } from "src/abis/Hyperdrive";
 
 test("It caches the read function", async () => {
   const contract = new ReadContractStub(HyperdriveABI);

--- a/packages/hyperdrive-sdk/src/contract/stubs/ReadContractStub.test.ts
+++ b/packages/hyperdrive-sdk/src/contract/stubs/ReadContractStub.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "vitest";
-import { HyperdriveABI } from "@hyperdrive/core";
 import { ContractEvent } from "src/contract/Contract";
 import { ReadContractStub } from "src/contract/stubs/ReadContractStub";
+import { HyperdriveABI } from "src/abis/Hyperdrive";
 
 test("It stubs the read function", async () => {
   const contract = new ReadContractStub(HyperdriveABI);

--- a/packages/hyperdrive-sdk/src/contract/stubs/ReadWriteContractStub.test.ts
+++ b/packages/hyperdrive-sdk/src/contract/stubs/ReadWriteContractStub.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "vitest";
-import { HyperdriveABI } from "@hyperdrive/core";
 import { ReadWriteContractStub } from "src/contract/stubs/ReadWriteContractStub";
+import { HyperdriveABI } from "@hyperdrive/core";
 
 test("It stubs the write function", async () => {
   const contract = new ReadWriteContractStub(HyperdriveABI);

--- a/packages/hyperdrive-sdk/src/hyperdrive/ReadHyperdrive.ts
+++ b/packages/hyperdrive-sdk/src/hyperdrive/ReadHyperdrive.ts
@@ -1,9 +1,3 @@
-import {
-  ClosedLpShares,
-  ClosedShort,
-  OpenShort,
-  RedeemedWithdrawalShares,
-} from "@hyperdrive/core";
 import { Address } from "abitype";
 import groupBy from "lodash.groupby";
 import mapValues from "lodash.mapvalues";
@@ -23,6 +17,9 @@ import { WITHDRAW_SHARES_ASSET_ID, LP_ASSET_ID } from "src/lp/constants";
 import { decodeAssetFromTransferSingleEventData } from "src/utils/decodeAssetFromTransferSingleEventData";
 import { HyperdriveABI } from "src/abis/Hyperdrive";
 import { ClosedLong, Long } from "src/longs/types";
+import { ClosedLpShares } from "src/lp/ClosedLpShares";
+import { RedeemedWithdrawalShares } from "src/withdrawalShares/RedeemedWithdrawalShares";
+import { ClosedShort, OpenShort } from "src/shorts/types";
 
 export interface ReadHyperdriveOptions {
   contract: IReadHyperdriveContract;

--- a/packages/hyperdrive-sdk/src/index.ts
+++ b/packages/hyperdrive-sdk/src/index.ts
@@ -48,12 +48,18 @@ export type {
 export type { INetwork } from "src/network/Network";
 
 // Shorts
-export type { ClosedShort, OpenShort } from "src/shorts/types";
+export type { Short, ClosedShort, OpenShort } from "src/shorts/types";
 
 // Longs
 export type { ClosedLong, Long } from "src/longs/types";
 
-// Utils
+// LP
+export type { ClosedLpShares } from "src/lp/ClosedLpShares";
+
+// Withdrawal Shares
+export type { RedeemedWithdrawalShares } from "src/withdrawalShares/RedeemedWithdrawalShares";
+
+// ABI utils
 export type {
   EventName,
   EventArgs,
@@ -62,6 +68,10 @@ export type {
   FunctionArgs,
   FunctionReturnType,
 } from "src/base/abitype";
+
+// Math utils
+export { adjustAmountByPercentage } from "src/base/adjustAmountByPercentage";
+export { multiplyBigInt } from "src/base/multiplyBigInt/multiplyBigInt";
 
 // Client classes
 export { ReadHyperdrive } from "src/hyperdrive/ReadHyperdrive";

--- a/packages/hyperdrive-sdk/src/lp/ClosedLpShares.ts
+++ b/packages/hyperdrive-sdk/src/lp/ClosedLpShares.ts
@@ -1,0 +1,7 @@
+export interface ClosedLpShares {
+  hyperdriveAddress: `0x${string}`;
+  lpAmount: bigint;
+  baseAmount: bigint;
+  withdrawalShareAmount: bigint;
+  closedTimestamp: bigint;
+}

--- a/packages/hyperdrive-sdk/src/shorts/types.ts
+++ b/packages/hyperdrive-sdk/src/shorts/types.ts
@@ -1,6 +1,6 @@
 import { Address } from "abitype";
 
-interface Short {
+export interface Short {
   hyperdriveAddress: Address;
   assetId: bigint;
   bondAmount: bigint;

--- a/packages/hyperdrive-sdk/src/withdrawalShares/RedeemedWithdrawalShares.ts
+++ b/packages/hyperdrive-sdk/src/withdrawalShares/RedeemedWithdrawalShares.ts
@@ -1,0 +1,8 @@
+import { Address } from "abitype";
+
+export interface RedeemedWithdrawalShares {
+  hyperdriveAddress: Address;
+  withdrawalShareAmount: bigint;
+  baseAmount: bigint;
+  timestamp: bigint;
+}


### PR DESCRIPTION
Removes almost all of the dependencies on hyperdrive/core from the trading ui and sdk