### PR TITLE
Updates return types and doc blocks

### DIFF
--- a/packages/hyperdrive-sdk/src/hyperdrive/ReadWriteHyperdrive.ts
+++ b/packages/hyperdrive-sdk/src/hyperdrive/ReadWriteHyperdrive.ts
@@ -52,8 +52,9 @@ export interface IReadWriteHyperdrive extends IReadHyperdrive {
    * @param destination - The account opening the position
    * @param baseAmount - The amount of base supplied to the position
    * @param bondAmountOut - The amount of bonds to send to the destination
-   * @param asUnderlying - TODO: come up with good comment for this
+   * @param asUnderlying - A flag indicating whether the sender will pay in base or using another currency. Implementations choose which currencies they accept.
    * @param options - Contract Write Options
+   * @return bondProceeds - The amount of bonds the user received
    *
    */
   openLong({
@@ -75,8 +76,10 @@ export interface IReadWriteHyperdrive extends IReadHyperdrive {
    * @param destination - The account opening the position
    * @param baseAmount - The amount of base supplied to the position
    * @param bondAmountOut - The amount of bonds to send to the destination
-   * @param asUnderlying - TODO: come up with good comment for this
+   * @param asUnderlying - A flag indicating whether the sender will pay in base or using another currency. Implementations choose which currencies they accept.
    * @param options - Contract Write Options
+   * @return maturityTime - The maturity time of the short.
+   * @return traderDeposit - The amount the user deposited for this trade.
    */
   openShort({
     destination,
@@ -98,8 +101,9 @@ export interface IReadWriteHyperdrive extends IReadHyperdrive {
    * @param bondAmountIn - The amount of of bonds to remove from the position
    * @param minBaseAmountOut - The minimum amount of base to send to the destination
    * @param destination - The account receiving the base
-   * @param asUnderlying - TODO: come up with good comment for this
+   * @param asUnderlying - A flag indicating whether the sender will pay in base or using another currency. Implementations choose which currencies they accept.
    * @param options - Contract Write Options
+   * @return The amount of underlying asset the user receives.
    */
   closeLong({
     long,
@@ -123,8 +127,9 @@ export interface IReadWriteHyperdrive extends IReadHyperdrive {
    * @param bondAmountIn - The amount of bonds to remove from the position
    * @param minBaseAmountOut - The minimum amount of base to send to the destination
    * @param destination - The account receiving the base
-   * @param asUnderlying - TODO: come up with good comment for this
+   * @param asUnderlying - A flag indicating whether the sender will pay in base or using another currency. Implementations choose which currencies they accept.
    * @param options - Contract Write Options
+   * @return The amount of base tokens produced by closing this short
    */
   closeShort({
     short,
@@ -148,7 +153,7 @@ export interface IReadWriteHyperdrive extends IReadHyperdrive {
    * @param contribution - The amount of base to supply
    * @param minAPR - The minimum APR to accept
    * @param maxAPR - The maximum APR to accept
-   * @param asUnderlying - TODO: come up with good comment for this
+   * @param asUnderlying - A flag indicating whether the sender will pay in base or using another currency. Implementations choose which currencies they accept.
    * @param options - Contract Write Options
    * @return lpShares The number of LP tokens created
    */
@@ -173,7 +178,7 @@ export interface IReadWriteHyperdrive extends IReadHyperdrive {
    * @param destination - The account removing liquidity
    * @param lpSharesIn - The amount of LP shares to remove
    * @param minBaseAmountOut - The minimum amount of base to send to the destination
-   * @param asUnderlying - TODO: come up with good comment for this
+   * @param asUnderlying - A flag indicating whether the sender will pay in base or using another currency. Implementations choose which currencies they accept.
    * @param options - Contract Write Options
    * @returns baseProceeds - The base the LP removing liquidity receives. The LP
    receives a proportional amount of the pool's idle capital
@@ -198,7 +203,7 @@ export interface IReadWriteHyperdrive extends IReadHyperdrive {
    * @param withdrawalSharesIn - The amount of withdrawal shares to redeem
    * @param minBaseAmountOutPerShare - The minimum amount of base to send to the destination per share
    * @param destination - The account receiving the base
-   * @param asUnderlying - TODO: come up with good comment for this
+   * @param asUnderlying - A flag indicating whether the sender will pay in base or using another currency. Implementations choose which currencies they accept.
    * @param options - Contract Write Options
    * @return baseProceeds The amount of base the LP received.
    * @return sharesRedeemed The amount of withdrawal shares that were redeemed.


### PR DESCRIPTION
Some of our return types were incorrect on ReadWriteHyperdrive. This updates the functions to reflect what's actually being returned from the contract. It also updates the doc block, using some of the same language used in the Solidity comments.