### PR TITLE
Fix bug in Open short form

### DIFF
--- a/apps/hyperdrive-trading/src/hyperdrive/convertBaseToShares.ts
+++ b/apps/hyperdrive-trading/src/hyperdrive/convertBaseToShares.ts
@@ -1,0 +1,17 @@
+import * as dnum from "dnum";
+
+export function convertBaseToShares({
+  baseAmount,
+  vaultSharePrice,
+  decimals,
+}: {
+  baseAmount: bigint | undefined;
+  vaultSharePrice: bigint | undefined;
+  decimals: number;
+}): bigint {
+  // if I have 20 base, and shares cost 2 base each, then 20 / 2 = 10 shares
+  return dnum.divide(
+    [baseAmount || 0n, decimals],
+    [vaultSharePrice || 0n, decimals],
+  )[0];
+}

--- a/apps/hyperdrive-trading/src/hyperdrive/convertSharesToBase.ts
+++ b/apps/hyperdrive-trading/src/hyperdrive/convertSharesToBase.ts
@@ -1,0 +1,16 @@
+import * as dnum from "dnum";
+
+export function convertSharesToBase({
+  sharesAmount,
+  vaultSharePrice,
+  decimals,
+}: {
+  sharesAmount: bigint | undefined;
+  vaultSharePrice: bigint | undefined;
+  decimals: number;
+}): bigint {
+  return dnum.multiply(
+    [sharesAmount || 0n, decimals],
+    [vaultSharePrice || 0n, decimals],
+  )[0];
+}

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
@@ -4,9 +4,9 @@ import {
   HyperdriveConfig,
 } from "@hyperdrive/appconfig";
 import { adjustAmountByPercentage } from "@hyperdrive/sdk";
-import * as dnum from "dnum";
 import { ReactElement } from "react";
 import toast from "react-hot-toast";
+import { convertSharesToBase } from "src/hyperdrive/convertSharesToBase";
 import { getHasEnoughAllowance } from "src/token/getHasEnoughAllowance";
 import { getHasEnoughBalance } from "src/token/getHasEnoughBalance";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
@@ -80,10 +80,11 @@ export function OpenLongForm({
   let finalAmount = amountAsBigInt;
 
   if (activeToken.address === sharesToken.address) {
-    finalAmount = dnum.multiply(
-      [amountAsBigInt || 0n, activeToken.decimals],
-      [poolInfo?.vaultSharePrice || 0n, activeToken.decimals],
-    )[0];
+    finalAmount = convertSharesToBase({
+      decimals: sharesToken.decimals,
+      sharesAmount: amountAsBigInt,
+      vaultSharePrice: poolInfo?.vaultSharePrice,
+    });
   }
 
   const { longAmountOut, status: openLongPreviewStatus } = usePreviewOpenLong({

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/usePreviewOpenShort.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/usePreviewOpenShort.ts
@@ -5,7 +5,7 @@ import { Address } from "viem";
 
 interface UsePreviewOpenShortOptions {
   hyperdriveAddress: Address;
-  amountBondShorts: bigint | undefined;
+  amountOfBondsToShort: bigint | undefined;
 }
 
 interface UsePreviewOpenShortResult {
@@ -15,21 +15,21 @@ interface UsePreviewOpenShortResult {
 
 export function usePreviewOpenShort({
   hyperdriveAddress,
-  amountBondShorts,
+  amountOfBondsToShort,
 }: UsePreviewOpenShortOptions): UsePreviewOpenShortResult {
   const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
-  const queryEnabled = !!readHyperdrive && !!amountBondShorts;
+  const queryEnabled = !!readHyperdrive && !!amountOfBondsToShort;
 
   const { data, status } = useQuery({
     queryKey: makeQueryKey("previewOpenShort", {
       market: hyperdriveAddress,
-      amountBondShorts: amountBondShorts?.toString(),
+      amountBondShorts: amountOfBondsToShort?.toString(),
     }),
     enabled: queryEnabled,
     queryFn: queryEnabled
       ? async () => {
           return readHyperdrive.previewOpenShort({
-            amountOfBondsToShort: amountBondShorts,
+            amountOfBondsToShort: amountOfBondsToShort,
           });
         }
       : undefined,


### PR DESCRIPTION
Fixes a small bug where we were converting the shorts instead of the deposit amount.

For context: The preview calc for open short returns the number of base required to open the position. If the user chooses to deposit shares, we need to convert the preview calc's output to shares.

While here I pulled the conversions out to separate functions and renamed some variables for clarity.
