### PR TITLE
Fix mobile alignment

### DIFF
--- a/apps/hyperdrive-trading/src/ui/app/Navbar/Navbar.tsx
+++ b/apps/hyperdrive-trading/src/ui/app/Navbar/Navbar.tsx
@@ -9,7 +9,7 @@ export function Navbar(): ReactElement {
   return (
     <div className="daisy-navbar">
       <div className="daisy-navbar-start ml-2">
-        <Link to={"/"} className="inline-flex items-center ">
+        <Link to={"/"} className="inline-flex items-center">
           <HyperdriveLogo />
         </Link>
       </div>

--- a/apps/hyperdrive-trading/src/ui/app/Navbar/Navbar.tsx
+++ b/apps/hyperdrive-trading/src/ui/app/Navbar/Navbar.tsx
@@ -1,18 +1,18 @@
 import { Link } from "@tanstack/react-router";
 import { ReactElement } from "react";
-import { FeatureFlagPicker } from "src/ui/app/Navbar/FeatureFlagPicker";
+// import { FeatureFlagPicker } from "src/ui/app/Navbar/FeatureFlagPicker";
 import { HyperdriveLogo } from "src/ui/app/Navbar/HyperdriveLogo";
 import { ConnectWalletButton } from "src/ui/base/components/ConnectWallet";
 export function Navbar(): ReactElement {
   return (
-    <div className="daisy-navbar">
+    <div className="daisy-navbar flex">
       <div className="daisy-navbar-start ml-2">
         <Link to={"/"} className="inline-flex items-center ">
           <HyperdriveLogo />
         </Link>
       </div>
       <div className="daisy-navbar-end gap-8">
-        {import.meta.env.DEV ? <FeatureFlagPicker /> : null}
+        {/* {import.meta.env.DEV ? <FeatureFlagPicker /> : null} */}
         <ConnectWalletButton />
       </div>
     </div>

--- a/apps/hyperdrive-trading/src/ui/app/Navbar/Navbar.tsx
+++ b/apps/hyperdrive-trading/src/ui/app/Navbar/Navbar.tsx
@@ -1,18 +1,22 @@
 import { Link } from "@tanstack/react-router";
 import { ReactElement } from "react";
-// import { FeatureFlagPicker } from "src/ui/app/Navbar/FeatureFlagPicker";
+import { FeatureFlagPicker } from "src/ui/app/Navbar/FeatureFlagPicker";
 import { HyperdriveLogo } from "src/ui/app/Navbar/HyperdriveLogo";
 import { ConnectWalletButton } from "src/ui/base/components/ConnectWallet";
+import { useIsTailwindSmallScreen } from "src/ui/base/mediaBreakpoints";
 export function Navbar(): ReactElement {
+  const isTailwindSmallScreen = useIsTailwindSmallScreen();
   return (
-    <div className="daisy-navbar flex">
+    <div className="daisy-navbar">
       <div className="daisy-navbar-start ml-2">
         <Link to={"/"} className="inline-flex items-center ">
           <HyperdriveLogo />
         </Link>
       </div>
       <div className="daisy-navbar-end gap-8">
-        {/* {import.meta.env.DEV ? <FeatureFlagPicker /> : null} */}
+        {import.meta.env.DEV && !isTailwindSmallScreen ? (
+          <FeatureFlagPicker />
+        ) : null}
         <ConnectWalletButton />
       </div>
     </div>

--- a/apps/hyperdrive-trading/src/ui/base/components/ConnectWallet.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/ConnectWallet.tsx
@@ -48,7 +48,7 @@ export function ConnectWalletButton(): JSX.Element {
                     {chain.name}
                   </button>
                   <button
-                    className="daisy-btn daisy-btn-circle daisy-btn-primary mx-0 w-32"
+                    className="daisy-btn daisy-btn-circle daisy-btn-primary daisy-btn-md mx-0 w-24 md:w-32"
                     onClick={openAccountModal}
                   >
                     {account.displayName}

--- a/apps/hyperdrive-trading/src/ui/base/components/ConnectWallet.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/ConnectWallet.tsx
@@ -48,7 +48,7 @@ export function ConnectWalletButton(): JSX.Element {
                     {chain.name}
                   </button>
                   <button
-                    className="daisy-btn daisy-btn-circle daisy-btn-primary daisy-btn-md mx-0 w-24 md:w-32"
+                    className="daisy-btn daisy-btn-circle daisy-btn-primary mx-0 w-24 md:w-32"
                     onClick={openAccountModal}
                   >
                     {account.displayName}

--- a/apps/hyperdrive-trading/src/ui/base/components/Stat.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/Stat.tsx
@@ -22,7 +22,7 @@ export function Stat({
         <p
           data-tip={description}
           className={classNames(
-            `group daisy-tooltip cursor-help text-sm text-neutral-content before:text-start`,
+            `group daisy-tooltip cursor-help text-sm text-neutral-content before:max-w-48 before:p-2 before:text-start`,
             {
               "daisy-tooltip-top": tooltipPosition === "top",
               "daisy-tooltip-bottom": tooltipPosition === "bottom",

--- a/apps/hyperdrive-trading/src/ui/markets/LongsTab/LongsTab.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/LongsTab/LongsTab.tsx
@@ -24,7 +24,7 @@ export function LongsTab({
     <MarketDetailsTab
       positions={
         <div className="flex flex-col">
-          <div className="flex items-center justify-between p-8">
+          <div className="flex flex-wrap items-center justify-between gap-4 p-8">
             <h5 className="font-medium">Long Positions</h5>
             <div className="flex items-center gap-4">
               {account && openLongs?.length ? (

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/MarketStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/MarketStats.tsx
@@ -5,6 +5,7 @@ import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { Stat } from "src/ui/base/components/Stat";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { formatCompact } from "src/ui/base/formatting/formatCompact";
+import { useIsTailwindSmallScreen } from "src/ui/base/mediaBreakpoints";
 import { useCurrentFixedAPR } from "src/ui/hyperdrive/hooks/useCurrentFixedAPR";
 import { useLiquidity } from "src/ui/hyperdrive/hooks/useLiquidity";
 import { useLpApy } from "src/ui/hyperdrive/hooks/useLpApy";
@@ -16,6 +17,7 @@ export function MarketStats({
 }: {
   hyperdrive: HyperdriveConfig;
 }): ReactElement {
+  const isTailwindSmallScreen = useIsTailwindSmallScreen();
   const { data: currentBlockNumber } = useBlockNumber();
   const appConfig = useAppConfig();
   const baseToken = findBaseToken({
@@ -49,7 +51,7 @@ export function MarketStats({
           )
         }
         description={`The yield source backing the hy${baseToken.symbol} in this pool.`}
-        tooltipPosition="right"
+        tooltipPosition={"right"}
       />
       <Stat
         label="Fixed APR"
@@ -76,6 +78,7 @@ export function MarketStats({
           )
         }
         description={`The LP's annual return projection assuming the past 7-day performance rate continues for a year.`}
+        tooltipPosition={isTailwindSmallScreen ? "right" : "bottom"}
       />
       <Stat
         description={`The amount of hy${
@@ -91,6 +94,7 @@ export function MarketStats({
           decimals: baseToken.decimals,
           places: 0,
         })} hy${baseToken.symbol}`}
+        tooltipPosition={isTailwindSmallScreen ? "left" : "bottom"}
         label="Volume (24h)"
         value={
           tradingVolumeStatus === "loading" && totalVolume === undefined ? (
@@ -123,7 +127,7 @@ export function MarketStats({
             />
           )
         }
-        tooltipPosition="left"
+        tooltipPosition={isTailwindSmallScreen ? "right" : "left"}
       />
     </div>
   );

--- a/apps/hyperdrive-trading/src/ui/markets/ShortsTab/ShortsTab.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/ShortsTab/ShortsTab.tsx
@@ -24,7 +24,7 @@ export function ShortsTab({
     <MarketDetailsTab
       positions={
         <div className="flex flex-col">
-          <div className="flex items-center justify-between p-8">
+          <div className="flex flex-wrap items-center justify-between gap-4 p-8">
             <h5 className="font-medium">Short Positions</h5>
             <div className="flex items-center gap-4">
               {account && openShorts?.length ? (


### PR DESCRIPTION
Two things are throwing off the mobile layout. First, there isn't enough room for the feature flag picker on mobile. Since we don't currently have feature flags and it will still be available on desktop, I've removed it on mobile. Second, the tooltips in market stats, while not visible, are still causing a layout issue. I've updated the tooltip positions on mobile so there's no longer a horizontal scroll.

Before:

https://github.com/delvtech/hyperdrive-frontend/assets/22210106/73865d35-4a74-4928-8acd-9b0b9a035e94

After:

https://github.com/delvtech/hyperdrive-frontend/assets/22210106/2177758f-84e0-4774-a02b-0173ab0e0b1d

