### PR TITLE
Improve tab section border visibility

### DIFF
--- a/apps/hyperdrive-trading/src/ui/base/components/Tabs/Tabs.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/Tabs/Tabs.tsx
@@ -37,7 +37,7 @@ export function Tabs({
       <div
         role="tabpanel"
         className={classNames(
-          "daisy-tab-content flex overflow-hidden rounded-b-box rounded-tr-box border-base-200 bg-base-100",
+          "daisy-tab-content flex overflow-hidden rounded-b-box rounded-tr-box border-neutral-content/20 bg-base-100",
           {
             // The Longs tab is first, and the tabby bit is connected to the
             // tab content, so don't put a round border on it

--- a/apps/hyperdrive-trading/src/ui/globals.css
+++ b/apps/hyperdrive-trading/src/ui/globals.css
@@ -18,6 +18,12 @@ div[data-rk] {
   scrollbar-gutter: stable;
 }
 
+.daisy-tab {
+  /* Adjust the Daisy Tabs component border to match the brighter border used in
+   * the app */
+  --tab-border-color: var(--fallback-nc, oklch(var(--nc) / 0.2));
+}
+
 @layer base {
   h1 {
     @apply font-chakraPetch text-h1;

--- a/apps/hyperdrive-trading/src/ui/markets/TransactionsAndFaqTabs/TransactionsAndFaqTabs.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/TransactionsAndFaqTabs/TransactionsAndFaqTabs.tsx
@@ -4,8 +4,6 @@ import { Tabs } from "src/ui/base/components/Tabs/Tabs";
 import { TransactionTable } from "src/ui/hyperdrive/TransactionTable/TransactionsTable";
 import { FAQEntries } from "src/ui/onboarding/FAQ/FAQ";
 
-type Tab = "Transactions" | "FAQ";
-
 export function TransactionAndFaqTabs({
   hyperdrive,
 }: {
@@ -18,7 +16,7 @@ export function TransactionAndFaqTabs({
         tabs={[
           {
             id: "Transactions",
-            label: "Transactions",
+            label: "All Transactions",
             content: <TransactionTable hyperdrive={hyperdrive} />,
             onClick: () => {},
           },


### PR DESCRIPTION
#775 

Tab section border now matches the border for the market stats, making the sections pop a bit more

|Before|After|
|---|---|
|<img width="1346" alt="image" src="https://github.com/delvtech/hyperdrive-frontend/assets/4524175/8290b61b-291e-4832-95eb-9266dabf1de2">|<img width="1353" alt="image" src="https://github.com/delvtech/hyperdrive-frontend/assets/4524175/4ffa041e-ba1b-4443-886d-eccf1eae906c">|