### PR TITLE
Fix scrollbar jitter bug

### DIFF
--- a/apps/hyperdrive-trading/src/ui/globals.css
+++ b/apps/hyperdrive-trading/src/ui/globals.css
@@ -8,6 +8,11 @@ body,
 #root,
 div[data-rk] {
   font-family: "Open Sans";
+
+  /* reserve space for the scrollbar, preventing unwanted layout changes as the
+   * content grows while also avoiding unnecessary visuals when scrolling isn't
+   * needed. */
+  scrollbar-gutter: stable;
 }
 
 @tailwind base;


### PR DESCRIPTION
Small fix to a visual bug. Don't shift the layout when scrollbar enters and exits. Most noticeable when opening a tx modal and the app underneath shifts to the right when scrollbars go away.
