### PR TITLE
Adds pending liquidity toasts

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
@@ -6,7 +6,7 @@ import {
   TokenConfig,
 } from "@hyperdrive/appconfig";
 import * as dnum from "dnum";
-import { MouseEvent, ReactElement } from "react";
+import { MouseEvent, ReactElement, useState } from "react";
 import toast from "react-hot-toast";
 import { calculateRatio } from "src/base/calculateRatio";
 import { parseUnits } from "src/base/parseUnits";
@@ -125,13 +125,17 @@ export function AddLiquidityForm({
     hyperdrive,
     baseToken,
   );
-
+  const [transactionStatus, setTransactionStatus] = useState<
+    "loading" | "success" | ""
+  >("");
   const { addLiquidity, addLiquidityStatus } = useAddLiquidity({
     ...addLiquidityParams,
     enabled:
       addLiquidityParams.enabled && addLiquidityPreviewStatus === "success",
     onExecuted: (hash) => {
       setAmount("");
+      // (window as any)["add-lp"].close();
+      setTransactionStatus("success");
       toast.success(
         <CustomToastMessage
           message="Liquidity added"
@@ -214,12 +218,25 @@ export function AddLiquidityForm({
           );
         }
 
+        if (transactionStatus === "loading") {
+          return (
+            <button
+              disabled
+              className="daisy-btn daisy-btn-circle daisy-btn-primary w-full disabled:bg-primary disabled:text-base-100 disabled:opacity-30"
+            >
+              Adding liquidity
+              <div className="daisy-loading daisy-loading-spinner" />
+            </button>
+          );
+        }
+
         return (
           <button
-            disabled={!addLiquidity || addLiquidityStatus === "loading"}
+            disabled={!addLiquidity}
             className="daisy-btn daisy-btn-circle daisy-btn-primary w-full disabled:bg-primary disabled:text-base-100 disabled:opacity-30"
             onClick={(e) => {
               addLiquidity?.();
+              setTransactionStatus("loading");
               onAddLiquidity?.(e);
             }}
           >

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
@@ -229,8 +229,8 @@ export function AddLiquidityForm({
               disabled
               className="daisy-btn daisy-btn-circle daisy-btn-primary w-full disabled:bg-primary disabled:text-base-100 disabled:opacity-30"
             >
-              Adding liquidity
               <div className="daisy-loading daisy-loading-spinner" />
+              Adding liquidity
             </button>
           );
         }

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
@@ -6,7 +6,7 @@ import {
   TokenConfig,
 } from "@hyperdrive/appconfig";
 import * as dnum from "dnum";
-import { MouseEvent, ReactElement, useState } from "react";
+import { MouseEvent, ReactElement } from "react";
 import toast from "react-hot-toast";
 import { calculateRatio } from "src/base/calculateRatio";
 import { parseUnits } from "src/base/parseUnits";
@@ -125,17 +125,22 @@ export function AddLiquidityForm({
     hyperdrive,
     baseToken,
   );
-  const [transactionStatus, setTransactionStatus] = useState<
-    "loading" | "success" | ""
-  >("");
+
   const { addLiquidity, addLiquidityStatus } = useAddLiquidity({
     ...addLiquidityParams,
     enabled:
       addLiquidityParams.enabled && addLiquidityPreviewStatus === "success",
+    onSubmitted: (hash) => {
+      (window as any)["add-lp"].close();
+      toast.success(
+        <CustomToastMessage
+          message="Add liquidity pending"
+          link={makeTransactionURL(hash, chainId)}
+        />,
+      );
+    },
     onExecuted: (hash) => {
       setAmount("");
-      // (window as any)["add-lp"].close();
-      setTransactionStatus("success");
       toast.success(
         <CustomToastMessage
           message="Liquidity added"
@@ -218,7 +223,7 @@ export function AddLiquidityForm({
           );
         }
 
-        if (transactionStatus === "loading") {
+        if (addLiquidityStatus === "loading") {
           return (
             <button
               disabled
@@ -236,7 +241,6 @@ export function AddLiquidityForm({
             className="daisy-btn daisy-btn-circle daisy-btn-primary w-full disabled:bg-primary disabled:text-base-100 disabled:opacity-30"
             onClick={(e) => {
               addLiquidity?.();
-              setTransactionStatus("loading");
               onAddLiquidity?.(e);
             }}
           >

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
@@ -243,8 +243,8 @@ export function RemoveLiquidityForm({
               disabled
               className="daisy-btn daisy-btn-circle daisy-btn-primary w-full disabled:bg-primary disabled:text-base-100 disabled:opacity-30"
             >
-              Removing liquidity
               <div className="daisy-loading daisy-loading-spinner" />
+              Removing liquidity
             </button>
           );
         }

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
@@ -5,7 +5,7 @@ import {
 } from "@hyperdrive/appconfig";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
 import * as dnum from "dnum";
-import { MouseEvent, ReactElement, useState } from "react";
+import { MouseEvent, ReactElement } from "react";
 import toast from "react-hot-toast";
 import { calculateValueFromPrice } from "src/base/calculateValueFromPrice";
 import { makeTransactionURL } from "src/blockexplorer/makeTransactionUrl";
@@ -101,9 +101,6 @@ export function RemoveLiquidityForm({
       hyperdrive.withdrawOptions.isBaseTokenWithdrawalEnabled &&
       activeWithdrawToken.address === baseToken.address,
   });
-  const [transactionStatus, setTransactionStatus] = useState<
-    "loading" | "success" | ""
-  >("");
   const { removeLiquidity, removeLiquidityStatus } = useRemoveLiquidity({
     hyperdriveAddress: hyperdrive.address,
     lpSharesIn: lpSharesIn,
@@ -113,10 +110,17 @@ export function RemoveLiquidityForm({
     asBase:
       hyperdrive.withdrawOptions.isBaseTokenWithdrawalEnabled &&
       activeWithdrawToken.address === baseToken.address,
+    onSubmitted: (hash) => {
+      toast.success(
+        <CustomToastMessage
+          message="Liquidity pending removal"
+          link={makeTransactionURL(hash, chainId)}
+        />,
+      );
+      (window as any)["withdrawalLpModal"].close();
+    },
     onExecuted: (hash) => {
       setAmount("");
-      // (window as any)["withdrawalLpModal"].close();
-      setTransactionStatus("success");
       toast.success(
         <CustomToastMessage
           message="Liquidity removed"
@@ -180,7 +184,6 @@ export function RemoveLiquidityForm({
               }}
             />
           }
-          disabled={transactionStatus === "loading"}
           value={amount ?? ""}
           maxValue={formatUnits(activeWithdrawTokenLpValue, baseToken.decimals)}
           stat={
@@ -234,7 +237,7 @@ export function RemoveLiquidityForm({
           return <ConnectButton />;
         }
 
-        if (transactionStatus === "loading") {
+        if (removeLiquidityStatus === "loading") {
           return (
             <button
               disabled
@@ -252,7 +255,6 @@ export function RemoveLiquidityForm({
             disabled={!hasEnoughBalance || !removeLiquidity}
             onClick={(e) => {
               e.preventDefault();
-              setTransactionStatus("loading");
               removeLiquidity?.();
               onRemoveLiquidity?.(e);
             }}

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
@@ -111,13 +111,13 @@ export function RemoveLiquidityForm({
       hyperdrive.withdrawOptions.isBaseTokenWithdrawalEnabled &&
       activeWithdrawToken.address === baseToken.address,
     onSubmitted: (hash) => {
+      (window as any)["withdrawalLpModal"].close();
       toast.success(
         <CustomToastMessage
           message="Liquidity pending removal"
           link={makeTransactionURL(hash, chainId)}
         />,
       );
-      (window as any)["withdrawalLpModal"].close();
     },
     onExecuted: (hash) => {
       setAmount("");
@@ -254,6 +254,7 @@ export function RemoveLiquidityForm({
             className="daisy-btn daisy-btn-circle daisy-btn-primary w-full"
             disabled={!hasEnoughBalance || !removeLiquidity}
             onClick={(e) => {
+              // prevent closing the modal until the user approves the transaction
               e.preventDefault();
               removeLiquidity?.();
               onRemoveLiquidity?.(e);

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useAddLiquidity.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useAddLiquidity.ts
@@ -37,8 +37,8 @@ export function useAddLiquidity({
   maxAPR,
   asBase = true,
   enabled,
-  onExecuted,
   onSubmitted,
+  onExecuted,
   ethValue,
 }: UseAddLiquidityOptions): UseAddLiquidityResult {
   const hyperdriveModel = useHyperdriveModel(hyperdriveAddress);

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useAddLiquidity.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useAddLiquidity.ts
@@ -19,6 +19,7 @@ interface UseAddLiquidityOptions {
   /** Controls whether or not an `addLiquidity` callback will be returned to the
    * caller, useful for disabling buttons and other hooks */
   enabled?: boolean;
+  onSubmitted: (hash: string | undefined) => void;
   onExecuted: (hash: string | undefined) => void;
 }
 
@@ -37,6 +38,7 @@ export function useAddLiquidity({
   asBase = true,
   enabled,
   onExecuted,
+  onSubmitted,
   ethValue,
 }: UseAddLiquidityOptions): UseAddLiquidityResult {
   const hyperdriveModel = useHyperdriveModel(hyperdriveAddress);
@@ -85,7 +87,7 @@ export function useAddLiquidity({
               options: { value: ethValue },
               onTransactionMined,
             });
-
+        onSubmitted(hash);
         addTransaction({
           hash,
           description: "Add Liquidity",

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useRemoveLiquidity.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useRemoveLiquidity.ts
@@ -15,6 +15,7 @@ interface UseRemoveLiquidityOptions {
   destination: Address | undefined;
   asBase?: boolean;
   enabled?: boolean;
+  onSubmitted: (hash: string | undefined) => void;
   onExecuted: (hash: string | undefined) => void;
 }
 
@@ -30,6 +31,7 @@ export function useRemoveLiquidity({
   destination,
   asBase = true,
   enabled,
+  onSubmitted,
   onExecuted,
 }: UseRemoveLiquidityOptions): UseRemoveLiquidityResult {
   const hyperdriveModel = useHyperdriveModel(hyperdriveAddress);
@@ -69,6 +71,7 @@ export function useRemoveLiquidity({
               },
               onTransactionMined,
             });
+        onSubmitted?.(hash);
         addTransaction({
           hash,
           description: "Remove Liquidity",


### PR DESCRIPTION
This PR cleans up the add/remove liquidity toast flow. The modal is closed after the user approves the transaction and a toast is shown indicating the pending transaction. 

https://github.com/delvtech/hyperdrive-frontend/assets/22210106/183e9ee2-84d3-4450-812a-aea4ae66322d

