### PR TITLE
Update package.jsons, fix artifacts release

### DIFF
--- a/.changeset/new-lizards-tie.md
+++ b/.changeset/new-lizards-tie.md
@@ -1,0 +1,7 @@
+---
+"@delvtech/hyperdrive-artifacts": patch
+"@delvtech/hyperdrive-js-core": patch
+"@delvtech/hyperdrive-viem": patch
+---
+
+Update license field in packages.json and add publishConfig to artifacts package.json

--- a/apps/hyperdrive-trading/package.json
+++ b/apps/hyperdrive-trading/package.json
@@ -3,7 +3,7 @@
   "description": "Trading interface for the hyperdrive protocol.",
   "version": "0.0.1",
   "private": true,
-  "license": "MIT",
+  "license": "AGPL-3.0",
   "author": {
     "name": "Element Labs",
     "email": "contact@element.fi",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "main": ".eslintrc",
   "type": "module",
-  "license": "MIT",
+  "license": "AGPL-3.0",
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.5.0",
     "@typescript-eslint/parser": "^7.5.0",

--- a/packages/hyperdrive-appconfig/package.json
+++ b/packages/hyperdrive-appconfig/package.json
@@ -2,7 +2,7 @@
   "name": "@hyperdrive/appconfig",
   "version": "0.0.0",
   "private": true,
-  "license": "MIT",
+  "license": "AGPL-3.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hyperdrive-artifacts/package.json
+++ b/packages/hyperdrive-artifacts/package.json
@@ -26,5 +26,8 @@
     "@hyperdrive/tsconfig": "*",
     "tsc": "^2.0.4",
     "typescript": "^5.3.3"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/hyperdrive-artifacts/package.json
+++ b/packages/hyperdrive-artifacts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@delvtech/hyperdrive-artifacts",
   "version": "0.0.1",
-  "license": "MIT",
+  "license": "AGPL-3.0",
   "type": "module",
   "files": [
     "dist"

--- a/packages/hyperdrive-js-core/package.json
+++ b/packages/hyperdrive-js-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@delvtech/hyperdrive-js-core",
   "version": "0.0.1",
-  "license": "MIT",
+  "license": "AGPL-3.0",
   "type": "module",
   "scripts": {
     "build": "tsup src/index.ts --minify --format esm --clean --dts",

--- a/packages/hyperdrive-viem/package.json
+++ b/packages/hyperdrive-viem/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@delvtech/hyperdrive-viem",
   "version": "0.0.1",
-  "license": "MIT",
+  "license": "AGPL-3.0",
   "type": "module",
   "scripts": {
     "build": "tsup src/index.ts --minify --format esm --clean --dts",

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "main": ".prettierrc.js",
-  "license": "MIT",
+  "license": "AGPL-3.0",
   "type": "module",
   "dependencies": {
     "prettier": "3.2.5"

--- a/packages/spark/package.json
+++ b/packages/spark/package.json
@@ -2,7 +2,7 @@
   "name": "@hyperdrive/spark",
   "version": "0.0.0",
   "private": true,
-  "license": "MIT",
+  "license": "AGPL-3.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Updates the licenses to match the repo and adds the missing `publishConfig` field to the `package.json` for `@delvtech/hyperdrive-artifacts` to fix the release workflow.