### PR TITLE
Standardize decimal places

### DIFF
--- a/apps/hyperdrive-trading/src/ui/base/formatting/formatCompact.ts
+++ b/apps/hyperdrive-trading/src/ui/base/formatting/formatCompact.ts
@@ -16,6 +16,6 @@ export function formatCompact({
   decimals: number;
 }): string {
   const convertedToNumber = dnum.toNumber([value, decimals], decimals);
-  const formatter = format(".4s");
+  const formatter = format(".3s");
   return formatter(convertedToNumber).toUpperCase().replace(/G$/, "B"); // ensure billion-scale numbers use 'B' instead of 'G', which is the default suffix used by d3-format for giga (billion).
 }

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/MarketStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/MarketStats.tsx
@@ -85,7 +85,7 @@ export function MarketStats({
         value={
           lpApy || lpApy === 0 ? (
             <span className="flex items-center gap-1.5">
-              {lpApy.toFixed(4)}% APY
+              {lpApy.toFixed(2)}% APY
             </span>
           ) : (
             <Skeleton className="opacity-50" />


### PR DESCRIPTION
Standardize our decimal places in market stats. 
Percentages: 2 places
Values: 3 Significant digits according to d3-format (https://observablehq.com/@d3/d3-format?collection=@d3/d3-format#cell-11)