### PR TITLE
fix pill text size

### DIFF
--- a/apps/hyperdrive-trading/src/ui/portfolio/MaturesOnCell/MaturesOnCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/MaturesOnCell/MaturesOnCell.tsx
@@ -21,17 +21,13 @@ export function MaturesOnCell({
       {isTermComplete ? (
         <div
           className={
-            "daisy-badge daisy-badge-primary daisy-badge-md inline-flex text-xs lg:text-body"
+            "daisy-badge daisy-badge-primary daisy-badge-md inline-flex text-xs"
           }
         >
           Term complete
         </div>
       ) : (
-        <div
-          className={
-            "daisy-badge daisy-badge-md inline-flex text-xs sm:text-body"
-          }
-        >
+        <div className={"daisy-badge daisy-badge-md inline-flex text-xs"}>
           <span>{daysLeft} days left</span>
         </div>
       )}

--- a/apps/hyperdrive-trading/src/ui/portfolio/OpenLongsTable/OpenLongsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/OpenLongsTable/OpenLongsTable.tsx
@@ -341,7 +341,7 @@ function CurrentValueCell({
       <div
         data-tip={"Profit/Loss since open"}
         className={classNames(
-          "daisy-badge daisy-badge-md daisy-tooltip inline-flex text-xs sm:text-sm",
+          "daisy-badge daisy-badge-md daisy-tooltip inline-flex text-xs",
           { "text-success": isPositiveChangeInValue },
           { "text-error": !isPositiveChangeInValue },
         )}
@@ -388,7 +388,7 @@ function FixedRateCell({
       <div
         data-tip={"Yield after fees if held to maturity"}
         className={
-          "daisy-badge daisy-badge-md daisy-tooltip inline-flex px-2 text-xs text-success md:text-sm"
+          "daisy-badge daisy-badge-md daisy-tooltip inline-flex px-2 text-xs text-success"
         }
       >
         <span>{"+"}</span>


### PR DESCRIPTION
I noticed the pill text spills over on certain screen sizes if its set to text-body. This pr sets all pill size text to xs like we have on the MaturesOnCell.
![image](https://github.com/delvtech/hyperdrive-monorepo/assets/22210106/e6745125-ea58-4619-91b6-32cccb56ebe5)
