### PR TITLE
swaps to reset

### DIFF
--- a/apps/hyperdrive-trading/src/network/waitForTransactionAndInvalidateCache.ts
+++ b/apps/hyperdrive-trading/src/network/waitForTransactionAndInvalidateCache.ts
@@ -21,8 +21,8 @@ export async function waitForTransactionAndInvalidateCache({
   publicClient.waitForTransactionReceipt({
     hash,
     onReplaced() {
-      queryClient.invalidateQueries();
+      queryClient.resetQueries();
     },
   });
-  queryClient.invalidateQueries();
+  queryClient.resetQueries();
 }

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useCloseLong.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useCloseLong.ts
@@ -56,7 +56,7 @@ export function useCloseLong({
             },
           },
         });
-        queryClient.invalidateQueries();
+        queryClient.resetQueries();
       }
     },
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useOpenLong.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useOpenLong.ts
@@ -61,7 +61,7 @@ export function useOpenLong({
             },
           },
         });
-        queryClient.invalidateQueries();
+        queryClient.resetQueries();
         onExecuted?.();
       }
     },

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useAddLiquidity.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useAddLiquidity.ts
@@ -62,7 +62,7 @@ export function useAddLiquidity({
             },
           },
         });
-        queryClient.invalidateQueries();
+        queryClient.resetQueries();
       }
     },
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useRedeemWithdrawalShares.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useRedeemWithdrawalShares.ts
@@ -56,7 +56,7 @@ export function useRedeemWithdrawalShares({
             },
           },
         });
-        queryClient.invalidateQueries();
+        queryClient.resetQueries();
       }
     },
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useRemoveLiquidity.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useRemoveLiquidity.ts
@@ -56,7 +56,7 @@ export function useRemoveLiquidity({
             },
           },
         });
-        queryClient.invalidateQueries();
+        queryClient.resetQueries();
       }
     },
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useCloseShort.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useCloseShort.ts
@@ -56,7 +56,7 @@ export function useCloseShort({
             },
           },
         });
-        queryClient.invalidateQueries();
+        queryClient.resetQueries();
       }
     },
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useOpenShort.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useOpenShort.ts
@@ -58,7 +58,7 @@ export function useOpenShort({
             },
           },
         });
-        queryClient.invalidateQueries();
+        queryClient.resetQueries();
         onExecuted?.();
       }
     },

--- a/apps/hyperdrive-trading/src/ui/network/useWaitForTransactionThenInvalidateCache/useWaitForTransactionThenInvalidateCache.ts
+++ b/apps/hyperdrive-trading/src/ui/network/useWaitForTransactionThenInvalidateCache/useWaitForTransactionThenInvalidateCache.ts
@@ -24,7 +24,7 @@ export function useWaitForTransactionThenInvalidateCache({
   const isCacheInvalidated = useRef(false);
   useEffect(() => {
     if (status === "success" && !isCacheInvalidated.current) {
-      queryClient.invalidateQueries();
+      queryClient.resetQueries();
       isCacheInvalidated.current = true;
     }
   }, [queryClient, status]);


### PR DESCRIPTION
Swap from invalidateQueries to resetQueries. Reset changes the cache back to any initial data and automatically causes a refetch if a query is active. Which is what we want for refreshing the row data. 