### PR TITLE
Add feature flag hook

### DIFF
--- a/apps/hyperdrive-trading/src/ui/base/featureFlags/featureFlags.ts
+++ b/apps/hyperdrive-trading/src/ui/base/featureFlags/featureFlags.ts
@@ -26,9 +26,10 @@ export function useFeatureFlag(flagName: string): {
     enableFlag: () => {
       // Create a new search params so we retain all existing search params
       const newSearchParams = new URLSearchParams(searchParams);
+
       newSearchParams.set(
         "feature_flags",
-        [...currentFlags, flagName].join(","),
+        [...new Set([...currentFlags, flagName])].join(","),
       );
       setSearchParams(newSearchParams);
     },
@@ -36,7 +37,7 @@ export function useFeatureFlag(flagName: string): {
     disableFlag: () => {
       // Create a new search params so we retain all existing search params
       const newSearchParams = new URLSearchParams(searchParams);
-      searchParams.set(
+      newSearchParams.set(
         "feature_flags",
         currentFlags.filter((name) => name !== flagName).join(","),
       );


### PR DESCRIPTION
Adding a simple feature flag hook that we can use to toggle UI components based on URL state (`?feature_flags=flag1,flag2`)

This is related to #501 where the LP cards refactor is too big to land in a single PR (we have to do both LP and Withdrawal Shares cards), and incrementally landing everything would create broken UI states.  By putting everything behind the feature flag during development (and removing it at the end) we can land incremental changes safely without ruining the user experience in the interim.