### PR TITLE
Fixes all markets table on mid-sized screens

### DIFF
--- a/apps/hyperdrive-trading/src/ui/markets/AllMarketsTable/AllMarketsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/AllMarketsTable/AllMarketsTable.tsx
@@ -8,7 +8,7 @@ export function AllMarketsTable(): ReactElement {
   return (
     <div className="flex w-full flex-col items-center">
       <h3 className="gradient-text mb-8 text-center">Available Markets</h3>
-      <div className="daisy-card daisy-card-bordered flex w-full md:p-6">
+      <div className="daisy-card daisy-card-bordered flex w-full md:w-3/4 md:p-6">
         {isTailwindSmallScreen ? (
           <AllMarketsTableMobile />
         ) : (

--- a/apps/hyperdrive-trading/src/ui/markets/AllMarketsTable/AllMarketsTableMobile.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/AllMarketsTable/AllMarketsTableMobile.tsx
@@ -83,9 +83,14 @@ function getMobileColumns() {
         return (
           <div className="flex flex-col gap-2">
             {data.map((column, i) => (
-              <div key={i} className="flex w-full justify-between gap-4">
-                <p className="text-neutral-content">{column.name}</p>
-                <p key={column.name}>{column.value}</p>
+              <div
+                key={i}
+                className="flex w-full justify-between gap-4 text-left md:justify-evenly"
+              >
+                <p className="text-neutral-content md:w-40">{column.name}</p>
+                <p className="md:w-40" key={column.name}>
+                  {column.value}
+                </p>
               </div>
             ))}
           </div>


### PR DESCRIPTION
This PR fixes the all markets table on mid-sized screens. Based on feedback, users had a hard time reading the label/values on the mobile table since they were so far apart.

https://github.com/delvtech/hyperdrive-frontend/assets/22210106/b7b530cf-cca9-489d-a092-0f75d29cf9f7

