### PR TITLE
Add yield amount badge to Open longs table

### DIFF
--- a/apps/hyperdrive-trading/src/ui/portfolio/OpenLongsTable/OpenLongsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/OpenLongsTable/OpenLongsTable.tsx
@@ -92,8 +92,8 @@ function FixedRateCell({
   hyperdrive: Hyperdrive;
 }) {
   return (
-    <div className="flex flex-col items-center gap-1">
-      <span className="font-bold">
+    <div className="flex flex-col gap-1">
+      <span className="ml-2 font-bold">
         {calculateAnnualizedPercentageChange({
           amountBefore: row.original.baseAmountPaid,
           amountAfter: row.original.bondAmount,
@@ -230,8 +230,8 @@ function CurrentValueCell({
     baseAmountOut && baseAmountOut > row.original.baseAmountPaid;
 
   return (
-    <div className="flex flex-col items-center gap-1">
-      <span className="font-bold">{currentValue?.toString()}</span>
+    <div className="flex flex-col gap-1">
+      <span className="ml-2 font-bold">{currentValue?.toString()}</span>
       <div
         data-tip={"Profit/Loss since open"}
         className={classNames(


### PR DESCRIPTION
See #446 

The Longs table now shows a badge containing the guaranteed fixed yield if held to maturity.

<img width="1237" alt="image" src="https://github.com/delvtech/hyperdrive-monorepo/assets/4524175/eabfda5c-6769-4898-9336-f9979d19e664">