### PR TITLE
Update evm-client

### DIFF
--- a/packages/hyperdrive-sdk/package.json
+++ b/packages/hyperdrive-sdk/package.json
@@ -16,10 +16,10 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "@delvtech/evm-client": "^0.0.6"
+    "@delvtech/evm-client": "^0.0.7"
   },
   "devDependencies": {
-    "@delvtech/evm-client": "^0.0.6",
+    "@delvtech/evm-client": "^0.0.7",
     "@hyperdrive/artifacts": "*",
     "@hyperdrive/eslint-config": "*",
     "@hyperdrive/prettier-config": "*",

--- a/packages/hyperdrive-viem/package.json
+++ b/packages/hyperdrive-viem/package.json
@@ -18,7 +18,7 @@
     "viem": "^2.7.8"
   },
   "dependencies": {
-    "@delvtech/evm-client-viem": "^0.0.7"
+    "@delvtech/evm-client-viem": "^0.0.9"
   },
   "devDependencies": {
     "@hyperdrive/artifacts": "*",


### PR DESCRIPTION
Fixed a bug last night where it was returning the first item of arrays if the only output from a contract was a single array parameter (e.g., `uint256[3]`). Rather than relying on checking if the output from the contract is an array to determine if it was "unwrapped" by Viem, I'm relying only on the number of parameters in the ABI.