### PR TITLE
Change 12h -> 7d in LP APY, full width position tables

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/ClosedLongsTable/ClosedLongsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/ClosedLongsTable/ClosedLongsTable.tsx
@@ -206,7 +206,7 @@ export function ClosedLongsTable({
   }
 
   return (
-    <div className="max-h-96 overflow-y-auto">
+    <div className="max-h-[512px] overflow-y-auto">
       <table className="daisy-table daisy-table-zebra daisy-table-lg">
         <thead>
           {tableInstance.getHeaderGroups().map((headerGroup) => (

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
@@ -76,7 +76,7 @@ export function OpenLongsTableDesktop({
   }
 
   return (
-    <div className="max-h-96 overflow-y-auto overflow-x-clip">
+    <div className="max-h-[512px] overflow-y-auto overflow-x-clip">
       {/* Modal needs to be rendered outside of the table so that dialog can be used. Otherwise react throws a dom nesting error */}
       {tableInstance.getRowModel().rows.map((row) => {
         const modalId = `${row.original.assetId}`;

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableMobile.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableMobile.tsx
@@ -76,7 +76,7 @@ export function OpenLongsTableMobile({
   }
 
   return (
-    <div className="max-h-96 overflow-y-auto overflow-x-clip">
+    <div className="max-h-[512px] overflow-y-auto overflow-x-clip">
       {/* Modal needs to be rendered outside of the table so that dialog can be used. Otherwise react throws a dom nesting error */}
       {tableInstance.getRowModel().rows.map((row) => {
         const modalId = `${row.original.assetId}`;

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/ClosedLpTable/ClosedLpTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/ClosedLpTable/ClosedLpTable.tsx
@@ -256,7 +256,7 @@ export function ClosedLpTable({
     );
   }
   return (
-    <div className="max-h-96 w-full overflow-y-auto">
+    <div className="max-h-[512px] w-full overflow-y-auto">
       <table className="daisy-table daisy-table-zebra daisy-table-lg">
         <thead>
           {tableInstance.getHeaderGroups().map((headerGroup) => (

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/ClosedShortsTable/ClosedShortsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/ClosedShortsTable/ClosedShortsTable.tsx
@@ -199,7 +199,7 @@ export function ClosedShortsTable({
     );
   }
   return (
-    <div className="max-h-96 overflow-y-auto">
+    <div className="max-h-[512px] overflow-y-auto">
       <table className="daisy-table daisy-table-zebra daisy-table-lg">
         <thead>
           {tableInstance.getHeaderGroups().map((headerGroup) => (

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktop.tsx
@@ -44,7 +44,7 @@ export function OpenShortsTableDesktop({
   });
 
   return (
-    <div className="max-h-96 overflow-y-auto">
+    <div className="max-h-[512px] overflow-y-auto">
       {/* Modal needs to be rendered outside of the table so that dialog can be used. Otherwise react throws a dom nesting error */}
       {tableInstance.getRowModel().rows.map((row) => {
         const modalId = `${row.original.assetId}`;

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableMobile.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableMobile.tsx
@@ -39,7 +39,7 @@ export function OpenShortsTableMobile({
   });
 
   return (
-    <div className="max-h-96 overflow-y-auto">
+    <div className="max-h-[512px] overflow-y-auto">
       {/* Modal needs to be rendered outside of the table so that dialog can be used. Otherwise react throws a dom nesting error */}
       {tableInstance.getRowModel().rows.map((row) => {
         const modalId = `${row.original.assetId}`;

--- a/apps/hyperdrive-trading/src/ui/markets/LongsTab/LongsTab.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/LongsTab/LongsTab.tsx
@@ -24,7 +24,7 @@ export function LongsTab({
     <MarketDetailsTab
       positions={
         <div className="flex flex-col">
-          <div className="flex items-center justify-between px-4 py-8">
+          <div className="flex items-center justify-between px-6 py-8">
             <h5 className="font-medium">Long Positions</h5>
             <div className="flex items-center gap-4">
               {account && openLongs?.length ? (

--- a/apps/hyperdrive-trading/src/ui/markets/LpTab/LpTab.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/LpTab/LpTab.tsx
@@ -37,7 +37,7 @@ export function LpTab({
     <MarketDetailsTab
       positions={
         <div className="flex flex-col items-center">
-          <div className="flex w-full items-center justify-between px-4 py-8">
+          <div className="flex w-full items-center justify-between px-6 py-8">
             <h5 className="font-medium">LP Position</h5>
             <div className="flex items-center gap-4">
               {(lpShares && lpSharesStatus === "success") ||

--- a/apps/hyperdrive-trading/src/ui/markets/MarketDetailsTab/MarketDetailsTab.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketDetailsTab/MarketDetailsTab.tsx
@@ -10,7 +10,7 @@ export function MarketDetailsTab({
 }): ReactElement {
   return (
     <div className="flex w-full flex-col gap-10 xl:w-[1200px] xl:flex-row">
-      <div className="flex min-w-0 flex-1 flex-col md:px-8">
+      <div className="flex min-w-0 flex-1 flex-col">
         {/* positions and faq tabs */}
         <div className="flex flex-col">{positions}</div>
       </div>

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/MarketStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/MarketStats.tsx
@@ -63,7 +63,7 @@ export function MarketStats({
         description="Fixed rate earned from opening longs, before fees and slippage are applied."
       />
       <Stat
-        label="LP APY (12 Hour)"
+        label="LP APY (7d)"
         value={
           lpApyStatus !== "loading" ? (
             <span className="flex items-center gap-1.5">
@@ -73,7 +73,7 @@ export function MarketStats({
             <Skeleton className="w-20" />
           )
         }
-        description={`The LP's annual return projection assuming the past 12-hour performance rate continues for a year.`}
+        description={`The LP's annual return projection assuming the past 7-day performance rate continues for a year.`}
       />
       <Stat
         description={`The amount of hy${

--- a/apps/hyperdrive-trading/src/ui/markets/ShortsTab/ShortsTab.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/ShortsTab/ShortsTab.tsx
@@ -24,7 +24,7 @@ export function ShortsTab({
     <MarketDetailsTab
       positions={
         <div className="flex flex-col">
-          <div className="flex items-center justify-between px-4 py-8">
+          <div className="flex items-center justify-between px-6 py-8">
             <h5 className="font-medium">Short Positions</h5>
             <div className="flex items-center gap-4">
               {account && openShorts?.length ? (


### PR DESCRIPTION
The LP APY is actually showing the 7d stats, so the label was updated to reflect that. I also fixed the awkward padding on our tables so now they extend the full width of the card.

|Before|After|
|--|--|
|<img width="1299" alt="image" src="https://github.com/delvtech/hyperdrive-frontend/assets/4524175/c1bbf177-94e4-4cff-bd42-be916541c556">|<img width="1364" alt="image" src="https://github.com/delvtech/hyperdrive-frontend/assets/4524175/86171065-e44a-4207-a30a-d00b6685a7a8">|