### PR TITLE
Use LP Shares in LP tab

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
@@ -105,11 +105,8 @@ export function AddLiquidityForm({
     enabled: hasEnoughAllowance && hasEnoughBalance,
   };
 
-  const {
-    lpSharesOut,
-    status: addLiquidityPreviewStatus,
-    slippagePaid,
-  } = usePreviewAddLiquidity(addLiquidityParams);
+  const { lpSharesOut, status: addLiquidityPreviewStatus } =
+    usePreviewAddLiquidity(addLiquidityParams);
 
   const { lpSharesTotalSupply } = useLpSharesTotalSupply({
     hyperdriveAddress: hyperdrive.address,
@@ -167,10 +164,10 @@ export function AddLiquidityForm({
       transactionPreview={
         <AddLiquidityPreview
           hyperdrive={hyperdrive}
+          lpSharesOut={lpSharesOut}
           depositAmount={depositAmountAsBigInt}
           depositTokenDecimals={activeToken.decimals}
           depositTokenSymbol={activeToken.symbol}
-          slippagePaid={slippagePaid}
           poolShareAfterDeposit={poolShareAfterDeposit}
         />
       }

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityPreview/AddLiquidityPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityPreview/AddLiquidityPreview.tsx
@@ -65,26 +65,6 @@ export function AddLiquidityPreview({
           </p>
         }
       />
-      {/* <LabelValue
-        label="Slippage paid"
-        value={
-          <span
-            className={classNames(
-              "daisy-tooltip daisy-tooltip-top daisy-tooltip-left cursor-help before:border",
-              { "border-b border-dashed border-current": slippagePaid },
-            )}
-            data-tip="Additional amount you pay to maintain the lp share price of the pool when adding liquidity"
-          >
-            {slippagePaid
-              ? `${formatBalance({
-                  balance: slippagePaid,
-                  decimals: depositTokenDecimals,
-                  places: 4,
-                })} ${depositTokenSymbol}`
-              : "-"}
-          </span>
-        }
-      /> */}
       <LabelValue
         label="You receive"
         value={

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityPreview/AddLiquidityPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityPreview/AddLiquidityPreview.tsx
@@ -1,15 +1,16 @@
-import { HyperdriveConfig } from "@hyperdrive/appconfig";
+import { HyperdriveConfig, findBaseToken } from "@hyperdrive/appconfig";
 import classNames from "classnames";
 import * as dnum from "dnum";
 import { ReactElement } from "react";
+import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { LabelValue } from "src/ui/base/components/LabelValue";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 
 interface AddLiquidityPreviewProps {
   hyperdrive: HyperdriveConfig;
-  slippagePaid: bigint | undefined;
   poolShareAfterDeposit: bigint | undefined;
   depositAmount: bigint | undefined;
+  lpSharesOut: bigint | undefined;
   depositTokenDecimals: number;
   depositTokenSymbol: string;
 }
@@ -20,44 +21,15 @@ export function AddLiquidityPreview({
   depositAmount,
   depositTokenSymbol,
   depositTokenDecimals,
-  slippagePaid,
+  lpSharesOut,
 }: AddLiquidityPreviewProps): ReactElement {
+  const appConfig = useAppConfig();
+  const baseToken = findBaseToken({
+    baseTokenAddress: hyperdrive.baseToken,
+    tokens: appConfig.tokens,
+  });
   return (
     <div className="flex flex-col gap-3">
-      <LabelValue
-        label="You deposit"
-        value={
-          <p className="font-bold">
-            {depositAmount
-              ? `${formatBalance({
-                  balance: depositAmount,
-                  decimals: depositTokenDecimals,
-                  places: 4,
-                })} ${depositTokenSymbol}`
-              : "-"}
-          </p>
-        }
-      />
-      <LabelValue
-        label="Slippage paid"
-        value={
-          <span
-            className={classNames(
-              "daisy-tooltip daisy-tooltip-top daisy-tooltip-left cursor-help before:border",
-              { "border-b border-dashed border-current": slippagePaid },
-            )}
-            data-tip="Additional amount you pay to maintain the lp share price of the pool when adding liquidity"
-          >
-            {slippagePaid
-              ? `${formatBalance({
-                  balance: slippagePaid,
-                  decimals: depositTokenDecimals,
-                  places: 4,
-                })} ${depositTokenSymbol}`
-              : "-"}
-          </span>
-        }
-      />
       <LabelValue
         label="Your pool share"
         value={
@@ -77,6 +49,54 @@ export function AddLiquidityPreview({
                 )}%`
               : "-"}
           </span>
+        }
+      />
+      <LabelValue
+        label="You deposit"
+        value={
+          <p>
+            {depositAmount
+              ? `${formatBalance({
+                  balance: depositAmount,
+                  decimals: depositTokenDecimals,
+                  places: 4,
+                })} ${depositTokenSymbol}`
+              : "-"}
+          </p>
+        }
+      />
+      {/* <LabelValue
+        label="Slippage paid"
+        value={
+          <span
+            className={classNames(
+              "daisy-tooltip daisy-tooltip-top daisy-tooltip-left cursor-help before:border",
+              { "border-b border-dashed border-current": slippagePaid },
+            )}
+            data-tip="Additional amount you pay to maintain the lp share price of the pool when adding liquidity"
+          >
+            {slippagePaid
+              ? `${formatBalance({
+                  balance: slippagePaid,
+                  decimals: depositTokenDecimals,
+                  places: 4,
+                })} ${depositTokenSymbol}`
+              : "-"}
+          </span>
+        }
+      /> */}
+      <LabelValue
+        label="You receive"
+        value={
+          <p className="font-bold">
+            {lpSharesOut
+              ? `${formatBalance({
+                  balance: lpSharesOut,
+                  decimals: hyperdrive.decimals,
+                  places: 4,
+                })} ${baseToken.symbol}-LP`
+              : "-"}
+          </p>
         }
       />
     </div>

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/OpenLpSharesCard/OpenLpSharesCard.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/OpenLpSharesCard/OpenLpSharesCard.tsx
@@ -76,7 +76,7 @@ export function OpenLpSharesCard({
           <>
             <span className="daisy-card-title font-bold">Your Liquidity</span>
             <LabelValue
-              label="Pool share"
+              label="Pool Share"
               value={
                 <p
                   className="daisy-tooltip inline-flex cursor-help items-center gap-1 border-b border-dashed border-current before:border"
@@ -91,20 +91,23 @@ export function OpenLpSharesCard({
               }
             />
             <LabelValue
-              label="Value deposited"
+              label="LP Shares"
               value={
                 <p>
-                  {formatBalance({
-                    balance: baseAmountPaid,
-                    decimals: baseToken.decimals,
-                    places: 4,
-                  })}{" "}
-                  {baseToken.symbol}
+                  {lpShares !== undefined ? (
+                    `${formatBalance({
+                      balance: lpShares || 0n,
+                      decimals: hyperdrive.decimals,
+                      places: 4,
+                    })} ${baseToken.symbol}-LP`
+                  ) : (
+                    <Skeleton />
+                  )}
                 </p>
               }
             />
             <LabelValue
-              label="Current value"
+              label="Current Value"
               value={
                 <p>
                   {!!poolInfo && !!lpShares ? (
@@ -146,7 +149,7 @@ export function OpenLpSharesCard({
                     className="daisy-tooltip mb-1 inline-flex cursor-help items-center border-b border-dashed border-current text-neutral-content before:border"
                     data-tip="Your ratio of idle capital to capital being used to back Longs and Shorts."
                   >
-                    Utilization ratio
+                    Utilization Ratio
                   </p>
                   <p>
                     {!!utilizationRatio

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
@@ -169,7 +169,7 @@ export function RemoveLiquidityForm({
       transactionPreview={
         <>
           <LabelValue
-            label="You remove"
+            label="Amount to withdraw"
             value={`${
               actualValueOut
                 ? `${formatBalance({

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
@@ -181,7 +181,7 @@ export function RemoveLiquidityForm({
             } ${baseToken.symbol}-LP`}
           />
           <LabelValue
-            label="Total you receive"
+            label="Total you receive now"
             value={
               <span className="font-bold">
                 {actualValueOut

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/usePreviewAddLiquidity.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/usePreviewAddLiquidity.ts
@@ -19,7 +19,6 @@ interface UsePreviewAddLiquidityOptions {
 interface UsePreviewAddLiquidityResult {
   status: "error" | "idle" | "loading" | "success";
   lpSharesOut: bigint | undefined;
-  slippagePaid: bigint | undefined;
 }
 
 export function usePreviewAddLiquidity({
@@ -87,6 +86,5 @@ export function usePreviewAddLiquidity({
   return {
     status,
     lpSharesOut: data?.lpSharesOut,
-    slippagePaid: data?.slippagePaid,
   };
 }

--- a/apps/hyperdrive-trading/src/ui/markets/MarketDetailsBody/MarketDetailsBody.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketDetailsBody/MarketDetailsBody.tsx
@@ -9,6 +9,7 @@ import { MarketHeader } from "src/ui/markets/MarketDetailsBody/MarketHeader";
 import { MarketStats } from "src/ui/markets/MarketStats/MarketStats";
 import { TransactionAndFaqTabs } from "src/ui/markets/TransactionsAndFaqTabs/TransactionsAndFaqTabs";
 import { YourBalanceWell } from "src/ui/markets/YourBalanceWell/YourBalanceWell";
+import { useAccount } from "wagmi";
 
 interface PositionsTableProps {
   hyperdrive: HyperdriveConfig;
@@ -17,6 +18,7 @@ export function MarketDetailsBody({
   hyperdrive,
 }: PositionsTableProps): ReactElement {
   const { marketState } = useMarketState(hyperdrive.address);
+  const { address: account } = useAccount();
   const isTailwindSmallScreen = useIsTailwindSmallScreen();
   return (
     <div className="flex flex-col gap-12 xl:w-[1200px]">
@@ -25,7 +27,7 @@ export function MarketDetailsBody({
           <MarketBreadcrumbs />
           <MarketHeader hyperdrive={hyperdrive} />
         </div>
-        {isTailwindSmallScreen ? undefined : (
+        {isTailwindSmallScreen || !account ? undefined : (
           <YourBalanceWell hyperdrive={hyperdrive} />
         )}
       </div>


### PR DESCRIPTION
- [x] LP Card now shows your balance of LP Shares
- [x] Input LP Shares when removing liquidity, instead of typing in the desired base/shares out 
- [x] Remove positive/negative slippage from tx previews
https://github.com/delvtech/hyperdrive-frontend/assets/4524175/916e8bf3-021e-463d-a35d-8d03bc6df9c6

Closes #875 
