### PR TITLE
fixes 24h volume stat

### DIFF
--- a/apps/hyperdrive-trading/src/base/constants.ts
+++ b/apps/hyperdrive-trading/src/base/constants.ts
@@ -3,3 +3,5 @@ export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 export const MAX_UINT256 = BigInt(
   "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
 );
+
+export const DAILY_AVERAGE_BLOCK_TOTAL = 7127n;

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useTradingVolume.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useTradingVolume.ts
@@ -1,7 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
+import { DAILY_AVERAGE_BLOCK_TOTAL } from "src/base/constants";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
+import { useChainId } from "wagmi";
 export function useTradingVolume(
   hyperdriveAddress: Address,
   currentBlockNumber: bigint | undefined,
@@ -12,12 +14,24 @@ export function useTradingVolume(
 } {
   const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
   const queryEnabled = !!readHyperdrive && currentBlockNumber !== undefined;
+  const chainId = useChainId();
+  const fromBlock =
+    currentBlockNumber &&
+    chainId === +import.meta.env.VITE_CUSTOM_CHAIN_CHAIN_ID
+      ? currentBlockNumber - DAILY_AVERAGE_BLOCK_TOTAL
+      : "earliest";
   const { data: volume } = useQuery({
     queryKey: makeQueryKey("tradingVolume", {
       hyperdriveAddress,
       currentBlockNumber: currentBlockNumber?.toString(),
     }),
-    queryFn: queryEnabled ? () => readHyperdrive.getTradingVolume() : undefined,
+    queryFn: queryEnabled
+      ? () =>
+          readHyperdrive.getTradingVolume({
+            fromBlock,
+            toBlock: currentBlockNumber,
+          })
+      : undefined,
     enabled: queryEnabled,
   });
   return {

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/MarketStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/MarketStats.tsx
@@ -75,7 +75,7 @@ export function MarketStats({
         label="Volume (24h)"
         value={
           <FormattedDaiValue
-            symbol={hyperdrive.baseToken.symbol}
+            symbol={`hy${hyperdrive.baseToken.symbol}`}
             value={formatBalance({
               balance: totalVolume || 0n,
               decimals: hyperdrive.baseToken.decimals,


### PR DESCRIPTION
This PR fixes the 24 hour volume stat so it reflects the last 24h and not the volume from the earliest block reachable.