### PR TITLE
Undo rounding tailwind change

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongModalButton/OpenLongModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongModalButton/OpenLongModalButton.tsx
@@ -41,7 +41,7 @@ export function OpenLongModalButton({
     >
       {({ showModal }) => (
         <button
-          className="daisy-btn daisy-btn-primary"
+          className="daisy-btn daisy-btn-primary rounded-full"
           onClick={() => showModal()}
         >
           + Open a long

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
@@ -241,7 +241,7 @@ function getColumns({
       id: "go-to-market",
       cell: ({ row }) => (
         <button
-          className="daisy-btn bg-gray-600 hover:bg-gray-700"
+          className="daisy-btn daisy-btn-ghost rounded-full bg-gray-600 hover:bg-gray-700"
           onClick={() => {
             const modalId = `${row.original.assetId}`;
             (window as any)[modalId].showModal();

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityModalButton/AddLiquidityModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityModalButton/AddLiquidityModalButton.tsx
@@ -40,7 +40,7 @@ export function AddLiquidityModalButton({
     >
       {({ showModal }) => (
         <button
-          className="daisy-btn daisy-btn-primary"
+          className="daisy-btn daisy-btn-primary rounded-full"
           onClick={() => showModal()}
         >
           + Add liquidity

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortModalButton/OpenShortModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortModalButton/OpenShortModalButton.tsx
@@ -41,7 +41,7 @@ export function OpenShortModalButton({
     >
       {({ showModal }) => (
         <button
-          className="daisy-btn daisy-btn-primary"
+          className="daisy-btn daisy-btn-primary rounded-full"
           onClick={() => showModal()}
         >
           + Open a short

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktop.tsx
@@ -177,7 +177,7 @@ function getColumns(
       header: "",
       id: "go-to-market",
       cell: () => (
-        <button className="daisy-btn daisy-btn-ghost bg-gray-600 hover:bg-gray-700">
+        <button className="daisy-btn daisy-btn-ghost rounded-full bg-gray-600 hover:bg-gray-700">
           Close Short
         </button>
       ),

--- a/apps/hyperdrive-trading/tailwind.config.js
+++ b/apps/hyperdrive-trading/tailwind.config.js
@@ -93,7 +93,7 @@ module.exports = {
 
           "--tab-radius": "0.4rem",
           "--rounded-box": "2rem", // border radius rounded-box utility class, used in card and other large boxes
-          "--rounded-btn": "2rem",
+          "--rounded-btn": "0.4rem",
           "--rounded-badge": "0.4rem",
         },
       },


### PR DESCRIPTION
Reverting some polish from #781, where I made these more round by default. Since this variable also governs input radiuses and input + button groups, which we don't want to change.