### PR TITLE
Add descriptions to loading state component

### DIFF
--- a/apps/hyperdrive-trading/src/ui/base/components/LoadingState.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/LoadingState.tsx
@@ -1,7 +1,21 @@
-export default function LoadingState(): JSX.Element {
+import { NonIdealState } from "src/ui/base/components/NonIdealState";
+
+export default function LoadingState({
+  text,
+  heading,
+}: {
+  text?: string;
+  heading?: string;
+}): JSX.Element {
   return (
-    <div className="my-28 flex items-center justify-center">
-      <div className="daisy-loading daisy-loading-spinner daisy-loading-lg text-primary" />
+    <div className="my-28 flex flex-col items-center justify-center">
+      <NonIdealState
+        heading={heading}
+        icon={
+          <div className="daisy-loading daisy-loading-spinner daisy-loading-lg text-primary" />
+        }
+        text={text || null}
+      />
     </div>
   );
 }

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
@@ -62,7 +62,12 @@ export function OpenLongsTableDesktop({
     );
   }
   if (openLongsStatus === "loading") {
-    return <LoadingState />;
+    return (
+      <LoadingState
+        heading="Loading your Longs..."
+        text="Searching for Long events, calculating current value and PnL..."
+      />
+    );
   }
   if (!openLongs?.length && openLongsStatus === "success") {
     return (

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableMobile.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableMobile.tsx
@@ -62,7 +62,12 @@ export function OpenLongsTableMobile({
     );
   }
   if (openLongsStatus === "loading") {
-    return <LoadingState />;
+    return (
+      <LoadingState
+        heading="Loading your Longs..."
+        text="Searching for Long events, calculating current value and PnL..."
+      />
+    );
   }
   if (!openLongs?.length && openLongsStatus === "success") {
     return (


### PR DESCRIPTION
Events might load slowly, but if users see a spinner for too long, they might think something's wrong. Adding this info to the spinner tells them, "We're working on it, so hang tight!"

<img width="1228" alt="image" src="https://github.com/delvtech/hyperdrive-frontend/assets/4524175/6d397426-e518-45ba-b9dc-53dfcb95ba50">
