### PR TITLE
Fix LP Shares current value

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/OpenLpSharesCard/OpenLpSharesCard.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/OpenLpSharesCard/OpenLpSharesCard.tsx
@@ -5,7 +5,6 @@ import * as dnum from "dnum";
 import { ReactElement } from "react";
 import Skeleton from "react-loading-skeleton";
 import { calculateRatio } from "src/base/calculateRatio";
-import { calculateValueFromPrice } from "src/base/calculateValueFromPrice";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { LabelValue } from "src/ui/base/components/LabelValue";
 import { Modal } from "src/ui/base/components/Modal/Modal";
@@ -44,16 +43,11 @@ export function OpenLpSharesCard({
     hyperdriveAddress: hyperdrive.address,
   });
 
-  const { baseAmountPaid } = useOpenLpPosition({
+  const { baseAmountPaid, baseValue } = useOpenLpPosition({
     hyperdriveAddress: hyperdrive.address,
     account,
   });
-  const currentValue = calculateValueFromPrice({
-    amount: lpShares || 0n,
-    unitPrice: poolInfo?.lpSharePrice || 0n,
-    decimals: baseToken.decimals,
-  });
-  const profit = dnum.subtract([currentValue, 18], [baseAmountPaid, 18])[0];
+  const profit = dnum.subtract([baseValue, 18], [baseAmountPaid, 18])[0];
   const isPositiveChangeInValue = profit > 0n;
 
   const utilizationRatio = useUtilizationRatio({
@@ -110,7 +104,7 @@ export function OpenLpSharesCard({
                 <p>
                   {!!poolInfo && !!lpShares ? (
                     `${formatBalance({
-                      balance: currentValue,
+                      balance: baseValue,
                       decimals: baseToken.decimals,
                       places: 4,
                     })} ${baseToken.symbol}`

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
@@ -173,6 +173,11 @@ export function RemoveLiquidityForm({
     balance: lpShares,
   });
 
+  const slippageReceived = dnum.subtract(
+    [actualValueOut || 0n, hyperdrive.decimals],
+    [desiredOut || 0n, hyperdrive.decimals],
+  )[0];
+
   return (
     <TransactionView
       tokenInput={
@@ -207,11 +212,11 @@ export function RemoveLiquidityForm({
       transactionPreview={
         <>
           <LabelValue
-            label="You receive"
+            label="Amount to withdraw"
             value={`${
               actualValueOut
                 ? `${formatBalance({
-                    balance: actualValueOut,
+                    balance: desiredOut || 0n,
                     decimals: activeWithdrawToken.decimals,
                     places: 4,
                   })}`
@@ -219,8 +224,45 @@ export function RemoveLiquidityForm({
             } ${activeWithdrawToken.symbol}`}
           />
           <LabelValue
+            label="Balance mechanism reward"
+            value={
+              <span
+                className="daisy-tooltip daisy-tooltip-top daisy-tooltip-left cursor-help border-b border-dashed border-current before:border"
+                data-tip="Additional amount you receive as part of the pool's mechanism for maintaining the existing lp share price"
+              >
+                {actualValueOut
+                  ? `${formatBalance({
+                      balance: slippageReceived,
+                      decimals: activeWithdrawToken.decimals,
+                      places: 4,
+                    })}`
+                  : "0"}{" "}
+                {activeWithdrawToken.symbol}
+              </span>
+            }
+          />
+          <LabelValue
+            label="Total you receive"
+            value={
+              <span className="font-bold">
+                {actualValueOut
+                  ? `${formatBalance({
+                      balance: actualValueOut,
+                      decimals: activeWithdrawToken.decimals,
+                      places: 4,
+                    })}`
+                  : "0"}{" "}
+                {activeWithdrawToken.symbol}
+              </span>
+            }
+          />
+          <LabelValue
             label="Queued for delayed withdrawal"
-            value={`${formattedWithdrawalSharesOut || 0} ${baseToken.symbol}`}
+            value={
+              <span className="font-bold">
+                {formattedWithdrawalSharesOut || 0} {baseToken.symbol}
+              </span>
+            }
           />
         </>
       }

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
@@ -199,7 +199,6 @@ export function RemoveLiquidityForm({
           }
           value={amount ?? ""}
           maxValue={formatUnits(activeWithdrawTokenLpValue, baseToken.decimals)}
-          strictMax
           stat={
             lpShares && !!poolInfo
               ? `Withdrawable: ${formatBalance({

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
@@ -234,7 +234,7 @@ export function RemoveLiquidityForm({
                 <div
                   data-tip="Additional amount you pay or receive as part of the pool's mechanism for maintaining the existing lp share price"
                   className={classNames(
-                    "daisy-tooltip daisy-tooltip-left flex cursor-help items-center border-b border-dashed border-current before:border",
+                    "daisy-tooltip daisy-tooltip-top flex cursor-help items-center border-b border-dashed border-current before:left-2 before:border",
                     {
                       "text-success": slippageReceived > 0n,
                       "text-error": slippageReceived < 0n,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useOpenLpPosition.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useOpenLpPosition.ts
@@ -12,6 +12,8 @@ export function useOpenLpPosition({
 }: UseOpenLpPositionOptions): {
   lpShareBalance: bigint;
   baseAmountPaid: bigint;
+  baseValue: bigint;
+  sharesValue: bigint;
   openLpPositionStatus: "loading" | "error" | "success";
 } {
   const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
@@ -26,6 +28,8 @@ export function useOpenLpPosition({
   return {
     lpShareBalance: data?.lpShareBalance ?? 0n,
     baseAmountPaid: data?.baseAmountPaid ?? 0n,
+    baseValue: data?.baseValue ?? 0n,
+    sharesValue: data?.sharesValue ?? 0n,
     openLpPositionStatus,
   };
 }

--- a/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
@@ -1,42 +1,42 @@
 import {
+  BlockTag,
+  CachedReadContract,
   ContractGetEventsOptions,
   ContractReadOptions,
   ContractWriteOptions,
-  BlockTag,
-  CachedReadContract,
   Event,
 } from "@delvtech/evm-client";
+import * as dnum from "dnum";
 import groupBy from "lodash.groupby";
 import mapValues from "lodash.mapvalues";
-import { sumBigInt } from "src/base/sumBigInt";
-import { PoolConfig } from "src/pool/PoolConfig";
-import { PoolInfo } from "src/pool/PoolInfo";
 import { ReturnType } from "src/base/ReturnType";
-import { LP_ASSET_ID } from "src/lp/assetId";
-import { decodeAssetFromTransferSingleEventData } from "src/pool/decodeAssetFromTransferSingleEventData";
+import { convertBigIntsToStrings } from "src/base/convertBigIntsToStrings";
+import { convertSecondsToYearFraction } from "src/base/convertSecondsToYearFraction";
+import { MAX_UINT256, ZERO_ADDRESS } from "src/base/numbers";
+import { sumBigInt } from "src/base/sumBigInt";
+import { getBlockOrThrow } from "src/evm-client/getBlockOrThrow";
+import { HyperdriveAbi, hyperdriveAbi } from "src/hyperdrive/abi";
+import { DEFAULT_EXTRA_DATA } from "src/hyperdrive/constants";
+import { convertBaseToShares } from "src/hyperdrive/utils/convertBaseToShares";
+import { convertSharesToBase } from "src/hyperdrive/utils/convertSharesToBase";
+import { hyperwasm } from "src/hyperwasm";
 import { ClosedLong, Long } from "src/longs/types";
 import { ClosedLpShares } from "src/lp/ClosedLpShares";
-import { RedeemedWithdrawalShares } from "src/withdrawalShares/RedeemedWithdrawalShares";
-import { ClosedShort, OpenShort } from "src/shorts/types";
-import { getCheckpointId } from "src/pool/getCheckpointId";
-import { WITHDRAW_SHARES_ASSET_ID } from "src/withdrawalShares/assetId";
+import { LP_ASSET_ID } from "src/lp/assetId";
+import { ReadContractModelOptions, ReadModel } from "src/model/ReadModel";
 import { Checkpoint, CheckpointEvent } from "src/pool/Checkpoint";
 import { MarketState } from "src/pool/MarketState";
-import * as dnum from "dnum";
-import { MAX_UINT256, ZERO_ADDRESS } from "src/base/numbers";
-import { DEFAULT_EXTRA_DATA } from "src/hyperdrive/constants";
+import { PoolConfig } from "src/pool/PoolConfig";
+import { PoolInfo } from "src/pool/PoolInfo";
+import { decodeAssetFromTransferSingleEventData } from "src/pool/decodeAssetFromTransferSingleEventData";
+import { getCheckpointId } from "src/pool/getCheckpointId";
 import { calculateShortAccruedYield } from "src/shorts/calculateShortAccruedYield";
-import { convertBigIntsToStrings } from "src/base/convertBigIntsToStrings";
-import { hyperwasm } from "src/hyperwasm";
-import { getBlockOrThrow } from "src/evm-client/getBlockOrThrow";
-import { convertSharesToBase } from "src/hyperdrive/utils/convertSharesToBase";
-import { convertBaseToShares } from "src/hyperdrive/utils/convertBaseToShares";
-import { convertSecondsToYearFraction } from "src/base/convertSecondsToYearFraction";
-import { ReadContractModelOptions, ReadModel } from "src/model/ReadModel";
-import { HyperdriveAbi, hyperdriveAbi } from "src/hyperdrive/abi";
+import { ClosedShort, OpenShort } from "src/shorts/types";
 import { ReadToken } from "src/token/ReadToken";
-import { ReadEth } from "src/token/eth/ReadEth";
 import { ReadErc20 } from "src/token/erc20/ReadErc20";
+import { ReadEth } from "src/token/eth/ReadEth";
+import { RedeemedWithdrawalShares } from "src/withdrawalShares/RedeemedWithdrawalShares";
+import { WITHDRAW_SHARES_ASSET_ID } from "src/withdrawalShares/assetId";
 
 export interface ReadHyperdriveOptions extends ReadContractModelOptions {}
 
@@ -1288,8 +1288,31 @@ export class ReadHyperdrive extends ReadModel implements IReadHyperdrive {
       },
     );
 
-    // combine the adds and removes in order of block number to get the full
-    // transaction history in the order the user executed them
+    const { lpShareBalance, baseAmountPaid } = this._calcOpenLpPosition(
+      addLiquidityEvents,
+      removeLiquidityEvents,
+    );
+
+    return {
+      lpShareBalance,
+      baseAmountPaid,
+    };
+  }
+
+  // combine the adds and removes in order of block number to get the full
+  // transaction history in the order the user executed them
+  private _calcOpenLpPosition(
+    addLiquidityEvents: {
+      eventName: "AddLiquidity";
+      blockNumber?: bigint;
+      args: { lpAmount: bigint; baseAmount: bigint };
+    }[],
+    removeLiquidityEvents: {
+      eventName: "RemoveLiquidity";
+      blockNumber?: bigint;
+      args: { lpAmount: bigint; baseAmount: bigint };
+    }[],
+  ) {
     const combinedEventsInOrder = [
       ...addLiquidityEvents,
       ...removeLiquidityEvents,
@@ -1330,10 +1353,7 @@ export class ReadHyperdrive extends ReadModel implements IReadHyperdrive {
       }
     });
 
-    return {
-      lpShareBalance,
-      baseAmountPaid,
-    };
+    return { lpShareBalance, baseAmountPaid };
   }
 
   async getClosedLpShares({


### PR DESCRIPTION
#775 

- The current value of an LP position now comes from the SDK and is shown in the Open LP Card.
![image](https://github.com/delvtech/hyperdrive-frontend/assets/4524175/2a923d33-8997-4f47-adee-dc83e85c0168)

Display the positive slippage:
<img width="549" alt="image" src="https://github.com/delvtech/hyperdrive-frontend/assets/4524175/2b1e3fa1-90f4-46b7-bd1a-8f940fc1c8dd">
<img width="441" alt="image" src="https://github.com/delvtech/hyperdrive-frontend/assets/4524175/8493cf0b-1d42-4f54-bd35-d1f6d40f13c3">
