### PR TITLE
Display full name of chain

### DIFF
--- a/apps/hyperdrive-trading/src/ui/base/components/ConnectWallet.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/ConnectWallet.tsx
@@ -41,14 +41,12 @@ export function ConnectWalletButton(): JSX.Element {
               }
               return (
                 <div className="flex items-center gap-4">
-                  <div
+                  <button
                     onClick={openChainModal}
-                    className="daisy-avatar cursor-pointer"
+                    className="daisy-btn daisy-btn-outline rounded-full"
                   >
-                    <div className="w-8 rounded-full">
-                      <img src={chain.iconUrl} />
-                    </div>
-                  </div>
+                    {chain.name}
+                  </button>
                   <button
                     className="daisy-btn daisy-btn-circle daisy-btn-primary mx-0 w-32"
                     onClick={openAccountModal}


### PR DESCRIPTION
Showing the full chain name instead of an icon, since not all chains will be configured with one.

|Before|After|
|---|---|
|<img width="1263" alt="image" src="https://github.com/delvtech/hyperdrive-frontend/assets/4524175/0e3c0631-9640-4676-b0c9-ef707d405aec">|<img width="1271" alt="image" src="https://github.com/delvtech/hyperdrive-frontend/assets/4524175/3b6eee27-6964-4a14-804e-59ceaa5dd165">|