### PR TITLE
Unify date formatting

### DIFF
--- a/apps/hyperdrive-trading/src/ui/base/formatting/formatDate.ts
+++ b/apps/hyperdrive-trading/src/ui/base/formatting/formatDate.ts
@@ -1,0 +1,7 @@
+export function formatDate(dateInMs: number): string {
+  return new Date(dateInMs).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/ClosedLongsTable/ClosedLongsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/ClosedLongsTable/ClosedLongsTable.tsx
@@ -18,6 +18,7 @@ import { ConnectWalletButton } from "src/ui/base/components/ConnectWallet";
 import LoadingState from "src/ui/base/components/LoadingState";
 import { NonIdealState } from "src/ui/base/components/NonIdealState";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
+import { formatDate } from "src/ui/base/formatting/formatDate";
 import { useIsTailwindSmallScreen } from "src/ui/base/mediaBreakpoints";
 import { useClosedLongs } from "src/ui/hyperdrive/longs/hooks/useClosedLongs";
 import { useAccount } from "wagmi";
@@ -35,11 +36,7 @@ function formatClosedLongMobileColumnData(
   return [
     {
       name: "Matures On",
-      value: (
-        <span>
-          {new Date(Number(closedLong.maturity * 1000n)).toLocaleDateString()}
-        </span>
-      ),
+      value: <span>{formatDate(Number(closedLong.maturity * 1000n))}</span>,
     },
     {
       name: `Size (hy${baseToken.symbol})`,
@@ -65,11 +62,7 @@ function formatClosedLongMobileColumnData(
     {
       name: "Closed On",
       value: (
-        <span>
-          {new Date(
-            Number(closedLong.closedTimestamp * 1000n),
-          ).toLocaleDateString()}
-        </span>
+        <span>{formatDate(Number(closedLong.closedTimestamp * 1000n))}</span>
       ),
     },
   ];
@@ -129,8 +122,8 @@ function getColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
     columnHelper.display({
       header: `Matures On`,
       cell: ({ row }) => {
-        const maturity = new Date(Number(row.original.maturity * 1000n));
-        return <span>{maturity.toLocaleDateString()}</span>;
+        const maturity = formatDate(Number(row.original.maturity * 1000n));
+        return <span>{maturity}</span>;
       },
     }),
     columnHelper.display({
@@ -163,9 +156,7 @@ function getColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
     columnHelper.accessor("closedTimestamp", {
       header: `Closed On`,
       cell: ({ row }) => {
-        return new Date(
-          Number(row.original.closedTimestamp * 1000n),
-        ).toLocaleDateString();
+        return formatDate(Number(row.original.closedTimestamp * 1000n));
       },
     }),
   ];

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongPreview.tsx
@@ -11,6 +11,7 @@ import { formatRate } from "src/base/formatRate";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { LabelValue } from "src/ui/base/components/LabelValue";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
+import { formatDate } from "src/ui/base/formatting/formatDate";
 import { useCurrentFixedAPR } from "src/ui/hyperdrive/hooks/useCurrentFixedAPR";
 
 interface OpenLongPreviewProps {
@@ -153,9 +154,7 @@ export function OpenLongPreview({
       />
       <LabelValue
         label="Matures in"
-        value={`${numDays} days, ${new Date(
-          Date.now() + termLengthMS,
-        ).toLocaleDateString()}`}
+        value={`${numDays} days, ${formatDate(Date.now() + termLengthMS)}`}
       />
     </div>
   );

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/ClosedLpTable/ClosedLpTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/ClosedLpTable/ClosedLpTable.tsx
@@ -19,6 +19,7 @@ import { ConnectWalletButton } from "src/ui/base/components/ConnectWallet";
 import { NonIdealState } from "src/ui/base/components/NonIdealState";
 import { TableSkeleton } from "src/ui/base/components/TableSkeleton";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
+import { formatDate } from "src/ui/base/formatting/formatDate";
 import { useIsTailwindSmallScreen } from "src/ui/base/mediaBreakpoints";
 import { useClosedLpShares } from "src/ui/hyperdrive/lp/hooks/useClosedLpShares";
 import { useRedeemedWithdrawalShares } from "src/ui/hyperdrive/lp/hooks/useRedeemedWithdrawalShares";
@@ -48,9 +49,7 @@ function formatClosedLpMobileColumnData(
   return [
     {
       name: "Closed On",
-      value: new Date(
-        Number(closedLpShares.closedTimestamp * 1000n),
-      ).toLocaleDateString(),
+      value: formatDate(Number(closedLpShares.closedTimestamp * 1000n)),
     },
     {
       name: "Shares Closed",
@@ -196,11 +195,7 @@ function getColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
       cell: ({ row }) => {
         const closedTimestamp =
           row.original.closedTimestamp || row.original.redeemedTimestamp;
-        return (
-          <span>
-            {new Date(Number(closedTimestamp * 1000n)).toLocaleDateString()}
-          </span>
-        );
+        return <span>{formatDate(Number(closedTimestamp * 1000n))}</span>;
       },
     }),
   ];

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/ClosedShortsTable/ClosedShortsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/ClosedShortsTable/ClosedShortsTable.tsx
@@ -16,6 +16,7 @@ import { ConnectWalletButton } from "src/ui/base/components/ConnectWallet";
 import LoadingState from "src/ui/base/components/LoadingState";
 import { NonIdealState } from "src/ui/base/components/NonIdealState";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
+import { formatDate } from "src/ui/base/formatting/formatDate";
 import { useIsTailwindSmallScreen } from "src/ui/base/mediaBreakpoints";
 import { useClosedShorts } from "src/ui/hyperdrive/shorts/hooks/useClosedShorts";
 import { useAccount } from "wagmi";
@@ -36,9 +37,7 @@ function formatClosedShortMobileColumnData(
   return [
     {
       name: "Matures On",
-      value: new Date(
-        Number(closedShort.maturity * 1000n),
-      ).toLocaleDateString(),
+      value: formatDate(Number(closedShort.maturity * 1000n)),
     },
     {
       name: `Size (${baseToken.symbol})`,
@@ -58,9 +57,7 @@ function formatClosedShortMobileColumnData(
     },
     {
       name: "Closed On",
-      value: new Date(
-        Number(closedShort.closedTimestamp * 1000n),
-      ).toLocaleDateString(),
+      value: formatDate(Number(closedShort.closedTimestamp * 1000n)),
     },
   ];
 }
@@ -118,8 +115,8 @@ function getColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
     columnHelper.display({
       header: `Matures On`,
       cell: ({ row }) => {
-        const maturity = new Date(Number(row.original.maturity * 1000n));
-        return <span>{maturity.toLocaleDateString()}</span>;
+        const maturity = formatDate(Number(row.original.maturity * 1000n));
+        return <span>{maturity}</span>;
       },
     }),
     columnHelper.accessor("bondAmount", {
@@ -151,11 +148,7 @@ function getColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
       header: `Closed On`,
       cell: (closedTimestamp) => {
         return (
-          <span>
-            {new Date(
-              Number(closedTimestamp.getValue() * 1000n),
-            ).toLocaleDateString()}
-          </span>
+          <span>{formatDate(Number(closedTimestamp.getValue() * 1000n))}</span>
         );
       },
     }),

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
@@ -11,6 +11,7 @@ import { formatRate } from "src/base/formatRate";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { LabelValue } from "src/ui/base/components/LabelValue";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
+import { formatDate } from "src/ui/base/formatting/formatDate";
 import { useCurrentFixedAPR } from "src/ui/hyperdrive/hooks/useCurrentFixedAPR";
 interface OpenShortPreviewProps {
   hyperdrive: HyperdriveConfig;
@@ -124,9 +125,9 @@ export function OpenShortPreview({
 
       <LabelValue
         label="Matures in"
-        value={`${convertMillisecondsToDays(termLengthMS)} days, ${new Date(
+        value={`${convertMillisecondsToDays(termLengthMS)} days, ${formatDate(
           Date.now() + termLengthMS,
-        ).toLocaleDateString()}`}
+        )}`}
       />
     </div>
   );

--- a/apps/hyperdrive-trading/src/version.output.ts
+++ b/apps/hyperdrive-trading/src/version.output.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION =  "a3150b3cbc82a6999d5d7e824134c7116d8a6f1f";
+export const APP_VERSION = "d7df3c8320513fc8a6165cebaedaa160aacf5d6b";


### PR DESCRIPTION
Adding a `formatDate` method so we can render dates consistently everywhere