### PR TITLE
Add backticks to code comments

### DIFF
--- a/apps/hyperdrive-trading/src/version.output.ts
+++ b/apps/hyperdrive-trading/src/version.output.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "4eea9c5906a3d44e6bea21c932fc72ced8ebe5b7";
+export const APP_VERSION = "25e9250b3712540fc101a06ab0c8df7a737470c3";

--- a/packages/hyperdrive-sdk/src/base/adjustAmountByPercentage.ts
+++ b/packages/hyperdrive-sdk/src/base/adjustAmountByPercentage.ts
@@ -19,11 +19,13 @@ interface AdjustAmountByPercentageOptions {
  *
  * Example:
  *
+ * ```ts
  * adjustAmountByPercentage({
  *   amount: parseUnits("100", 18),
  *   decimals: 18,
  *   percentage: 1n
  * }) === parseUnits("99")
+ * ```
  */
 export function adjustAmountByPercentage({
   amount,

--- a/packages/hyperdrive-sdk/src/lp/calculateShareValue.ts
+++ b/packages/hyperdrive-sdk/src/lp/calculateShareValue.ts
@@ -4,7 +4,10 @@ import * as dnum from "dnum";
  * Calculates how much an amount of shares are worth, give the price, example:
  *
  * Example: 10 shares each worth $2 each:
- *   calculateShareValue({ amount 10, price: 2, decimals: 2 }) // $20
+ *
+ * ```ts
+ * calculateShareValue({ amount 10, price: 2, decimals: 2 }) // $20
+ * ```
  */
 export function calculateShareValue({
   amount,


### PR DESCRIPTION
Brackets (`{ ... }`) are treated like escapes to JS in the MDX parser for Docusaurus, so we have to use backticks around the code to ensure it's parsed correctly.