### PR TITLE
Remove ETH Deposits for Lido

### DIFF
--- a/apps/hyperdrive-trading/src/network/constants.ts
+++ b/apps/hyperdrive-trading/src/network/constants.ts
@@ -1,0 +1,1 @@
+export const isSepoliaChain = process.env.VITE_SEPOLIA_RPC_URL;

--- a/apps/hyperdrive-trading/src/network/constants.ts
+++ b/apps/hyperdrive-trading/src/network/constants.ts
@@ -1,1 +1,0 @@
-export const isSepoliaChain = process.env.VITE_SEPOLIA_RPC_URL;

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
@@ -6,6 +6,7 @@ import {
 } from "@hyperdrive/appconfig";
 import { MouseEvent, ReactElement } from "react";
 import { getIsValidTradeSize } from "src/hyperdrive/getIsValidTradeSize";
+import { isSepoliaChain } from "src/network/constants";
 import { getHasEnoughAllowance } from "src/token/getHasEnoughAllowance";
 import { getHasEnoughBalance } from "src/token/getHasEnoughBalance";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
@@ -50,8 +51,12 @@ export function OpenLongForm({
   const { activeToken, activeTokenBalance, setActiveToken, isActiveTokenEth } =
     useActiveToken({
       account,
-      defaultActiveToken: baseToken.address,
-      tokens: [baseToken, sharesToken],
+      // TODO: Remove check for Sepolia chain after testnet period.
+      defaultActiveToken: isSepoliaChain
+        ? sharesToken.address
+        : baseToken.address,
+      // TODO: Remove check for Sepolia chain after testnet period.
+      tokens: isSepoliaChain ? [sharesToken] : [baseToken, sharesToken],
     });
 
   // All tokens besides ETH require an allowance to spend it on hyperdrive
@@ -148,7 +153,8 @@ export function OpenLongForm({
           name={activeToken.symbol}
           token={
             <TokenPicker
-              tokens={[baseToken, sharesToken]}
+              // TODO: Remove check for Sepolia chain after testnet period.
+              tokens={isSepoliaChain ? [sharesToken] : [baseToken, sharesToken]}
               activeTokenAddress={activeToken.address}
               onChange={(tokenAddress) => {
                 setActiveToken(tokenAddress);

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
@@ -6,7 +6,6 @@ import {
 } from "@hyperdrive/appconfig";
 import { MouseEvent, ReactElement } from "react";
 import { getIsValidTradeSize } from "src/hyperdrive/getIsValidTradeSize";
-import { isSepoliaChain } from "src/network/constants";
 import { getHasEnoughAllowance } from "src/token/getHasEnoughAllowance";
 import { getHasEnoughBalance } from "src/token/getHasEnoughBalance";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
@@ -47,16 +46,18 @@ export function OpenLongForm({
     yieldSourceTokenAddress: hyperdrive.sharesToken,
     tokens: appConfig.tokens,
   });
+  const isLidoSepolia =
+    process.env.VITE_SEPOLIA_RPC_URL && baseToken.symbol === "ETH";
 
   const { activeToken, activeTokenBalance, setActiveToken, isActiveTokenEth } =
     useActiveToken({
       account,
       // TODO: Remove check for Sepolia chain after testnet period.
-      defaultActiveToken: isSepoliaChain
+      defaultActiveToken: isLidoSepolia
         ? sharesToken.address
         : baseToken.address,
       // TODO: Remove check for Sepolia chain after testnet period.
-      tokens: isSepoliaChain ? [sharesToken] : [baseToken, sharesToken],
+      tokens: isLidoSepolia ? [sharesToken] : [baseToken, sharesToken],
     });
 
   // All tokens besides ETH require an allowance to spend it on hyperdrive
@@ -154,7 +155,7 @@ export function OpenLongForm({
           token={
             <TokenPicker
               // TODO: Remove check for Sepolia chain after testnet period.
-              tokens={isSepoliaChain ? [sharesToken] : [baseToken, sharesToken]}
+              tokens={isLidoSepolia ? [sharesToken] : [baseToken, sharesToken]}
               activeTokenAddress={activeToken.address}
               onChange={(tokenAddress) => {
                 setActiveToken(tokenAddress);

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
@@ -48,6 +48,8 @@ export function AddLiquidityForm({
     yieldSourceTokenAddress: hyperdrive.sharesToken,
     tokens: appConfig.tokens,
   });
+  const isLidoSepolia =
+    process.env.VITE_SEPOLIA_RPC_URL && baseToken.symbol === "ETH";
 
   const { lpShares: lpSharesBalanceOf } = useLpShares({
     account,
@@ -57,8 +59,12 @@ export function AddLiquidityForm({
   const { activeToken, activeTokenBalance, setActiveToken, isActiveTokenEth } =
     useActiveToken({
       account,
-      defaultActiveToken: baseToken.address,
-      tokens: [baseToken, sharesToken],
+      // TODO: Remove check for Sepolia chain after testnet period.
+      defaultActiveToken: isLidoSepolia
+        ? sharesToken.address
+        : baseToken.address,
+      // TODO: Remove check for Sepolia chain after testnet period.
+      tokens: isLidoSepolia ? [sharesToken] : [baseToken, sharesToken],
     });
 
   const {
@@ -138,7 +144,8 @@ export function AddLiquidityForm({
           name={activeToken.symbol}
           token={
             <TokenPicker
-              tokens={[baseToken, sharesToken]}
+              // TODO: Remove check for Sepolia chain after testnet period.
+              tokens={isLidoSepolia ? [sharesToken] : [baseToken, sharesToken]}
               activeTokenAddress={activeToken.address}
               onChange={(tokenAddress) => {
                 setActiveToken(tokenAddress);

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
@@ -43,6 +43,8 @@ export function RemoveLiquidityForm({
     yieldSourceTokenAddress: hyperdrive.sharesToken,
     tokens: appConfig.tokens,
   });
+  const isLidoSepolia =
+    process.env.VITE_SEPOLIA_RPC_URL && baseToken.symbol === "ETH";
 
   const tokens: TokenConfig<any>[] = [sharesToken];
   if (hyperdrive.withdrawOptions.isBaseTokenWithdrawalEnabled) {
@@ -127,16 +129,28 @@ export function RemoveLiquidityForm({
     <TransactionView
       setting={
         <TokenChoices
-          label="Choose asset for withdrawal"
+          label={
+            isLidoSepolia
+              ? "Asset for withdrawal"
+              : "Choose asset for withdrawal"
+          }
           vertical
-          tokens={[
-            {
-              tokenConfig: baseToken,
-            },
-            {
-              tokenConfig: sharesToken,
-            },
-          ]}
+          tokens={
+            isLidoSepolia
+              ? [
+                  {
+                    tokenConfig: sharesToken,
+                  },
+                ]
+              : [
+                  {
+                    tokenConfig: baseToken,
+                  },
+                  {
+                    tokenConfig: sharesToken,
+                  },
+                ]
+          }
           selectedTokenAddress={activeWithdrawToken.address}
           onTokenChange={(tokenAddress) => setActiveWithdrawToken(tokenAddress)}
         />

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
@@ -50,12 +50,19 @@ export function OpenShortForm({
     yieldSourceTokenAddress: hyperdrive.sharesToken,
     tokens: appConfig.tokens,
   });
+  // TODO: Remove check for Sepolia chain after testnet period.
+  const isLidoSepolia =
+    process.env.VITE_SEPOLIA_RPC_URL && baseToken.symbol === "ETH";
 
   const { activeToken, activeTokenBalance, setActiveToken, isActiveTokenEth } =
     useActiveToken({
       account,
-      defaultActiveToken: baseToken.address,
-      tokens: [baseToken, sharesToken],
+      // TODO: Remove check for Sepolia chain after testnet period.
+      defaultActiveToken: isLidoSepolia
+        ? sharesToken.address
+        : baseToken.address,
+      // TODO: Remove check for Sepolia chain after testnet period.
+      tokens: isLidoSepolia ? [sharesToken] : [baseToken, sharesToken],
     });
 
   const { balance: baseTokenBalance } = useTokenBalance({
@@ -165,18 +172,30 @@ export function OpenShortForm({
       }
       setting={
         <TokenChoices
-          label="Choose asset for short deposit"
+          label={
+            isLidoSepolia ? "Asset for deposit" : "Choose asset for depost"
+          }
           vertical
-          tokens={[
-            {
-              tokenConfig: baseToken,
-              tokenBalance: baseTokenBalance?.value,
-            },
-            {
-              tokenConfig: sharesToken,
-              tokenBalance: sharesTokenBalance?.value,
-            },
-          ]}
+          tokens={
+            // TODO: Remove check for Sepolia chain after testnet period.
+            isLidoSepolia
+              ? [
+                  {
+                    tokenConfig: sharesToken,
+                    tokenBalance: sharesTokenBalance?.value,
+                  },
+                ]
+              : [
+                  {
+                    tokenConfig: baseToken,
+                    tokenBalance: baseTokenBalance?.value,
+                  },
+                  {
+                    tokenConfig: sharesToken,
+                    tokenBalance: sharesTokenBalance?.value,
+                  },
+                ]
+          }
           selectedTokenAddress={activeToken.address}
           onTokenChange={(tokenAddress) => setActiveToken(tokenAddress)}
         />

--- a/apps/hyperdrive-trading/src/ui/token/hooks/useActiveToken.ts
+++ b/apps/hyperdrive-trading/src/ui/token/hooks/useActiveToken.ts
@@ -10,7 +10,7 @@ export function useActiveToken<T1, T2>({
   defaultActiveToken,
 }: {
   account: Address | undefined;
-  tokens: [TokenConfig<T1>, TokenConfig<T2>];
+  tokens: [TokenConfig<T1>, TokenConfig<T2>] | [TokenConfig<any>]; // Remove TokenConfig<any> to after Sepolia. Temporary fix to avoid users losing their testnet ETH to Lido.
   defaultActiveToken: Address;
 }): {
   activeToken: TokenConfig<T1 | T2>;


### PR DESCRIPTION
This PR removes the option to deposit ETH in the Lido market. We don't want users losing their Sepolia ETH because they can't withdraw to native ETH in Sepolia Lido market. TODO's are commented where this logic will need to be removed for mainnet.
Closes #924 


https://github.com/delvtech/hyperdrive-frontend/assets/22210106/ab35c39d-e0c6-49be-9479-8e319de11cbd


