### PR TITLE
Fixes market stats tooltips on smaller screens

### DIFF
--- a/apps/hyperdrive-trading/src/ui/base/components/Stat.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/Stat.tsx
@@ -1,4 +1,5 @@
 import { InformationCircleIcon } from "@heroicons/react/24/outline";
+import classNames from "classnames";
 import { ReactElement, ReactNode } from "react";
 
 interface StatProps {
@@ -20,7 +21,15 @@ export function Stat({
       {description ? (
         <p
           data-tip={description}
-          className={`group daisy-tooltip cursor-help text-sm text-neutral-content before:text-start daisy-tooltip-${tooltipPosition}`}
+          className={classNames(
+            `group daisy-tooltip cursor-help text-sm text-neutral-content before:text-start`,
+            {
+              "daisy-tooltip-top": tooltipPosition === "top",
+              "daisy-tooltip-bottom": tooltipPosition === "bottom",
+              "daisy-tooltip-left": tooltipPosition === "left",
+              "daisy-tooltip-right": tooltipPosition === "right",
+            },
+          )}
         >
           {label}
           <InformationCircleIcon className="group-hover:text-gray-500 ml-1 inline-block w-4 text-neutral-content opacity-0 transition duration-150 ease-in-out group-hover:opacity-100" />

--- a/apps/hyperdrive-trading/src/ui/base/components/Stat.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/Stat.tsx
@@ -5,17 +5,23 @@ interface StatProps {
   label: string;
   value: ReactNode;
   description?: string;
+  tooltipPosition?: "top" | "bottom" | "left" | "right";
 }
 
-export function Stat({ label, value, description }: StatProps): ReactElement {
+export function Stat({
+  label,
+  value,
+  description,
+  tooltipPosition = "bottom",
+}: StatProps): ReactElement {
   return (
-    <div
-      data-tip={description}
-      className="group daisy-tooltip flex cursor-help flex-col items-start whitespace-pre-wrap transition duration-150 ease-in-out before:text-start"
-    >
+    <div className="flex flex-col items-start whitespace-pre-wrap ease-in-out">
       <div className="mb-1 whitespace-nowrap text-h4 font-bold">{value}</div>
       {description ? (
-        <p className="text-sm text-neutral-content">
+        <p
+          data-tip={description}
+          className={`group daisy-tooltip cursor-help text-sm text-neutral-content before:text-start daisy-tooltip-${tooltipPosition}`}
+        >
           {label}
           <InformationCircleIcon className="group-hover:text-gray-500 ml-1 inline-block w-4 text-neutral-content opacity-0 transition duration-150 ease-in-out group-hover:opacity-100" />
         </p>

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/MarketStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/MarketStats.tsx
@@ -46,7 +46,8 @@ export function MarketStats({
         value={
           <div className="flex flex-row">{vaultRate?.formatted || 0}%</div>
         }
-        description={`The yield source backing the hy${baseToken.symbol} in this pool`}
+        description={`The yield source backing the hy${baseToken.symbol} in this pool.`}
+        tooltipPosition="right"
       />
       <Stat
         label="Fixed APR"
@@ -59,7 +60,7 @@ export function MarketStats({
             <Skeleton className="opacity-50" />
           )
         }
-        description="Fixed rate earned from opening longs, before fees and slippage are applied"
+        description="Fixed rate earned from opening longs, before fees and slippage are applied."
       />
       <Stat
         label="LP APY (12 Hour)"
@@ -77,7 +78,7 @@ export function MarketStats({
       <Stat
         description={`The amount of hy${
           baseToken.symbol
-        } (either longs or shorts) that have been traded in the last 24 hours \n\nLong volume: ${formatBalance(
+        } (either longs or shorts) that have been traded in the last 24 hours.\n\nLong volume: ${formatBalance(
           {
             balance: longVolume || 0n,
             decimals: baseToken.decimals,
@@ -112,6 +113,7 @@ export function MarketStats({
             })}
           />
         }
+        tooltipPosition="left"
       />
     </div>
   );


### PR DESCRIPTION
This PR fixes the market stats tooltip being cutoff on smaller screens. It introduces a tooltipPosition prop to the stat component. Ideally when there is more bandwidth we can implement a better tooltip library that allows for different placement so the other stats aren't covered (see video). But this fixes the cutoff issue. Fixes issue on #775 

https://github.com/delvtech/hyperdrive-frontend/assets/22210106/3bcd769c-e651-45e7-bc16-ea1eb255d046

