### PR TITLE
Fix negative interest bug in getOpenLongs

### DIFF
--- a/packages/hyperdrive-js-core/src/base/testing/replaceBigIntsWithStrings.ts
+++ b/packages/hyperdrive-js-core/src/base/testing/replaceBigIntsWithStrings.ts
@@ -1,0 +1,18 @@
+import { formatUnits } from "viem";
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function replaceBigIntsWithStrings(key: string, value: any): string {
+  if (typeof value === "bigint") {
+    if (
+      key.includes("Time") ||
+      key.includes("blockNumber") ||
+      key.includes("id") ||
+      key.includes("assetId")
+    ) {
+      // Convert bigint to a string
+      return `${value.toString()}n`; // Adding 'n' to differentiate from normal numbers
+    }
+    return `dnum.from('${formatUnits(value, 18)}', 18)[0]`;
+  }
+  return value;
+}

--- a/packages/hyperdrive-js-core/src/base/testing/replaceBigIntsWithStrings.ts
+++ b/packages/hyperdrive-js-core/src/base/testing/replaceBigIntsWithStrings.ts
@@ -1,7 +1,17 @@
 import { formatUnits } from "viem";
 
+/**
+ * Replacer for JSON.stringify to convert bigints into strings. Helpful when
+ * reproducing events in test.
+ *
+ * Example:
+ * JSON.stringify({ id: 1n, value: 100000000000000000n }, replaceBigintWithString);
+ * // -> '{ "id": "1n", "value": "dnum.from("1", 18)[0]" }'
+ */
+
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export function replaceBigIntsWithStrings(key: string, value: any): string {
+export function replaceBigIntWithString(key: string, value: any): string {
+  // bigints for non-amounts can just be suffixed with `n`
   if (typeof value === "bigint") {
     if (
       key.includes("Time") ||
@@ -12,6 +22,7 @@ export function replaceBigIntsWithStrings(key: string, value: any): string {
       // Convert bigint to a string
       return `${value.toString()}n`; // Adding 'n' to differentiate from normal numbers
     }
+    // otherwise display the formatted value
     return `dnum.from('${formatUnits(value, 18)}', 18)[0]`;
   }
   return value;

--- a/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
@@ -489,87 +489,57 @@ export class ReadHyperdrive extends ReadModel {
   private _calcOpenLongs({
     openLongEvents,
     closeLongEvents,
-    longsInTransferSingleEvents,
-    longsOutTransferSingleEvents,
   }: {
     openLongEvents: Event<HyperdriveAbi, "OpenLong">[];
     closeLongEvents: Event<HyperdriveAbi, "CloseLong">[];
-    longsInTransferSingleEvents: Event<HyperdriveAbi, "TransferSingle">[];
-    longsOutTransferSingleEvents: Event<HyperdriveAbi, "TransferSingle">[];
-  }) {
-    const totalBasePaidByAssetId = mapValues(
-      groupBy(openLongEvents, (event) => event.args.assetId.toString()),
-      (events) => {
-        const baseAmounts = events.map((event) => {
-          const { baseAmount } = event.args;
-          return baseAmount;
-        });
-
-        return sumBigInt(baseAmounts);
-      },
+  }): Record<string, Long> {
+    // Put open and long events in block order. We spread openLongEvents first
+    // since you have to open a long before you can close one.
+    const orderedLongEvents = [...openLongEvents, ...closeLongEvents].sort(
+      (a, b) => Number(a.blockNumber) - Number(b.blockNumber),
     );
 
-    const totalBaseReceivedByAssetId = mapValues(
-      groupBy(closeLongEvents, (event) => event.args.assetId.toString()),
-      (events) => {
-        const baseAmounts = events.map((event) => {
-          const { baseAmount } = event.args;
-          return baseAmount;
-        });
-        return sumBigInt(baseAmounts);
-      },
-    );
+    const openLongs: Record<string, Long> = {};
 
-    const longsMintedOrReceivedById = mapValues(
-      groupBy(longsInTransferSingleEvents, (event) => event.args.id),
-      (events): Long => {
-        const assetId = events[0].args.id;
-        const decoded = decodeAssetFromTransferSingleEventData(
-          events[0].data as `0x${string}`,
-        );
-        return {
-          assetId,
-          bondAmount: sumBigInt(events.map((event) => event.args.value)),
-          baseAmountPaid: totalBasePaidByAssetId[assetId.toString()],
-          maturity: decoded.timestamp,
+    orderedLongEvents.forEach((event) => {
+      const assetId = event.args.assetId.toString();
+
+      const long: Long = openLongs[assetId] || {
+        assetId: event.args.assetId,
+        maturity: event.args.maturityTime,
+        baseAmountPaid: 0n,
+        bondAmount: 0n,
+      };
+
+      if (event.eventName === "OpenLong") {
+        const updatedLong: Long = {
+          ...long,
+          baseAmountPaid: long.baseAmountPaid + event.args.baseAmount,
+          bondAmount: long.bondAmount + event.args.bondAmount,
         };
-      },
-    );
+        openLongs[assetId] = updatedLong;
+        return;
+      }
 
-    const longsRedeemedOrSentById = mapValues(
-      groupBy(longsOutTransferSingleEvents, (event) => event.args.id),
-      (events): Long => {
-        const assetId = events[0].args.id;
-        const decoded = decodeAssetFromTransferSingleEventData(
-          events[0].data as `0x${string}`,
-        );
-        return {
-          assetId,
-          bondAmount: sumBigInt(events.map((event) => event.args.value)),
-          baseAmountPaid: totalBaseReceivedByAssetId[assetId.toString()],
-          maturity: decoded.timestamp,
-        };
-      },
-    );
-
-    const openLongsById = mapValues(
-      longsMintedOrReceivedById,
-      (long, key): Long => {
-        const matchingExit = longsRedeemedOrSentById[key];
-        if (matchingExit) {
-          const newBondAmount = long.bondAmount - matchingExit.bondAmount;
-          const newBaseAmountPaid =
-            long.baseAmountPaid - matchingExit.baseAmountPaid;
-          return {
-            ...long,
-            bondAmount: newBondAmount,
-            baseAmountPaid: newBaseAmountPaid,
-          };
+      if (event.eventName === "CloseLong") {
+        // If a user closes their whole position, we should remove the whole
+        // position since it's basically starting over
+        if (event.args.bondAmount === long.bondAmount) {
+          delete openLongs[assetId];
+          return;
         }
-        return long;
-      },
-    );
-    return openLongsById;
+        // otherwise just subtract the amount of bonds they closed and baseAmount
+        // they received back from the running total
+        const updatedLong: Long = {
+          ...long,
+          baseAmountPaid: long.baseAmountPaid - event.args.baseAmount,
+          bondAmount: long.bondAmount - event.args.bondAmount,
+        };
+        openLongs[assetId] = updatedLong;
+      }
+    });
+
+    return openLongs;
   }
 
   /**
@@ -596,36 +566,9 @@ export class ReadHyperdrive extends ReadModel {
       toBlock,
     });
 
-    const longsInTransferSingleEvents = (
-      await this.getTransferSingleEvents({
-        filter: { to: account },
-        toBlock,
-      })
-    ).filter(
-      (transferSingleEvent) =>
-        decodeAssetFromTransferSingleEventData(
-          transferSingleEvent.data as `0x${string}`,
-        ).assetType === "LONG",
-    );
-
-    const longsOutTransferSingleEvents = (
-      await this.getTransferSingleEvents({
-        filter: { from: account },
-        toBlock,
-      })
-    ).filter((transferSingleEvent) => {
-      return (
-        decodeAssetFromTransferSingleEventData(
-          transferSingleEvent.data as `0x${string}`,
-        ).assetType === "LONG"
-      );
-    });
-
     const openLongsById = this._calcOpenLongs({
       openLongEvents,
       closeLongEvents,
-      longsInTransferSingleEvents,
-      longsOutTransferSingleEvents,
     });
 
     return Object.values(openLongsById).filter((long) => long.bondAmount);


### PR DESCRIPTION
## Before:
Value paid showing more than the bond amount, since this user open and closed this position once already at a loss and didn't make up the difference in the new position.
![image](https://github.com/delvtech/hyperdrive-frontend/assets/4524175/c9d522d9-b79b-479c-973f-9608268b84f3)
## After:
Same scenario, but since they fully closed the position, that resets the value paid and Fixed APR
<img width="1242" alt="image" src="https://github.com/delvtech/hyperdrive-frontend/assets/4524175/d21d0633-738d-4848-b96a-6d923ddb2add">

- [x] Fixes accounting bug in `getOpenLongs` where user fully closes their long, the re-opens a long in. the same checkpoint.
- [x] Add test

This PR simplifies getOpenLongs by removing the **TransferSingle** events from the calculation. As a result, positions you transfer between wallets will not be visible in the UI at this time. This is for a few reasons:
- Previous support was untested and is currently unused
- The UI shows **value paid** and **profit/loss**, only available in OpenLong/CloseLong events

We do want to support `TransferSingle`-based positions. However, we'll need to consider how the UI will display these positions properly alongside `OpenLong`-based positions.