### PR TITLE
Homepage polish

### DIFF
--- a/apps/hyperdrive-trading/src/pages/Landing.tsx
+++ b/apps/hyperdrive-trading/src/pages/Landing.tsx
@@ -90,7 +90,7 @@ function Hero() {
           <h2 className="gradient-text mb-5 text-h3 font-bold md:text-h2">
             DeFi yields that match your risk tolerance
           </h2>
-          <h4 className="mb-5 text-h5 text-gray-400">
+          <h4 className="mb-5 text-h5 text-neutral-content">
             Hyperdrive is an AMM that lets you buy fixed rates upfront, or
             maximize your exposure to variable rates like stETH and sDAI.
           </h4>

--- a/apps/hyperdrive-trading/src/pages/Markets.tsx
+++ b/apps/hyperdrive-trading/src/pages/Markets.tsx
@@ -21,7 +21,7 @@ export function Markets(): ReactElement {
             <span className="gradient-text mb-6 text-h2 font-bold md:text-h1">
               Explore Hyperdrive Markets
             </span>
-            <p className="mb-5 mt-3 text-gray-400 md:mb-16">
+            <p className="mb-5 mt-3 text-neutral-content md:mb-16">
               Dive into our extensive table of pools, each offering unique term
               lengths to align with your strategic trading goals. Select the
               perfect pool for your next investment move in the dynamic world of

--- a/apps/hyperdrive-trading/src/ui/base/components/Disclosure/Disclosure.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/Disclosure/Disclosure.tsx
@@ -12,7 +12,7 @@ export function Disclosure({
 }: DisclosureProps): ReactElement {
   const [isOpen, setIsOpen] = useState(false);
   return (
-    <div className="group daisy-collapse daisy-collapse-plus items-center border border-gray-400">
+    <div className="group daisy-collapse daisy-collapse-plus items-center border border-neutral-content">
       <input
         type="checkbox"
         onChange={() => {
@@ -21,7 +21,7 @@ export function Disclosure({
       />
       <div
         className={classNames(
-          "text-xl daisy-collapse-title font-medium text-gray-400 group-hover:opacity-100",
+          "text-xl daisy-collapse-title font-medium text-neutral-content group-hover:opacity-100",
           isOpen ? "opacity-100" : "opacity-80",
         )}
       >

--- a/apps/hyperdrive-trading/src/ui/base/components/Stat.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/Stat.tsx
@@ -21,13 +21,13 @@ export function Stat({ label, value, description }: StatProps): ReactElement {
             description ? "cursor-help" : "",
           )}
         >
-          <p className="text-sm text-gray-400">
+          <p className="text-sm text-neutral-content">
             {label}
-            <InformationCircleIcon className="group-hover:text-gray-500 ml-1 inline-block w-4 text-gray-400 opacity-0 transition duration-150 ease-in-out group-hover:opacity-100" />
+            <InformationCircleIcon className="group-hover:text-gray-500 ml-1 inline-block w-4 text-neutral-content opacity-0 transition duration-150 ease-in-out group-hover:opacity-100" />
           </p>
         </div>
       ) : (
-        <p className="text-sm text-gray-400">{label}</p>
+        <p className="text-sm text-neutral-content">{label}</p>
       )}
     </div>
   );

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/PositionCard.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/PositionCard.tsx
@@ -24,7 +24,7 @@ export function PositionCard({
           {icon}
         </div>
         <p className="mb-6 text-h4 font-bold">{title}</p>
-        <p className="mb-8 text-p2 text-gray-400">{subtitle}</p>
+        <p className="text-p2 mb-8 text-neutral-content">{subtitle}</p>
         <div className="flex flex-col gap-6">
           {checklist.map((item, idx) => (
             <ChecklistItem key={idx} checked readOnly variant="success">

--- a/apps/hyperdrive-trading/src/ui/markets/AllMarketsTable/AllMarketsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/AllMarketsTable/AllMarketsTable.tsx
@@ -189,7 +189,7 @@ export function AllMarketsTable(): ReactElement {
   });
   return (
     <div className="flex w-full max-w-6xl flex-col items-center overflow-y-scroll p-2 md:p-4 md:px-0">
-      <h3 className="mb-5 w-full pl-1 text-h5 text-gray-400">
+      <h3 className="mb-5 w-full pl-1 text-h5 text-neutral-content">
         Available Markets
       </h3>
       <div className="daisy-card-bordered daisy-card flex w-full overflow-auto md:p-6">
@@ -275,7 +275,7 @@ function GoToMarketButton({ market }: { market: Hyperdrive }): ReactElement {
       onClick={() => {
         navigate(`/market/${market}`);
       }}
-      className="daisy-btn-md daisy-btn-circle flex items-center justify-center rounded-full bg-gray-600 hover:bg-gray-700"
+      className="daisy-btn-circle daisy-btn-md flex items-center justify-center rounded-full bg-gray-600 hover:bg-gray-700"
     >
       <ArrowRightIcon className="h-5" />
     </button>

--- a/apps/hyperdrive-trading/src/ui/markets/MarketDetailsBody/PriceBadges.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketDetailsBody/PriceBadges.tsx
@@ -13,7 +13,7 @@ export function PriceBadges({
 }): ReactElement {
   return (
     <div className="flex flex-col gap-2 md:flex-row md:gap-4">
-      <div className="daisy-badge daisy-badge-neutral daisy-badge-lg py-4 text-md text-gray-400">
+      <div className="daisy-badge daisy-badge-neutral daisy-badge-lg py-4 text-md text-neutral-content">
         1 hy{hyperdrive.baseToken.symbol} ≈{" "}
         {formatBalance({
           balance: longPrice.price,
@@ -22,7 +22,7 @@ export function PriceBadges({
         })}{" "}
         {hyperdrive.baseToken.symbol}
       </div>
-      <div className="daisy-badge daisy-badge-neutral daisy-badge-lg py-4 text-md text-gray-400">
+      <div className="daisy-badge daisy-badge-neutral daisy-badge-lg py-4 text-md text-neutral-content">
         1 {hyperdrive.baseToken.symbol} ≈{" "}
         {formatBalance({
           balance: divideBigInt(


### PR DESCRIPTION
Related to #572 

Home page polish:

- [x] Add chevron to View Markets
- [x] Fix styling of Mobile FAQ

While here, I refactored our uses of `gray-400` to use the daisy `netural-content` class instead. Wherever possible we should lean on daisy classes now that we've switched themes. Where we can't, we should use the tailwind color palette.

<img width="443" alt="image" src="https://github.com/delvtech/hyperdrive-monorepo/assets/4524175/cb22f55a-b9be-4fbc-b292-2780fb9ecd6c">
  