### PR TITLE
Add slippage menu for open longs

### DIFF
--- a/apps/hyperdrive-trading/src/ui/base/components/PercentInput.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/PercentInput.tsx
@@ -1,0 +1,29 @@
+import classNames from "classnames";
+import { ChangeEvent } from "react";
+import { HIDE_NUMERIC_INPUT_ARROWS_CLASS } from "src/ui/base/numericInput";
+
+export function PercentInput({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+}): JSX.Element {
+  return (
+    <div className="relative">
+      <input
+        min={0}
+        placeholder="0.5"
+        step="any"
+        type="number"
+        value={value}
+        onChange={(e) => onChange(e)}
+        className={classNames(
+          "daisy-input daisy-input-bordered h-8 max-w-24 text-sm",
+          HIDE_NUMERIC_INPUT_ARROWS_CLASS,
+        )}
+      />
+      <span className="absolute right-2 top-2 text-neutral-content">%</span>
+    </div>
+  );
+}

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
@@ -4,6 +4,7 @@ import {
   findYieldSourceToken,
   HyperdriveConfig,
 } from "@hyperdrive/appconfig";
+import * as dnum from "dnum";
 import { MouseEvent, ReactElement } from "react";
 import { getIsValidTradeSize } from "src/hyperdrive/getIsValidTradeSize";
 import { getHasEnoughAllowance } from "src/token/getHasEnoughAllowance";
@@ -220,13 +221,20 @@ export function OpenLongForm({
           maxValue={maxButtonValue}
           inputLabel="Amount to spend"
           stat={
-            activeTokenBalance
-              ? `Balance: ${formatBalance({
-                  balance: activeTokenBalance?.value,
-                  decimals: activeToken.decimals,
-                  places: 4,
-                })} ${activeToken.symbol}`
-              : undefined
+            <div className="flex flex-col gap-1 text-xs text-neutral-content">
+              <span>
+                {activeTokenBalance
+                  ? `Balance: ${formatBalance({
+                      balance: activeTokenBalance?.value,
+                      decimals: activeToken.decimals,
+                      places: 4,
+                    })} ${activeToken.symbol}`
+                  : undefined}
+              </span>
+              <span>
+                {`Slippage: ${dnum.format([slippage, activeToken.decimals])}%`}
+              </span>
+            </div>
           }
           onChange={(newAmount) => setAmount(newAmount)}
         />

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
@@ -21,6 +21,7 @@ import { OpenLongPreview } from "src/ui/hyperdrive/longs/OpenLongPreview/OpenLon
 import { TransactionView } from "src/ui/hyperdrive/TransactionView";
 import { ApproveTokenChoices } from "src/ui/token/ApproveTokenChoices";
 import { useActiveToken } from "src/ui/token/hooks/useActiveToken";
+import { useSlippageSettings } from "src/ui/token/hooks/useSlippageSettings";
 import { useTokenAllowance } from "src/ui/token/hooks/useTokenAllowance";
 import { useTokenBalance } from "src/ui/token/hooks/useTokenBalance";
 import { SlippageSettings } from "src/ui/token/SlippageSettings";
@@ -124,11 +125,20 @@ export function OpenLongForm({
     asBase: activeToken.address === baseToken.address,
   });
 
+  const {
+    setSlippage,
+    slippage,
+    activeTab: activeSlippageTab,
+    setActiveTab: setActiveSlippageTab,
+  } = useSlippageSettings({
+    decimals: activeToken.decimals,
+  });
+
   const bondsReceivedAfterSlippage =
     bondsReceived &&
     adjustAmountByPercentage({
       amount: bondsReceived,
-      percentage: 1n,
+      percentage: slippage,
       decimals: activeToken.decimals,
       direction: "down",
     });
@@ -166,7 +176,15 @@ export function OpenLongForm({
     <TransactionView
       tokenInput={
         <TokenInput
-          settings={<SlippageSettings />}
+          settings={
+            <SlippageSettings
+              setSlippage={setSlippage}
+              slippage={slippage}
+              activeToken={activeToken}
+              activeTab={activeSlippageTab}
+              setActiveTab={setActiveSlippageTab}
+            />
+          }
           name={activeToken.symbol}
           token={
             <TokenPicker

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
@@ -131,9 +131,7 @@ export function OpenLongForm({
     slippage,
     activeTab: activeSlippageTab,
     setActiveTab: setActiveSlippageTab,
-  } = useSlippageSettings({
-    decimals: activeToken.decimals,
-  });
+  } = useSlippageSettings();
 
   const bondsReceivedAfterSlippage =
     bondsReceived &&
@@ -179,7 +177,7 @@ export function OpenLongForm({
         <TokenInput
           settings={
             <SlippageSettings
-              setSlippage={setSlippage}
+              onSlippageChange={setSlippage}
               slippage={slippage}
               decimals={activeToken.decimals}
               activeOption={activeSlippageTab}

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
@@ -23,6 +23,7 @@ import { ApproveTokenChoices } from "src/ui/token/ApproveTokenChoices";
 import { useActiveToken } from "src/ui/token/hooks/useActiveToken";
 import { useTokenAllowance } from "src/ui/token/hooks/useTokenAllowance";
 import { useTokenBalance } from "src/ui/token/hooks/useTokenBalance";
+import { SlippageSettings } from "src/ui/token/SlippageSettings";
 import { TokenInput } from "src/ui/token/TokenInput";
 import { TokenPicker } from "src/ui/token/TokenPicker";
 import { formatUnits } from "viem";
@@ -165,7 +166,7 @@ export function OpenLongForm({
     <TransactionView
       tokenInput={
         <TokenInput
-          settings
+          settings={<SlippageSettings />}
           name={activeToken.symbol}
           token={
             <TokenPicker

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
@@ -1,4 +1,4 @@
-import { adjustAmountByPercentage } from "@delvtech/hyperdrive-viem";
+import { adjustAmountByPercentage } from "@delvtech/hyperdrive-js-core";
 import {
   findBaseToken,
   findYieldSourceToken,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
@@ -165,6 +165,7 @@ export function OpenLongForm({
     <TransactionView
       tokenInput={
         <TokenInput
+          settings
           name={activeToken.symbol}
           token={
             <TokenPicker

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
@@ -181,9 +181,9 @@ export function OpenLongForm({
             <SlippageSettings
               setSlippage={setSlippage}
               slippage={slippage}
-              activeToken={activeToken}
-              activeTab={activeSlippageTab}
-              setActiveTab={setActiveSlippageTab}
+              decimals={activeToken.decimals}
+              activeOption={activeSlippageTab}
+              onActiveOptionChange={setActiveSlippageTab}
             />
           }
           name={activeToken.symbol}

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
@@ -4,6 +4,8 @@ import {
   findYieldSourceToken,
   HyperdriveConfig,
 } from "@hyperdrive/appconfig";
+
+import * as dnum from "dnum";
 import { MouseEvent, ReactElement } from "react";
 import { getIsValidTradeSize } from "src/hyperdrive/getIsValidTradeSize";
 import { getHasEnoughAllowance } from "src/token/getHasEnoughAllowance";
@@ -34,6 +36,7 @@ interface OpenLongFormProps {
   hyperdrive: HyperdriveConfig;
   onOpenLong?: (e: MouseEvent<HTMLButtonElement>) => void;
 }
+
 export function OpenLongForm({
   hyperdrive: hyperdrive,
   onOpenLong,
@@ -130,7 +133,7 @@ export function OpenLongForm({
     slippage,
     activeTab: activeSlippageTab,
     setActiveTab: setActiveSlippageTab,
-  } = useSlippageSettings();
+  } = useSlippageSettings({ decimals: activeToken.decimals });
 
   const bondsReceivedAfterSlippage =
     bondsReceived &&
@@ -218,13 +221,20 @@ export function OpenLongForm({
           maxValue={maxButtonValue}
           inputLabel="Amount to spend"
           stat={
-            activeTokenBalance
-              ? `Balance: ${formatBalance({
-                  balance: activeTokenBalance?.value,
-                  decimals: activeToken.decimals,
-                  places: activeToken.places,
-                })} ${activeToken.symbol}`
-              : undefined
+            <div className="flex flex-col gap-1 text-xs text-neutral-content">
+              <span>
+                {activeTokenBalance
+                  ? `Balance: ${formatBalance({
+                      balance: activeTokenBalance?.value,
+                      decimals: activeToken.decimals,
+                      places: activeToken.places,
+                    })} ${activeToken.symbol}`
+                  : undefined}
+              </span>
+              <span>
+                {`Slippage: ${dnum.format([slippage, activeToken.decimals])}%`}
+              </span>
+            </div>
           }
           onChange={(newAmount) => setAmount(newAmount)}
         />

--- a/apps/hyperdrive-trading/src/ui/token/SlippageSettings.tsx
+++ b/apps/hyperdrive-trading/src/ui/token/SlippageSettings.tsx
@@ -2,15 +2,18 @@ import { InformationCircleIcon } from "@heroicons/react/24/outline";
 import classNames from "classnames";
 import * as dnum from "dnum";
 import { PercentInput } from "src/ui/base/components/PercentInput";
+
+export const AUTO_SLIPPAGE_AMOUNT = dnum.from("0.5", 18)[0];
+
 export function SlippageSettings({
   slippage,
-  setSlippage,
+  onSlippageChange,
   decimals,
-  activeOption: activeTab,
-  onActiveOptionChange: setActiveOption,
+  activeOption,
+  onActiveOptionChange,
 }: {
   slippage: bigint;
-  setSlippage: (slippage: bigint) => void;
+  onSlippageChange: (slippage: bigint) => void;
   decimals: number;
   activeOption: "auto" | "custom";
   onActiveOptionChange: (activeTab: "auto" | "custom") => void;
@@ -33,11 +36,11 @@ export function SlippageSettings({
           <button
             onClick={(e) => {
               e.preventDefault();
-              setActiveOption("auto");
-              setSlippage(dnum.from("0.5", decimals)[0]);
+              onActiveOptionChange("auto");
+              onSlippageChange(AUTO_SLIPPAGE_AMOUNT);
             }}
             className={classNames("daisy-tab text-sm", {
-              "font-bold": activeTab === "auto",
+              "font-bold": activeOption === "auto",
             })}
           >
             Auto
@@ -45,10 +48,10 @@ export function SlippageSettings({
           <button
             onClick={(e) => {
               e.preventDefault();
-              setActiveOption("custom");
+              onActiveOptionChange("custom");
             }}
             className={classNames("daisy-tab text-sm", {
-              "font-bold": activeTab === "custom",
+              "font-bold": activeOption === "custom",
             })}
           >
             Custom
@@ -57,8 +60,8 @@ export function SlippageSettings({
         <PercentInput
           value={dnum.format([slippage, decimals])}
           onChange={(e) => {
-            setActiveOption("custom");
-            setSlippage(dnum.from(e.target.value, decimals)[0]);
+            onActiveOptionChange("custom");
+            onSlippageChange(dnum.from(e.target.value, decimals)[0]);
           }}
         />
       </div>

--- a/apps/hyperdrive-trading/src/ui/token/SlippageSettings.tsx
+++ b/apps/hyperdrive-trading/src/ui/token/SlippageSettings.tsx
@@ -1,18 +1,43 @@
-export function SlippageSettings(): JSX.Element {
+import { TokenConfig } from "@hyperdrive/appconfig";
+import classNames from "classnames";
+import * as dnum from "dnum";
+export function SlippageSettings({
+  slippage,
+  setSlippage,
+  activeToken,
+  activeTab,
+  setActiveTab,
+}: {
+  slippage: bigint;
+  setSlippage: (slippage: bigint) => void;
+  activeToken: TokenConfig<any>;
+  activeTab: "auto" | "custom";
+  setActiveTab: (activeTab: "auto" | "custom") => void;
+}): JSX.Element {
   return (
     <>
       <span className="ml-1">Max. Slippage</span>
       <div className="flex flex-row items-center justify-between">
         <div className="daisy-tabs daisy-tabs-xs my-4">
           <button
-            onClick={(e) => e.preventDefault()}
-            className="daisy-tab text-sm"
+            onClick={(e) => {
+              e.preventDefault();
+              setActiveTab("auto");
+            }}
+            className={classNames("daisy-tab text-sm", {
+              "font-bold": activeTab === "auto",
+            })}
           >
             Auto
           </button>
           <button
-            onClick={(e) => e.preventDefault()}
-            className="daisy-tab text-sm"
+            onClick={(e) => {
+              e.preventDefault();
+              setActiveTab("custom");
+            }}
+            className={classNames("daisy-tab text-sm", {
+              "font-bold": activeTab === "custom",
+            })}
           >
             Custom
           </button>
@@ -21,6 +46,9 @@ export function SlippageSettings(): JSX.Element {
           <input
             min={0}
             placeholder="0.5"
+            onChange={(e) =>
+              setSlippage(dnum.from(e.target.value, activeToken.decimals)[0])
+            }
             className="daisy-input daisy-input-bordered h-8 max-w-24 text-sm"
           />
           <span className="absolute right-2 top-2 text-neutral-content">%</span>

--- a/apps/hyperdrive-trading/src/ui/token/SlippageSettings.tsx
+++ b/apps/hyperdrive-trading/src/ui/token/SlippageSettings.tsx
@@ -3,7 +3,8 @@ import classNames from "classnames";
 import * as dnum from "dnum";
 import { PercentInput } from "src/ui/base/components/PercentInput";
 
-export const AUTO_SLIPPAGE_AMOUNT = dnum.from("0.5", 18)[0];
+export const AUTO_SLIPPAGE_AMOUNT = (decimals: number): bigint =>
+  dnum.from("0.5", decimals)[0];
 
 export function SlippageSettings({
   slippage,
@@ -37,7 +38,7 @@ export function SlippageSettings({
             onClick={(e) => {
               e.preventDefault();
               onActiveOptionChange("auto");
-              onSlippageChange(AUTO_SLIPPAGE_AMOUNT);
+              onSlippageChange(AUTO_SLIPPAGE_AMOUNT(decimals));
             }}
             className={classNames("daisy-tab text-sm", {
               "font-bold": activeOption === "auto",

--- a/apps/hyperdrive-trading/src/ui/token/SlippageSettings.tsx
+++ b/apps/hyperdrive-trading/src/ui/token/SlippageSettings.tsx
@@ -1,20 +1,19 @@
 import { InformationCircleIcon } from "@heroicons/react/24/outline";
-import { TokenConfig } from "@hyperdrive/appconfig";
 import classNames from "classnames";
 import * as dnum from "dnum";
-import { HIDE_NUMERIC_INPUT_ARROWS_CLASS } from "src/ui/base/numericInput";
+import { PercentInput } from "src/ui/base/components/PercentInput";
 export function SlippageSettings({
   slippage,
   setSlippage,
-  activeToken,
-  activeTab,
-  setActiveTab,
+  decimals,
+  activeOption: activeTab,
+  onActiveOptionChange: setActiveOption,
 }: {
   slippage: bigint;
   setSlippage: (slippage: bigint) => void;
-  activeToken: TokenConfig<any>;
-  activeTab: "auto" | "custom";
-  setActiveTab: (activeTab: "auto" | "custom") => void;
+  decimals: number;
+  activeOption: "auto" | "custom";
+  onActiveOptionChange: (activeTab: "auto" | "custom") => void;
 }): JSX.Element {
   return (
     <>
@@ -34,8 +33,8 @@ export function SlippageSettings({
           <button
             onClick={(e) => {
               e.preventDefault();
-              setActiveTab("auto");
-              setSlippage(dnum.from("0.5", activeToken.decimals)[0]);
+              setActiveOption("auto");
+              setSlippage(dnum.from("0.5", decimals)[0]);
             }}
             className={classNames("daisy-tab text-sm", {
               "font-bold": activeTab === "auto",
@@ -46,7 +45,7 @@ export function SlippageSettings({
           <button
             onClick={(e) => {
               e.preventDefault();
-              setActiveTab("custom");
+              setActiveOption("custom");
             }}
             className={classNames("daisy-tab text-sm", {
               "font-bold": activeTab === "custom",
@@ -55,24 +54,13 @@ export function SlippageSettings({
             Custom
           </button>
         </div>
-        <div className="relative">
-          <input
-            min={0}
-            placeholder="0.5"
-            step="any"
-            type="number"
-            value={dnum.format([slippage, activeToken.decimals])}
-            onChange={(e) => {
-              setActiveTab("custom");
-              setSlippage(dnum.from(e.target.value, activeToken.decimals)[0]);
-            }}
-            className={classNames(
-              "daisy-input daisy-input-bordered h-8 max-w-24 text-sm",
-              HIDE_NUMERIC_INPUT_ARROWS_CLASS,
-            )}
-          />
-          <span className="absolute right-2 top-2 text-neutral-content">%</span>
-        </div>
+        <PercentInput
+          value={dnum.format([slippage, decimals])}
+          onChange={(e) => {
+            setActiveOption("custom");
+            setSlippage(dnum.from(e.target.value, decimals)[0]);
+          }}
+        />
       </div>
     </>
   );

--- a/apps/hyperdrive-trading/src/ui/token/SlippageSettings.tsx
+++ b/apps/hyperdrive-trading/src/ui/token/SlippageSettings.tsx
@@ -1,0 +1,31 @@
+export function SlippageSettings(): JSX.Element {
+  return (
+    <>
+      <span className="ml-1">Max. Slippage</span>
+      <div className="flex flex-row items-center justify-between">
+        <div className="daisy-tabs daisy-tabs-xs my-4">
+          <button
+            onClick={(e) => e.preventDefault()}
+            className="daisy-tab text-sm"
+          >
+            Auto
+          </button>
+          <button
+            onClick={(e) => e.preventDefault()}
+            className="daisy-tab text-sm"
+          >
+            Custom
+          </button>
+        </div>
+        <div className="relative">
+          <input
+            min={0}
+            placeholder="0.5"
+            className="daisy-input daisy-input-bordered h-8 max-w-24 text-sm"
+          />
+          <span className="absolute right-2 top-2 text-neutral-content">%</span>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/hyperdrive-trading/src/ui/token/SlippageSettings.tsx
+++ b/apps/hyperdrive-trading/src/ui/token/SlippageSettings.tsx
@@ -1,6 +1,7 @@
 import { TokenConfig } from "@hyperdrive/appconfig";
 import classNames from "classnames";
 import * as dnum from "dnum";
+import { HIDE_NUMERIC_INPUT_ARROWS_CLASS } from "src/ui/base/numericInput";
 export function SlippageSettings({
   slippage,
   setSlippage,
@@ -47,13 +48,17 @@ export function SlippageSettings({
           <input
             min={0}
             placeholder="0.5"
+            step="any"
             type="number"
             value={dnum.format([slippage, activeToken.decimals])}
             onChange={(e) => {
               setActiveTab("custom");
               setSlippage(dnum.from(e.target.value, activeToken.decimals)[0]);
             }}
-            className="daisy-input daisy-input-bordered h-8 max-w-24 text-sm"
+            className={classNames(
+              "daisy-input daisy-input-bordered h-8 max-w-24 text-sm",
+              HIDE_NUMERIC_INPUT_ARROWS_CLASS,
+            )}
           />
           <span className="absolute right-2 top-2 text-neutral-content">%</span>
         </div>

--- a/apps/hyperdrive-trading/src/ui/token/SlippageSettings.tsx
+++ b/apps/hyperdrive-trading/src/ui/token/SlippageSettings.tsx
@@ -23,6 +23,7 @@ export function SlippageSettings({
             onClick={(e) => {
               e.preventDefault();
               setActiveTab("auto");
+              setSlippage(dnum.from("0.5", activeToken.decimals)[0]);
             }}
             className={classNames("daisy-tab text-sm", {
               "font-bold": activeTab === "auto",
@@ -46,9 +47,12 @@ export function SlippageSettings({
           <input
             min={0}
             placeholder="0.5"
-            onChange={(e) =>
-              setSlippage(dnum.from(e.target.value, activeToken.decimals)[0])
-            }
+            type="number"
+            value={dnum.format([slippage, activeToken.decimals])}
+            onChange={(e) => {
+              setActiveTab("custom");
+              setSlippage(dnum.from(e.target.value, activeToken.decimals)[0]);
+            }}
             className="daisy-input daisy-input-bordered h-8 max-w-24 text-sm"
           />
           <span className="absolute right-2 top-2 text-neutral-content">%</span>

--- a/apps/hyperdrive-trading/src/ui/token/SlippageSettings.tsx
+++ b/apps/hyperdrive-trading/src/ui/token/SlippageSettings.tsx
@@ -26,7 +26,7 @@ export function SlippageSettings({
             "Your transaction will revert if the price changes unfavorably by more than this percentage."
           }
         >
-          <InformationCircleIcon className="size-4 text-neutral-content" />
+          <InformationCircleIcon className="size-4" />
         </div>
       </div>
       <div className="flex flex-row items-center justify-between">

--- a/apps/hyperdrive-trading/src/ui/token/SlippageSettings.tsx
+++ b/apps/hyperdrive-trading/src/ui/token/SlippageSettings.tsx
@@ -1,3 +1,4 @@
+import { InformationCircleIcon } from "@heroicons/react/24/outline";
 import { TokenConfig } from "@hyperdrive/appconfig";
 import classNames from "classnames";
 import * as dnum from "dnum";
@@ -17,7 +18,17 @@ export function SlippageSettings({
 }): JSX.Element {
   return (
     <>
-      <span className="ml-1">Max. Slippage</span>
+      <div className="flex items-center">
+        <span className="ml-1">Max. Slippage</span>
+        <div
+          className="daisy-tooltip ml-1 before:w-48 before:border before:text-xs"
+          data-tip={
+            "Your transaction will revert if the price changes unfavorably by more than this percentage."
+          }
+        >
+          <InformationCircleIcon className="size-4 text-neutral-content" />
+        </div>
+      </div>
       <div className="flex flex-row items-center justify-between">
         <div className="daisy-tabs daisy-tabs-xs my-4">
           <button

--- a/apps/hyperdrive-trading/src/ui/token/TokenInput.tsx
+++ b/apps/hyperdrive-trading/src/ui/token/TokenInput.tsx
@@ -122,8 +122,8 @@ export function TokenInput({
                 >
                   <Cog6ToothIcon className="h-4" />
                 </button>
-                <div className="daisy-menu daisy-dropdown-content absolute right-0 w-48 justify-evenly rounded-lg bg-base-100 p-2 shadow">
-                  <span>Hello</span>
+                <div className="daisy-menu daisy-dropdown-content absolute right-0 z-[1] w-64 justify-evenly rounded-lg bg-base-100 p-4 shadow">
+                  {settings}
                 </div>
               </div>
             ) : null}

--- a/apps/hyperdrive-trading/src/ui/token/TokenInput.tsx
+++ b/apps/hyperdrive-trading/src/ui/token/TokenInput.tsx
@@ -1,3 +1,4 @@
+import { Cog6ToothIcon } from "@heroicons/react/24/outline";
 import classNames from "classnames";
 import { ReactElement, ReactNode } from "react";
 import { HIDE_NUMERIC_INPUT_ARROWS_CLASS } from "src/ui/base/numericInput";
@@ -19,6 +20,7 @@ interface TokenInputProps {
    * Optional stat to show, useful for things like wallet balances
    */
   stat?: ReactNode;
+  settings?: ReactNode;
   disabled?: boolean;
   /**
    * If true, this will render the input with error styling
@@ -35,6 +37,7 @@ export function TokenInput({
   maxValue,
   inputLabel = "Enter amount",
   stat,
+  settings,
   hasError = false,
   disabled = false,
   autoFocus = false,
@@ -94,20 +97,37 @@ export function TokenInput({
           }}
         />
         {maxValue !== undefined && !disabled ? (
-          <button
-            className={classNames(
-              "daisy-btn daisy-join-item border-b-neutral-content/30 border-l-base-100 border-r-neutral-content/30 border-t-neutral-content/30 bg-base-100 hover:border-b-neutral-content/30 hover:border-l-base-100 hover:border-r-neutral-content/30 hover:border-t-neutral-content/30 hover:bg-base-100 hover:underline active:hover:border-l-base-100",
-              {
-                "daisy-btn-error": hasError,
-              },
-            )}
-            onClick={(e) => {
-              e.preventDefault();
-              onChange(maxValue);
-            }}
-          >
-            Max
-          </button>
+          <div className="flex justify-around">
+            <button
+              className={classNames(
+                "daisy-btn daisy-join-item border-b-neutral-content/30 border-l-base-100 border-r-neutral-content/30 border-t-neutral-content/30 bg-base-100 hover:border-b-neutral-content/30 hover:border-l-base-100 hover:border-r-neutral-content/30 hover:border-t-neutral-content/30 hover:bg-base-100 hover:underline active:hover:border-l-base-100",
+                {
+                  "daisy-btn-error": hasError,
+                },
+              )}
+              onClick={(e) => {
+                e.preventDefault();
+                onChange(maxValue);
+              }}
+            >
+              Max
+            </button>
+            {settings ? (
+              <div className="daisy-dropdown daisy-dropdown-bottom relative">
+                <button
+                  onClick={(e) => {
+                    e.preventDefault();
+                  }}
+                  className="daisy-btn daisy-join-item border-b-neutral-content/30 border-l-base-100 border-r-neutral-content/30 border-t-neutral-content/30 bg-base-100 hover:border-b-neutral-content/30 hover:border-l-base-100 hover:border-r-neutral-content/30 hover:border-t-neutral-content/30 hover:bg-base-100 hover:underline active:hover:border-l-base-100"
+                >
+                  <Cog6ToothIcon className="h-4" />
+                </button>
+                <div className="daisy-menu daisy-dropdown-content absolute right-0 w-48 justify-evenly rounded-lg bg-base-100 p-2 shadow">
+                  <span>Hello</span>
+                </div>
+              </div>
+            ) : null}
+          </div>
         ) : null}
       </label>
       <label className="daisy-label flex justify-end">

--- a/apps/hyperdrive-trading/src/ui/token/hooks/useSlippageSettings.ts
+++ b/apps/hyperdrive-trading/src/ui/token/hooks/useSlippageSettings.ts
@@ -1,14 +1,12 @@
-import * as dnum from "dnum";
 import { useState } from "react";
-export function useSlippageSettings({ decimals }: { decimals: number }): {
+import { AUTO_SLIPPAGE_AMOUNT } from "src/ui/token/SlippageSettings";
+export function useSlippageSettings(): {
   slippage: bigint;
   setSlippage: (slippage: bigint) => void;
   activeTab: "auto" | "custom";
   setActiveTab: (activeTab: "auto" | "custom") => void;
 } {
-  const [slippage, setSlippage] = useState<bigint>(
-    dnum.from("0.5", decimals)[0],
-  );
+  const [slippage, setSlippage] = useState<bigint>(AUTO_SLIPPAGE_AMOUNT);
   const [activeTab, setActiveTab] = useState<"auto" | "custom">("auto");
 
   return {

--- a/apps/hyperdrive-trading/src/ui/token/hooks/useSlippageSettings.ts
+++ b/apps/hyperdrive-trading/src/ui/token/hooks/useSlippageSettings.ts
@@ -1,12 +1,14 @@
 import { useState } from "react";
 import { AUTO_SLIPPAGE_AMOUNT } from "src/ui/token/SlippageSettings";
-export function useSlippageSettings(): {
+export function useSlippageSettings({ decimals }: { decimals: number }): {
   slippage: bigint;
   setSlippage: (slippage: bigint) => void;
   activeTab: "auto" | "custom";
   setActiveTab: (activeTab: "auto" | "custom") => void;
 } {
-  const [slippage, setSlippage] = useState<bigint>(AUTO_SLIPPAGE_AMOUNT);
+  const [slippage, setSlippage] = useState<bigint>(
+    AUTO_SLIPPAGE_AMOUNT(decimals),
+  );
   const [activeTab, setActiveTab] = useState<"auto" | "custom">("auto");
 
   return {

--- a/apps/hyperdrive-trading/src/ui/token/hooks/useSlippageSettings.ts
+++ b/apps/hyperdrive-trading/src/ui/token/hooks/useSlippageSettings.ts
@@ -1,0 +1,20 @@
+import * as dnum from "dnum";
+import { useState } from "react";
+export function useSlippageSettings({ decimals }: { decimals: number }): {
+  slippage: bigint;
+  setSlippage: (slippage: bigint) => void;
+  activeTab: "auto" | "custom";
+  setActiveTab: (activeTab: "auto" | "custom") => void;
+} {
+  const [slippage, setSlippage] = useState<bigint>(
+    dnum.from("0.5", decimals)[0],
+  );
+  const [activeTab, setActiveTab] = useState<"auto" | "custom">("auto");
+
+  return {
+    slippage,
+    setSlippage,
+    activeTab,
+    setActiveTab,
+  };
+}

--- a/packages/hyperdrive-js-core/src/base/adjustAmountByPercentage.test.ts
+++ b/packages/hyperdrive-js-core/src/base/adjustAmountByPercentage.test.ts
@@ -8,7 +8,7 @@ test("should return adjusted amount down when given a basic input", () => {
   expect(
     adjustAmountByPercentage({
       amount,
-      percentage: 1n,
+      percentage: dnum.from("1", 18)[0],
       decimals: 18,
       direction: "down",
     }),
@@ -20,7 +20,7 @@ test("should return adjusted amount up when given a basic input", () => {
   expect(
     adjustAmountByPercentage({
       amount,
-      percentage: 1n,
+      percentage: dnum.from("1", 18)[0],
       decimals: 18,
       direction: "up",
     }),
@@ -33,7 +33,7 @@ test("should handle precision accurately when given precise input amounts", () =
   expect(
     adjustAmountByPercentage({
       amount: preciseAmount,
-      percentage: 1n,
+      percentage: dnum.from("1", 18)[0],
       decimals: 18,
       direction: "down",
     }),
@@ -45,7 +45,7 @@ test("should round down to zero when given the smallest possible positive value"
   expect(
     adjustAmountByPercentage({
       amount: roundingAmount,
-      percentage: 1n,
+      percentage: dnum.from("1", 18)[0],
       decimals: 18,
       direction: "down",
     }),
@@ -56,7 +56,7 @@ test("should return zero when input amount is zero", () => {
   expect(
     adjustAmountByPercentage({
       amount: 0n,
-      percentage: 1n,
+      percentage: dnum.from("1", 18)[0],
       decimals: 18,
       direction: "down",
     }),
@@ -68,7 +68,7 @@ test("should throw an error when given a negative input amount", () => {
   expect(() => {
     adjustAmountByPercentage({
       amount: negativeAmount,
-      percentage: 1n,
+      percentage: dnum.from("1", 18)[0],
       decimals: 18,
       direction: "down",
     });

--- a/packages/hyperdrive-js-core/src/base/adjustAmountByPercentage.ts
+++ b/packages/hyperdrive-js-core/src/base/adjustAmountByPercentage.ts
@@ -54,7 +54,8 @@ export function adjustAmountByPercentage({
   const amountWithDecimals = amount * shiftDecimals;
 
   // Calculate the slippage amount
-  const slippageAmount = (amountWithDecimals * percentage) / 100n;
+  const slippageAmount =
+    (amountWithDecimals * percentage) / (100n * shiftDecimals);
 
   // Subtract the slippage from the amountOut if "down", or add it if "up"
   let minOutput = amountWithDecimals - slippageAmount;


### PR DESCRIPTION
This PR adds a slippage settings menu to the token input form when opening a long. The form allows users to set an auto amount (0.5%), or a custom amount of slippage. 
<img width="605" alt="Screenshot 2024-04-12 at 9 16 32 PM" src="https://github.com/delvtech/hyperdrive-frontend/assets/22210106/e35aad21-38ba-46ac-81f8-1cf39f9602c1">

https://github.com/delvtech/hyperdrive-frontend/assets/22210106/6a5305a9-f726-491c-985d-6ea84fcea6c3




