### PR TITLE
Rename component

### DIFF
--- a/apps/hyperdrive-trading/src/ui/base/components/LabelValue.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/LabelValue.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from "react";
 
-export function PreviewTransactionRow({
+export function LabelValue({
   label: label,
   value: value,
 }: {

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongForm/CloseLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongForm/CloseLongForm.tsx
@@ -3,7 +3,7 @@ import { ConnectButton } from "@rainbow-me/rainbowkit";
 import { MouseEvent, ReactElement } from "react";
 import toast from "react-hot-toast";
 import { Hyperdrive } from "src/appconfig/types";
-import { PreviewTransactionRow } from "src/ui/base/components/PreviewTransactionRow";
+import { LabelValue } from "src/ui/base/components/LabelValue";
 import CustomToastMessage from "src/ui/base/components/Toaster/CustomToastMessage";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { useNumericInput } from "src/ui/base/hooks/useNumericInput";
@@ -105,7 +105,7 @@ export function CloseLongForm({
         />
       }
       transactionPreview={
-        <PreviewTransactionRow
+        <LabelValue
           label="You receive"
           value={`${
             baseAmountOut

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongPreview.tsx
@@ -4,7 +4,7 @@ import { ReactElement } from "react";
 import { Hyperdrive } from "src/appconfig/types";
 import { convertMillisecondsToDays } from "src/base/convertMillisecondsToDays";
 import { formatRate } from "src/base/formatRate";
-import { PreviewTransactionRow } from "src/ui/base/components/PreviewTransactionRow";
+import { LabelValue } from "src/ui/base/components/LabelValue";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { useCurrentFixedAPR } from "src/ui/hyperdrive/hooks/useCurrentFixedAPR";
 import { usePoolConfig } from "src/ui/hyperdrive/hooks/usePoolConfig";
@@ -29,7 +29,7 @@ export function OpenLongPreview({
   );
   return (
     <div className="flex flex-col gap-3">
-      <PreviewTransactionRow
+      <LabelValue
         label="You receive"
         value={
           <span className="font-bold">{`${formatBalance({
@@ -39,7 +39,7 @@ export function OpenLongPreview({
           })} hy${hyperdrive.baseToken.symbol}`}</span>
         }
       />
-      <PreviewTransactionRow
+      <LabelValue
         label="Pool fee"
         value={
           <span
@@ -50,7 +50,7 @@ export function OpenLongPreview({
           </span>
         }
       />
-      <PreviewTransactionRow
+      <LabelValue
         label="Net fixed rate"
         value={
           <span
@@ -71,7 +71,7 @@ export function OpenLongPreview({
           </span>
         }
       />
-      <PreviewTransactionRow
+      <LabelValue
         label="Yield at maturity"
         value={
           <div
@@ -97,7 +97,7 @@ export function OpenLongPreview({
           </div>
         }
       />
-      <PreviewTransactionRow
+      <LabelValue
         label="Matures in"
         value={`${numDays} days, ${new Date(
           Date.now() + Number(hyperdrive.termLengthMS),

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityPreview/AddLiquidityPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityPreview/AddLiquidityPreview.tsx
@@ -1,6 +1,6 @@
 import { ReactElement } from "react";
 import { Hyperdrive } from "src/appconfig/types";
-import { PreviewTransactionRow } from "src/ui/base/components/PreviewTransactionRow";
+import { LabelValue } from "src/ui/base/components/LabelValue";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 
 interface AddLiquidityPreviewProps {
@@ -14,7 +14,7 @@ export function AddLiquidityPreview({
 }: AddLiquidityPreviewProps): ReactElement {
   return (
     <div className="flex flex-col gap-3">
-      <PreviewTransactionRow
+      <LabelValue
         label="You receive"
         value={
           <p className="font-bold">

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
@@ -5,7 +5,7 @@ import { MouseEvent, ReactElement } from "react";
 import toast from "react-hot-toast";
 import { Hyperdrive } from "src/appconfig/types";
 import { calculateTotalValueFromPrice } from "src/base/calculateTotalValueFromPrice";
-import { PreviewTransactionRow } from "src/ui/base/components/PreviewTransactionRow";
+import { LabelValue } from "src/ui/base/components/LabelValue";
 import CustomToastMessage from "src/ui/base/components/Toaster/CustomToastMessage";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { useNumericInput } from "src/ui/base/hooks/useNumericInput";
@@ -131,13 +131,13 @@ export function RemoveLiquidityForm({
       }
       transactionPreview={
         <>
-          <PreviewTransactionRow
+          <LabelValue
             label="You receive"
             value={`${formattedBaseAmountOut || 0} ${
               hyperdrive.baseToken.symbol
             }`}
           />
-          <PreviewTransactionRow
+          <LabelValue
             label="Queued for withdrawal"
             value={`${formattedWithdrawalSharesOut || 0} ${
               hyperdrive.baseToken.symbol

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortForm/CloseShortForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortForm/CloseShortForm.tsx
@@ -3,7 +3,7 @@ import { ConnectButton } from "@rainbow-me/rainbowkit";
 import { MouseEvent, ReactElement } from "react";
 import toast from "react-hot-toast";
 import { Hyperdrive } from "src/appconfig/types";
-import { PreviewTransactionRow } from "src/ui/base/components/PreviewTransactionRow";
+import { LabelValue } from "src/ui/base/components/LabelValue";
 import CustomToastMessage from "src/ui/base/components/Toaster/CustomToastMessage";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { useNumericInput } from "src/ui/base/hooks/useNumericInput";
@@ -92,7 +92,7 @@ export function CloseShortForm({
         />
       }
       transactionPreview={
-        <PreviewTransactionRow
+        <LabelValue
           label="You receive"
           value={
             <p className="font-bold">

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
@@ -1,7 +1,7 @@
 import { ReactElement } from "react";
 import { Hyperdrive } from "src/appconfig/types";
 import { convertMillisecondsToDays } from "src/base/convertMillisecondsToDays";
-import { PreviewTransactionRow } from "src/ui/base/components/PreviewTransactionRow";
+import { LabelValue } from "src/ui/base/components/LabelValue";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 
 interface OpenShortPreviewProps {
@@ -17,7 +17,7 @@ export function OpenShortPreview({
 }: OpenShortPreviewProps): ReactElement {
   return (
     <div className="flex flex-col gap-1">
-      <PreviewTransactionRow
+      <LabelValue
         label="Short size"
         value={
           <span
@@ -34,7 +34,7 @@ export function OpenShortPreview({
           </span>
         }
       />
-      <PreviewTransactionRow
+      <LabelValue
         label="You pay"
         value={
           <span
@@ -52,7 +52,7 @@ export function OpenShortPreview({
         }
       />
 
-      <PreviewTransactionRow
+      <LabelValue
         label="Matures in"
         value={`${convertMillisecondsToDays(
           market.termLengthMS,

--- a/apps/hyperdrive-trading/src/ui/portfolio/OpenLpSharesCard/OpenLpSharesCard.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/OpenLpSharesCard/OpenLpSharesCard.tsx
@@ -4,9 +4,9 @@ import Skeleton from "react-loading-skeleton";
 import { Hyperdrive } from "src/appconfig/types";
 import { calculateRatio } from "src/base/calculateRatio";
 import { calculateTotalValueFromPrice } from "src/base/calculateTotalValueFromPrice";
+import { LabelValue } from "src/ui/base/components/LabelValue";
 import { Modal } from "src/ui/base/components/Modal/Modal";
 import { NonIdealState } from "src/ui/base/components/NonIdealState";
-import { PreviewTransactionRow } from "src/ui/base/components/PreviewTransactionRow";
 import { Well } from "src/ui/base/components/Well/Well";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { usePoolInfo } from "src/ui/hyperdrive/hooks/usePoolInfo";
@@ -66,7 +66,7 @@ export function OpenLpSharesCard({
         {lpShares !== 0n ? (
           <>
             <span className="daisy-card-title font-bold">LP Shares</span>
-            <PreviewTransactionRow
+            <LabelValue
               label="Pool share"
               value={
                 <p
@@ -84,7 +84,7 @@ export function OpenLpSharesCard({
                 </p>
               }
             />
-            <PreviewTransactionRow
+            <LabelValue
               label="LP balance"
               value={
                 <p>
@@ -101,7 +101,7 @@ export function OpenLpSharesCard({
                 </p>
               }
             />
-            <PreviewTransactionRow
+            <LabelValue
               label="Current value"
               value={
                 <p className="font-bold">

--- a/apps/hyperdrive-trading/src/ui/portfolio/OpenWithdrawalSharesCard/OpenWithdrawalSharesCard.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/OpenWithdrawalSharesCard/OpenWithdrawalSharesCard.tsx
@@ -1,8 +1,8 @@
 import { ReactElement } from "react";
 import Skeleton from "react-loading-skeleton";
 import { Hyperdrive } from "src/appconfig/types";
+import { LabelValue } from "src/ui/base/components/LabelValue";
 import { Modal } from "src/ui/base/components/Modal/Modal";
-import { PreviewTransactionRow } from "src/ui/base/components/PreviewTransactionRow";
 import { Well } from "src/ui/base/components/Well/Well";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { usePoolInfo } from "src/ui/hyperdrive/hooks/usePoolInfo";
@@ -41,7 +41,7 @@ export function OpenWithdrawalSharesCard({
         {withdrawalShares !== 0n ? (
           <div className="flex h-full flex-col justify-between">
             <div className="mb-4 flex flex-col gap-3">
-              <PreviewTransactionRow
+              <LabelValue
                 label="Shares balance"
                 value={
                   <p>
@@ -58,7 +58,7 @@ export function OpenWithdrawalSharesCard({
                   </p>
                 }
               />
-              <PreviewTransactionRow
+              <LabelValue
                 label="Current value"
                 value={
                   <p>
@@ -78,7 +78,7 @@ export function OpenWithdrawalSharesCard({
                   </p>
                 }
               />
-              <PreviewTransactionRow
+              <LabelValue
                 label="Withdrawable"
                 value={
                   <p className="font-bold">


### PR DESCRIPTION
Updated the component name to be more generic, as it's now used in contexts beyond just transaction previews. This change better suits its placement in the base/ directory, reflecting its broader applicability.