### PR TITLE
Adds nonideal state if no filtered positions

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/TransactionTable/TransactionsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/TransactionTable/TransactionsTable.tsx
@@ -373,25 +373,38 @@ export function TransactionTable({
           ))}
         </thead>
 
-        <tbody>
-          {tableInstance.getRowModel().rows.map((row) => {
-            return (
-              <tr key={row.id} className="h-20">
-                <>
-                  {row.getVisibleCells().map((cell) => {
-                    return (
-                      <td key={cell.id}>
-                        {flexRender(
-                          cell.column.columnDef.cell,
-                          cell.getContext(),
-                        )}
-                      </td>
-                    );
-                  })}
-                </>
-              </tr>
-            );
+        <tbody
+          className={classNames({
+            "relative h-52": !tableInstance.getFilteredRowModel().rows.length,
           })}
+        >
+          {tableInstance.getFilteredRowModel().rows.length ? (
+            tableInstance.getRowModel().rows.map((row) => {
+              return (
+                <tr key={row.id} className="h-20">
+                  <>
+                    {row.getVisibleCells().map((cell) => {
+                      return (
+                        <td key={cell.id}>
+                          {flexRender(
+                            cell.column.columnDef.cell,
+                            cell.getContext(),
+                          )}
+                        </td>
+                      );
+                    })}
+                  </>
+                </tr>
+              );
+            })
+          ) : (
+            <div className="absolute flex h-52 w-full justify-center">
+              <NonIdealState
+                heading="There are no transactions for this position type."
+                text="Open a position or add liquidity to see transactions here."
+              />
+            </div>
+          )}
         </tbody>
       </table>
       <div className="flex h-24 items-center justify-center gap-2">


### PR DESCRIPTION
This PR adds a non-ideal state if there are no transactions for filtered position types. This gives clarity to users (rather than an empty table) and it fixes the dropdown overflow issue on #775 
![image](https://github.com/delvtech/hyperdrive-frontend/assets/22210106/b84b492a-c4ab-4b65-a68f-a23a15342ed4)
