### PR TITLE
Fix token approval toast

### DIFF
--- a/apps/hyperdrive-trading/src/ui/token/hooks/useApproveToken.tsx
+++ b/apps/hyperdrive-trading/src/ui/token/hooks/useApproveToken.tsx
@@ -50,6 +50,7 @@ export function useApproveToken({
                 amount === 0n ? "Revoking approval..." : "Approving...";
               toast.loading(
                 <TransactionToast message={loadingDescription} txHash={hash} />,
+                { id: hash },
               );
 
               await waitForTransactionAndInvalidateCache({
@@ -63,6 +64,7 @@ export function useApproveToken({
                 amount === 0n ? "Approval revoked" : "Token approved";
               toast.success(
                 <TransactionToast message={loadedDescription} txHash={hash} />,
+                { id: hash },
               );
             },
           },


### PR DESCRIPTION
Forgot the `id` field on this one which makes toasts able to update in-place instead of rendering two toasts.

Related to #835