### PR TITLE
Ignore capsule if not configured

### DIFF
--- a/apps/hyperdrive-trading/src/network/wagmiClient.ts
+++ b/apps/hyperdrive-trading/src/network/wagmiClient.ts
@@ -48,7 +48,9 @@ if (
 if (VITE_SEPOLIA_RPC_URL) {
   chains.push(sepolia);
   transports[sepolia.id] = http(VITE_SEPOLIA_RPC_URL);
-  customWallets.push(capsuleWallet);
+  if (capsuleWallet) {
+    customWallets.push(capsuleWallet);
+  }
 }
 
 export const wagmiConfig = getDefaultConfig({

--- a/apps/hyperdrive-trading/src/wallets/capsule.ts
+++ b/apps/hyperdrive-trading/src/wallets/capsule.ts
@@ -7,6 +7,8 @@ import {
 
 const { VITE_CAPSULE_API_KEY, VITE_CAPSULE_ENV } = import.meta.env;
 
+const hasRequiredEnvVars = !!VITE_CAPSULE_API_KEY && !!VITE_CAPSULE_ENV;
+
 export const getCapsuleWalletOpts: GetCapsuleOpts = {
   capsule: {
     environment: VITE_CAPSULE_ENV, // Environment.PROD for Production
@@ -41,4 +43,6 @@ export const getCapsuleWalletOpts: GetCapsuleOpts = {
     OAuthMethod.APPLE,
   ],
 };
-export const capsuleWallet = getCapsuleWallet(getCapsuleWalletOpts);
+export const capsuleWallet = hasRequiredEnvVars
+  ? getCapsuleWallet(getCapsuleWalletOpts)
+  : undefined;


### PR DESCRIPTION
The app was crashing when I had Sepoila configured, but didn't include the capsule env vars.