### PR TITLE
fixes negative value on lp apy

### DIFF
--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/MarketStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/MarketStats.tsx
@@ -71,7 +71,9 @@ export function MarketStats({
         value={
           lpApyStatus !== "loading" ? (
             <span className="flex items-center gap-1.5">
-              {lpApy === undefined ? "no data" : `${(lpApy * 100).toFixed(2)}%`}
+              {lpApy === undefined
+                ? "no data"
+                : `${(lpApy * 100).toFixed(2) === "-0.00" ? "0.00" : (lpApy * 100).toFixed(2)}%`}{" "}
             </span>
           ) : (
             <Skeleton className="w-20" />


### PR DESCRIPTION
There might be a better way to handle this but we use the same snippet to solve this negative 0 problem on pnl values too:
https://github.com/delvtech/hyperdrive-frontend/pull/860/files
fixes #926 
