### PR TITLE
Upgrade hyperdrive-wasm to 0.7.1

### DIFF
--- a/packages/hyperdrive-sdk/package.json
+++ b/packages/hyperdrive-sdk/package.json
@@ -15,7 +15,7 @@
     "@delvtech/hyperdrive-artifacts": "*"
   },
   "dependencies": {
-    "@delvtech/hyperdrive-wasm": "^0.7.0",
+    "@delvtech/hyperdrive-wasm": "^0.7.1",
     "lodash.groupby": "^4.6.0",
     "lodash.mapvalues": "^4.6.0"
   },

--- a/packages/hyperdrive-sdk/src/hyperwasm.ts
+++ b/packages/hyperdrive-sdk/src/hyperwasm.ts
@@ -1,7 +1,7 @@
 // NOTE: Make sure to add the hyperwasm version number to the end of the import. Adding a query parameter to the import path will cause the esm cache to be invalidated and the latest version of the wasm package will be loaded.
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import * as hyperwasm from "@delvtech/hyperdrive-wasm?v0.7.0";
+import * as hyperwasm from "@delvtech/hyperdrive-wasm?v0.7.1";
 
 hyperwasm.initSync(hyperwasm.wasmBuffer);
 

--- a/packages/hyperdrive-sdk/vite.config.ts
+++ b/packages/hyperdrive-sdk/vite.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   plugins: [tsconfigPaths()],
   test: {
     alias: {
-      "@delvtech/hyperdrive-wasm?v0.7.0": "@delvtech/hyperdrive-wasm",
+      "@delvtech/hyperdrive-wasm?v0.7.1": "@delvtech/hyperdrive-wasm",
     },
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1329,10 +1329,10 @@
     fast-safe-stringify "^2.1.1"
     lru-cache "^10.0.1"
 
-"@delvtech/hyperdrive-wasm@^0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@delvtech/hyperdrive-wasm/-/hyperdrive-wasm-0.7.0.tgz#57deaf685a249428895a70fff6b3a2716e9b0e21"
-  integrity sha512-EOjALWiVd7KIzPtj6Jyu3gABoksoCYWJ7RZ1n3juDp0AfPEOiDvpnQd5gPkuO4PaO5iLCZ+sTn8apa1eMSag3g==
+"@delvtech/hyperdrive-wasm@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@delvtech/hyperdrive-wasm/-/hyperdrive-wasm-0.7.1.tgz#208309af9fbae836675ed19d88a530f5e0f02d55"
+  integrity sha512-0xnxi4E71oVvnUTeK5mjYMauu7H4vNlHq4TiYCLQOT2qi10fuEUji5R6puyR/EZbDvYd6nw5LQcFJLX9TlL5nQ==
 
 "@discoveryjs/json-ext@0.5.7":
   version "0.5.7"


### PR DESCRIPTION
Fixes the issue causing InvalidCharacter errors to throw from `ReadHyperdrive.getMaxShort`