### PR TITLE
Fixes console warning

### DIFF
--- a/apps/hyperdrive-trading/src/ui/markets/LongsShortsLpTabs/LongsShortsLpTabs.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/LongsShortsLpTabs/LongsShortsLpTabs.tsx
@@ -41,8 +41,7 @@ export function LongsShortsLpTabs({
             })}
             aria-label={tabId}
             checked={activeTab === tabId}
-            readOnly
-            onClick={() => {
+            onChange={() => {
               handleChangeTab(tabId);
             }}
           />

--- a/apps/hyperdrive-trading/src/ui/markets/TransactionsAndFaqTabs/TransactionsAndFaqTabs.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/TransactionsAndFaqTabs/TransactionsAndFaqTabs.tsx
@@ -27,8 +27,7 @@ export function TransactionAndFaqTabs({
             })}
             aria-label={tab}
             checked={activeTab === tab}
-            readOnly
-            onClick={() => {
+            onChange={() => {
               setActiveTab(tab);
             }}
           />


### PR DESCRIPTION
This fixes 2 console warnings we have on our tab sections. We have an input without an onChange, just swapped the onClick for onChange
![Screenshot 2023-12-04 at 12 54 36 PM](https://github.com/delvtech/hyperdrive-monorepo/assets/22210106/af90a71a-59cd-49c8-a92a-d306144b15e2)
