### PR TITLE
Move app header into same column as content

### DIFF
--- a/apps/hyperdrive-trading/src/ui/markets/AllMarketsTable/AllMarketsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/AllMarketsTable/AllMarketsTable.tsx
@@ -8,7 +8,7 @@ export function AllMarketsTable(): ReactElement {
   return (
     <div className="flex w-full flex-col items-center">
       <h3 className="gradient-text mb-8 text-center">Available Markets</h3>
-      <div className="daisy-card daisy-card-bordered flex w-full md:w-3/4 md:p-6">
+      <div className="daisy-card daisy-card-bordered flex w-full md:p-6">
         {isTailwindSmallScreen ? (
           <AllMarketsTableMobile />
         ) : (

--- a/apps/hyperdrive-trading/src/ui/markets/AllMarketsTable/AllMarketsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/AllMarketsTable/AllMarketsTable.tsx
@@ -8,7 +8,7 @@ export function AllMarketsTable(): ReactElement {
   return (
     <div className="flex w-full flex-col items-center">
       <h3 className="gradient-text mb-8 text-center">Available Markets</h3>
-      <div className="daisy-card daisy-card-bordered flex w-full md:p-6">
+      <div className="daisy-card daisy-card-bordered flex w-full md:w-5/6 md:p-6">
         {isTailwindSmallScreen ? (
           <AllMarketsTableMobile />
         ) : (

--- a/apps/hyperdrive-trading/src/ui/routes/__root.tsx
+++ b/apps/hyperdrive-trading/src/ui/routes/__root.tsx
@@ -9,8 +9,10 @@ export const Route = new RootRoute({
 function RootComponent() {
   return (
     <div className="flex h-full flex-col items-center">
-      <Navbar />
-      <Outlet />
+      <div className="flex flex-col gap-9">
+        <Navbar />
+        <Outlet />
+      </div>
       <Footer />
       {import.meta.env.DEV ? <TanStackRouterDevtools /> : null}
     </div>


### PR DESCRIPTION
Wide screens rejoice! The logo and wallet components now live in the same column as the content.

<img width="2672" alt="image" src="https://github.com/delvtech/hyperdrive-frontend/assets/4524175/42f95064-de8c-438f-a79a-7d6caf15e804">
