### PR TITLE
Add MAX button in open short form

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
@@ -125,6 +125,7 @@ export function OpenShortForm({
 
   const { maxBondsOut } = useMaxShort({
     hyperdriveAddress: hyperdrive.address,
+    budget: MAX_UINT256,
   });
 
   const hasEnoughLiquidity = getIsValidTradeSize({

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useMaxShort.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useMaxShort.ts
@@ -14,15 +14,16 @@ export function useMaxShort({
   hyperdriveAddress,
   budget,
 }: {
-  budget: bigint;
+  budget: bigint | undefined;
   hyperdriveAddress: Address;
 }): UseMaxShortResult {
   const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
-  const queryEnabled = !!readHyperdrive;
+  const queryEnabled = !!readHyperdrive && budget !== undefined;
 
   const { data, status } = useQuery({
     queryKey: makeQueryKey("maxShort", {
       market: hyperdriveAddress,
+      budget: budget?.toString(),
     }),
     enabled: queryEnabled,
     queryFn: queryEnabled

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useMaxShort.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useMaxShort.ts
@@ -12,7 +12,9 @@ interface UseMaxShortResult {
 
 export function useMaxShort({
   hyperdriveAddress,
+  budget,
 }: {
+  budget: bigint;
   hyperdriveAddress: Address;
 }): UseMaxShortResult {
   const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
@@ -23,7 +25,9 @@ export function useMaxShort({
       market: hyperdriveAddress,
     }),
     enabled: queryEnabled,
-    queryFn: queryEnabled ? () => readHyperdrive.getMaxShort() : undefined,
+    queryFn: queryEnabled
+      ? () => readHyperdrive.getMaxShort({ budget })
+      : undefined,
   });
 
   return {

--- a/packages/hyperdrive-sdk/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
+++ b/packages/hyperdrive-sdk/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
@@ -186,7 +186,10 @@ export interface IReadHyperdrive {
   /**
    * Gets the maximum amount of bonds a user can open a short for.
    */
-  getMaxShort(options?: ContractReadOptions): Promise<{
+  getMaxShort(
+    args: { budget: bigint },
+    options?: ContractReadOptions,
+  ): Promise<{
     maxBaseIn: bigint;
     maxSharesIn: bigint;
     maxBondsOut: bigint;
@@ -1071,6 +1074,7 @@ export class ReadHyperdrive implements IReadHyperdrive {
   }
 
   async getMaxShort(
+    { budget }: { budget: bigint },
     options?: ContractReadOptions,
   ): ReturnType<IReadHyperdrive, "getMaxShort"> {
     const poolInfo = await this.getPoolInfo(options);
@@ -1098,7 +1102,7 @@ export class ReadHyperdrive implements IReadHyperdrive {
     const maxBondsOut = hyperwasm.getMaxShort(
       stringifiedPoolInfo,
       stringifiedPoolConfig,
-      MAX_UINT256.toString(),
+      budget.toString(),
       openSharePrice.toString(),
       checkpointExposure.toString(),
     );


### PR DESCRIPTION
DRAFT: There is a known bug in `get_max_short` in the rust sdk that makes this feature only work some of the time: https://discord.com/channels/754739461707006013/1062553591988113489/1214621518315651154

Since getMaxShort takes a budget param, we can pass the user's balance to it and get back a value to wire up the max button to.

<img width="417" alt="image" src="https://github.com/delvtech/hyperdrive-monorepo/assets/4524175/10b2af2f-9224-4e03-ae73-135662c1f082">
