### PR TITLE
Fix bug so that shorts only accrue yield up to their maturity

### DIFF
--- a/packages/evm-client/src/network/stubs/NetworkStub.ts
+++ b/packages/evm-client/src/network/stubs/NetworkStub.ts
@@ -1,18 +1,49 @@
 import { GetBlockParameters, INetwork } from "src/network/Network";
-import { stub } from "sinon";
+import { SinonStub, stub } from "sinon";
 
 /**
  * A mock implementation of a `Network` designed to facilitate unit
  * testing.
  */
 export class NetworkStub implements INetwork {
+  protected getBlockStub:
+    | SinonStub<
+        [GetBlockParameters | undefined],
+        Promise<{ blockNumber: bigint; timestamp: bigint }>
+      >
+    | undefined;
   constructor() {}
+
+  stubGetBlock({
+    args,
+    value,
+  }: {
+    args?: GetBlockParameters | undefined;
+    value: Promise<{ blockNumber: bigint; timestamp: bigint }>;
+  }): void {
+    if (!this.getBlockStub) {
+      this.getBlockStub = stub();
+    }
+
+    // Account for dynamic args if provided
+    if (args) {
+      this.getBlockStub.withArgs(args).resolves(value as any);
+      return;
+    }
+
+    this.getBlockStub.resolves(value as any);
+  }
 
   getBlock = stub().callsFake(
     (
       args?: GetBlockParameters | undefined,
     ): Promise<{ blockNumber: bigint; timestamp: bigint }> => {
-      throw new Error("Method not implemented.");
+      if (!this.getBlockStub) {
+        throw new Error(
+          `The getBlock function must be stubbed first:\n\tcontract.stubGetBlock()`,
+        );
+      }
+      return this.getBlockStub(args);
     },
   );
 }

--- a/packages/hyperdrive-sdk/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.test.ts
+++ b/packages/hyperdrive-sdk/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.test.ts
@@ -137,6 +137,91 @@ test("getTradingVolume should get the trading volume in terms of bonds", async (
   });
 });
 
+test("getShortAccruedYield should return the amount of yield a non-mature position has earned", async () => {
+  const { contract, network, readHyperdrive } = setupReadHyperdrive();
+
+  network.stubGetBlock({
+    value: Promise.resolve({ blockNumber: 1n, timestamp: 100n }),
+  });
+
+  contract.stubRead({
+    functionName: "getPoolConfig",
+    value: [
+      {
+        ...simplePoolConfig,
+        positionDuration: 86400n, // one day in seconds
+        checkpointDuration: 86400n, // one day in seconds
+      },
+    ],
+  });
+
+  // The pool info gives us the current price
+  contract.stubRead({
+    functionName: "getPoolInfo",
+    value: [{ ...simplePoolInfo, sharePrice: dnum.from("1.01", 18)[0] }],
+  });
+
+  // The checkpoint gives us the price when the bond was opened
+  contract.stubRead({
+    functionName: "getCheckpoint",
+    value: [{ longExposure: 0n, sharePrice: dnum.from("1.008", 18)[0] }],
+  });
+
+  const accruedYield = await readHyperdrive.getShortAccruedYield({
+    checkpointId: 0n,
+    bondAmount: dnum.from("100", 18)[0],
+    decimals: 18,
+  });
+
+  // If you opened a short position on 100 bonds at a previous checkpoint price
+  // of 1.008 and the current price is 1.01, your accrued profit would
+  // be 0.20.
+  expect(accruedYield).toEqual(dnum.from("0.20", 18)[0]);
+});
+
+test("getShortAccruedYield should return the amount of yield a mature position has earned", async () => {
+  const { network, contract, readHyperdrive } = setupReadHyperdrive();
+
+  network.stubGetBlock({
+    value: Promise.resolve({ blockNumber: 1n, timestamp: 1699503565n }),
+  });
+  contract.stubRead({
+    functionName: "getPoolConfig",
+    value: [
+      {
+        ...simplePoolConfig,
+        positionDuration: 86400n, // one day in seconds
+        checkpointDuration: 86400n, // one day in seconds
+      },
+    ],
+  });
+
+  // This checkpoint gives us the price when the short was opened
+  contract.stubRead({
+    functionName: "getCheckpoint",
+    args: [1n],
+    value: [{ longExposure: 0n, sharePrice: dnum.from("1.008", 18)[0] }],
+  });
+
+  // This checkpoint gives us the price when the shorts matured
+  contract.stubRead({
+    functionName: "getCheckpoint",
+    args: [86401n],
+    value: [{ longExposure: 0n, sharePrice: dnum.from("1.01", 18)[0] }],
+  });
+
+  const accruedYield = await readHyperdrive.getShortAccruedYield({
+    checkpointId: 1n,
+    bondAmount: dnum.from("100", 18)[0],
+    decimals: 18,
+  });
+
+  // If you opened a short position on 100 bonds at a previous checkpoint price
+  // of 1.008 and the price was 1.01 at maturity, your accrued profit would
+  // be 0.20.
+  expect(accruedYield).toEqual(dnum.from("0.20", 18)[0]);
+});
+
 function setupReadHyperdrive() {
   const contract = new ReadContractStub(IHyperdrive.abi);
   const cachedContract = new CachedReadContract({ contract });


### PR DESCRIPTION
Fixes the bug where we were showing yield accrued on shorts after they matured, and adds two tests to pin down that ReadHyperdrive will give you back the correctly calculated yield