### PR TITLE
Fix bug in LP APY calculation

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/OpenLpSharesCard/OpenLpSharesCard.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/OpenLpSharesCard/OpenLpSharesCard.tsx
@@ -220,7 +220,7 @@ export function OpenLpSharesCard({
         ) : (
           <NonIdealState
             heading="You have no LP positions"
-            text="Add liquidity, switch wallets, or view your closed LP positions."
+            text="Add liquidity, switch wallets, or view your closed LP positions"
           />
         )}
       </div>

--- a/apps/hyperdrive-trading/src/ui/markets/AllMarketsTable/LpApyCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/AllMarketsTable/LpApyCell.tsx
@@ -15,5 +15,5 @@ export function LpApyCell({
   if (!lpApy) {
     return <span>no data</span>;
   }
-  return <span>{lpApy?.toFixed(2)}%</span>;
+  return <span>{(lpApy * 100).toFixed(2)}%</span>;
 }

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/MarketStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/MarketStats.tsx
@@ -67,7 +67,7 @@ export function MarketStats({
         value={
           lpApyStatus !== "loading" ? (
             <span className="flex items-center gap-1.5">
-              {lpApy === undefined ? "no data" : `${lpApy?.toFixed(2)}%`}
+              {lpApy === undefined ? "no data" : `${(lpApy * 100).toFixed(2)}%`}
             </span>
           ) : (
             <Skeleton className="w-20" />

--- a/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
@@ -1784,7 +1784,6 @@ function calculateBaseAmount({
  * p_1 = to lpSharePrice
  * t = term length in fractions of a year
  * 
- * Original calc:
  * r = ln(p_1 / p_0) / t
  */
 function calculateLpApy({


### PR DESCRIPTION
The calc for lp apy had a bug:

Before:
`r = ln(p_1 / p_0 / t)`

After:
`r = ln(p_1 / p_0) / t`

This brings the lp apy back to normal numbers:

<img width="1255" alt="image" src="https://github.com/delvtech/hyperdrive-frontend/assets/4524175/b539f172-53bb-4f4e-8af8-40eeeb53cafe">
