### PR TITLE
hotfix for lp table

### DIFF
--- a/apps/hyperdrive-trading/src/ui/portfolio/OpenLpTable/OpenLpTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/OpenLpTable/OpenLpTable.tsx
@@ -230,16 +230,18 @@ export function OpenLpTable({
     hyperdriveAddress: hyperdrive.address,
     account,
   });
+
   const memoizedData = useMemo(() => {
-    return [
-      {
-        lpShares: lpShares || 0n,
-      },
-      {
-        withdrawalShares: withdrawalShares || 0n,
-      },
-    ];
+    const data = [];
+    if (lpShares && lpShares !== 0n) {
+      data.push({ lpShares });
+    }
+    if (withdrawalShares && withdrawalShares !== 0n) {
+      data.push({ withdrawalShares });
+    }
+    return data;
   }, [lpShares, withdrawalShares]);
+
   const tableInstance = useReactTable({
     columns: getColumns(hyperdrive),
     data: memoizedData as LpRowType[],


### PR DESCRIPTION
The memoized data either returned the value or 0n. Now we only push the row if the relevant value is non-zero.

```ts
const memoizedData = useMemo(() => {
    const data = [];
    if (lpShares && lpShares !== 0n) {
      data.push({ lpShares });
    }
    if (withdrawalShares && withdrawalShares !== 0n) {
      data.push({ withdrawalShares });
    }
    return data;
  }, [lpShares, withdrawalShares]);
```