### PR TITLE
Add places to tokenconfig

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/TransactionTable/TransactionsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/TransactionTable/TransactionsTable.tsx
@@ -317,6 +317,7 @@ function formatTransactionTableMobileData(
       baseQueuedForWithdrawal,
       hyperdrive.decimals,
       baseToken.symbol,
+      baseToken.places,
     );
   }
   return [
@@ -413,10 +414,11 @@ function formatBaseQueuedForWithdrawalLabel(
   baseQueuedForWithdrawal: bigint,
   decimals: number,
   baseSymbol: string,
+  places: number = 2,
 ) {
   const baseQueuedForWithdrawalLabel = formatBalance({
     balance: baseQueuedForWithdrawal,
-    places: 2,
+    places: places,
     decimals,
   });
   const floorOrAmount =

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongForm/CloseLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongForm/CloseLongForm.tsx
@@ -133,7 +133,7 @@ export function CloseLongForm({
           stat={`Balance: ${formatBalance({
             balance: long.bondAmount,
             decimals: hyperdrive.decimals,
-            places: 4,
+            places: baseToken.places,
           })}`}
           onChange={(newAmount) => setAmount(newAmount)}
         />
@@ -157,7 +157,7 @@ export function CloseLongForm({
                 ? `${formatBalance({
                     balance: withdrawAmount,
                     decimals: baseToken.decimals,
-                    places: 8,
+                    places: baseToken.places,
                   })}`
                 : "0"}{" "}
               {activeWithdrawToken.symbol}

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/ClosedLongsTable/ClosedLongsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/ClosedLongsTable/ClosedLongsTable.tsx
@@ -47,7 +47,7 @@ function formatClosedLongMobileColumnData(
           {formatBalance({
             balance: closedLong.bondAmount,
             decimals: baseToken.decimals,
-            places: 2,
+            places: baseToken.places,
           })}
         </span>
       ),
@@ -137,7 +137,7 @@ function getColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
             {formatBalance({
               balance: row.original.bondAmount,
               decimals: baseToken.decimals,
-              places: 2,
+              places: baseToken.places,
             })}
           </span>
         );
@@ -274,7 +274,7 @@ function BaseAmountReceivedCell({
   const currentValueLabel = formatBalance({
     balance: closedLong.baseAmount,
     decimals: baseToken.decimals,
-    places: 4,
+    places: baseToken.places,
   });
 
   return (

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
@@ -204,7 +204,7 @@ export function OpenLongForm({
               ? `Balance: ${formatBalance({
                   balance: activeTokenBalance?.value,
                   decimals: activeToken.decimals,
-                  places: 4,
+                  places: activeToken.places,
                 })} ${activeToken.symbol}`
               : undefined
           }

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongPreview.tsx
@@ -51,7 +51,7 @@ export function OpenLongPreview({
             <span>{`${formatBalance({
               balance: long.baseAmountPaid,
               decimals: baseToken.decimals,
-              places: 4,
+              places: baseToken.places,
             })} ${activeToken.symbol}`}</span>
           }
         />
@@ -61,7 +61,7 @@ export function OpenLongPreview({
             <span className="font-bold">{`${formatBalance({
               balance: long.bondAmount,
               decimals: baseToken.decimals,
-              places: 4,
+              places: baseToken.places,
             })} hy${baseToken.symbol}`}</span>
           }
         />
@@ -76,7 +76,7 @@ export function OpenLongPreview({
                 ? `${formatBalance({
                     balance: curveFee,
                     decimals: baseToken.decimals,
-                    places: 6,
+                    places: baseToken.places,
                   })} hy${baseToken.symbol}`
                 : `0 hy${baseToken.symbol}`}
             </span>
@@ -161,7 +161,7 @@ export function OpenLongPreview({
                     ? `${formatBalance({
                         balance: long.bondAmount - long.baseAmountPaid,
                         decimals: baseToken.decimals,
-                        places: 4,
+                        places: baseToken.places,
                       })} ${baseToken.symbol}`
                     : undefined}
                 </span>

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/CurrentValueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/CurrentValueCell.tsx
@@ -48,7 +48,7 @@ export function CurrentValueCell({
   const currentValueLabel = formatBalance({
     balance: amountOutInBase || 0n,
     decimals: baseToken.decimals,
-    places: 4,
+    places: baseToken.places,
   });
 
   const isPositiveChangeInValue =
@@ -74,7 +74,7 @@ export function CurrentValueCell({
           ? `${formatBalance({
               balance: amountOutInBase - row.baseAmountPaid,
               decimals: baseToken.decimals,
-              places: 4,
+              places: baseToken.places,
             })} ${baseToken.symbol}`
           : undefined}
       </div>

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/FixedRateCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/FixedRateCell.tsx
@@ -58,7 +58,7 @@ export function FixedRateCell({
         {formatBalance({
           balance: yieldAfterFlatFee,
           decimals: baseToken.decimals,
-          places: 4,
+          places: baseToken.places,
         })}{" "}
         {baseToken.symbol}
       </div>

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
@@ -195,7 +195,7 @@ function getColumns({
             {formatBalance({
               balance: row.original.bondAmount,
               decimals: baseToken.decimals,
-              places: 2,
+              places: baseToken.places,
             })}
           </span>
         );
@@ -209,7 +209,7 @@ function getColumns({
         return formatBalance({
           balance: amountPaid,
           decimals: baseToken.decimals,
-          places: 2,
+          places: baseToken.places,
         });
       },
     }),

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableMobile.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableMobile.tsx
@@ -184,7 +184,7 @@ function formatOpenLongMobileColumnData(
           {formatBalance({
             balance: row.bondAmount,
             decimals: baseToken.decimals,
-            places: 2,
+            places: baseToken.places,
           })}
         </span>
       ),
@@ -194,7 +194,7 @@ function formatOpenLongMobileColumnData(
       value: formatBalance({
         balance: row.baseAmountPaid,
         decimals: baseToken.decimals,
-        places: 2,
+        places: baseToken.places,
       }),
     },
     {

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
@@ -196,7 +196,7 @@ export function AddLiquidityForm({
               ? `Balance: ${formatBalance({
                   balance: activeTokenBalance?.value,
                   decimals: activeToken.decimals,
-                  places: 4,
+                  places: activeToken.places,
                 })} ${activeToken.symbol}`
               : undefined
           }
@@ -209,6 +209,7 @@ export function AddLiquidityForm({
           lpSharesOut={lpSharesOut}
           depositAmount={depositAmountAsBigInt}
           depositTokenDecimals={activeToken.decimals}
+          depositTokenPlaces={activeToken.places}
           depositTokenSymbol={activeToken.symbol}
           poolShareAfterDeposit={poolShareAfterDeposit}
         />

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityPreview/AddLiquidityPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityPreview/AddLiquidityPreview.tsx
@@ -12,6 +12,7 @@ interface AddLiquidityPreviewProps {
   depositAmount: bigint | undefined;
   lpSharesOut: bigint | undefined;
   depositTokenDecimals: number;
+  depositTokenPlaces: number;
   depositTokenSymbol: string;
 }
 
@@ -21,6 +22,7 @@ export function AddLiquidityPreview({
   depositAmount,
   depositTokenSymbol,
   depositTokenDecimals,
+  depositTokenPlaces,
   lpSharesOut,
 }: AddLiquidityPreviewProps): ReactElement {
   const appConfig = useAppConfig();
@@ -59,7 +61,7 @@ export function AddLiquidityPreview({
               ? `${formatBalance({
                   balance: depositAmount,
                   decimals: depositTokenDecimals,
-                  places: 4,
+                  places: depositTokenPlaces,
                 })} ${depositTokenSymbol}`
               : "-"}
           </p>
@@ -73,7 +75,7 @@ export function AddLiquidityPreview({
               ? `${formatBalance({
                   balance: lpSharesOut,
                   decimals: hyperdrive.decimals,
-                  places: 4,
+                  places: baseToken.places,
                 })} ${baseToken.symbol}-LP`
               : "-"}
           </p>

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/ClosedLpTable/ClosedLpTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/ClosedLpTable/ClosedLpTable.tsx
@@ -57,7 +57,7 @@ function formatClosedLpMobileColumnData(
       value: formatBalance({
         balance: shares,
         decimals: baseToken.decimals,
-        places: 4,
+        places: baseToken.places,
       }),
     },
     {
@@ -65,7 +65,7 @@ function formatClosedLpMobileColumnData(
       value: formatBalance({
         balance: closedLpShares.baseAmount,
         decimals: baseToken.decimals,
-        places: 4,
+        places: baseToken.places,
       }),
     },
     {
@@ -75,7 +75,7 @@ function formatClosedLpMobileColumnData(
         : formatBalance({
             balance: closedLpShares.withdrawalShareAmount,
             decimals: baseToken.decimals,
-            places: 4,
+            places: baseToken.places,
           }),
     },
   ];
@@ -151,7 +151,7 @@ function getColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
             {formatBalance({
               balance: shares,
               decimals: baseToken.decimals,
-              places: 4,
+              places: baseToken.places,
             })}
           </span>
         );
@@ -166,7 +166,7 @@ function getColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
             {formatBalance({
               balance: baseAmount,
               decimals: baseToken.decimals,
-              places: 4,
+              places: baseToken.places,
             })}
           </span>
         );
@@ -185,7 +185,7 @@ function getColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
             {formatBalance({
               balance: withdrawalShareAmount,
               decimals: baseToken.decimals,
-              places: 4,
+              places: baseToken.places,
             })}
           </span>
         );

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/OpenLpSharesCard/OpenLpSharesCard.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/OpenLpSharesCard/OpenLpSharesCard.tsx
@@ -52,7 +52,7 @@ export function OpenLpSharesCard({
   const formattedProfit = formatBalance({
     balance: profit,
     decimals: baseToken.decimals,
-    places: 4,
+    places: baseToken.places,
   });
 
   const utilizationRatio = useUtilizationRatio({
@@ -98,7 +98,7 @@ export function OpenLpSharesCard({
                     `${formatBalance({
                       balance: lpShares || 0n,
                       decimals: hyperdrive.decimals,
-                      places: 4,
+                      places: baseToken.places,
                     })} ${baseToken.symbol}-LP`
                   ) : (
                     <Skeleton />
@@ -114,7 +114,7 @@ export function OpenLpSharesCard({
                     `${formatBalance({
                       balance: baseValue,
                       decimals: baseToken.decimals,
-                      places: 4,
+                      places: baseToken.places,
                     })} ${baseToken.symbol}`
                   ) : (
                     <Skeleton />

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
@@ -117,7 +117,7 @@ export function RemoveLiquidityForm({
           decimals: baseToken.decimals,
         }),
         decimals: baseToken.decimals,
-        places: 4,
+        places: baseToken.places,
       })
     : null;
 
@@ -174,7 +174,7 @@ export function RemoveLiquidityForm({
               ? `Withdrawable: ${formatBalance({
                   balance: lpShares,
                   decimals: hyperdrive.decimals,
-                  places: 2,
+                  places: baseToken.places,
                 })} ${baseToken.symbol}-LP`
               : undefined
           }
@@ -190,7 +190,7 @@ export function RemoveLiquidityForm({
                 ? `${formatBalance({
                     balance: lpShares || 0n,
                     decimals: hyperdrive.decimals,
-                    places: 4,
+                    places: baseToken.places,
                   })}`
                 : "0"
             } ${baseToken.symbol}-LP`}
@@ -203,7 +203,7 @@ export function RemoveLiquidityForm({
                   ? `${formatBalance({
                       balance: actualValueOut,
                       decimals: activeWithdrawToken.decimals,
-                      places: 4,
+                      places: activeWithdrawToken.places,
                     })}`
                   : "0"}{" "}
                 {activeWithdrawToken.symbol}

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortForm/CloseShortForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortForm/CloseShortForm.tsx
@@ -122,7 +122,7 @@ export function CloseShortForm({
               ? `Balance: ${formatBalance({
                   balance: short.bondAmount,
                   decimals: hyperdrive.decimals,
-                  places: 4,
+                  places: baseToken.places,
                 })}`
               : undefined
           }
@@ -148,7 +148,7 @@ export function CloseShortForm({
                 ? `${formatBalance({
                     balance: amountOut,
                     decimals: baseToken.decimals,
-                    places: 8,
+                    places: baseToken.places,
                   })}`
                 : "0"}{" "}
               {activeWithdrawToken.symbol}

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/ClosedShortsTable/ClosedShortsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/ClosedShortsTable/ClosedShortsTable.tsx
@@ -46,7 +46,7 @@ function formatClosedShortMobileColumnData(
       value: formatBalance({
         balance: closedShort.bondAmount,
         decimals: baseToken.decimals,
-        places: 2,
+        places: baseToken.places,
       }),
     },
     {
@@ -54,7 +54,7 @@ function formatClosedShortMobileColumnData(
       value: formatBalance({
         balance: closedShort.baseAmountReceived,
         decimals: baseToken.decimals,
-        places: 4,
+        places: baseToken.places,
       }),
     },
     {
@@ -128,6 +128,7 @@ function getColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
         return formatBalance({
           balance: bondAmountValue,
           decimals: baseToken.decimals,
+          places: baseToken.places,
         });
       },
     }),
@@ -140,7 +141,7 @@ function getColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
             {formatBalance({
               balance: amountReceived,
               decimals: baseToken.decimals,
-              places: 4,
+              places: baseToken.places,
             })}
           </span>
         );

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
@@ -226,7 +226,7 @@ export function OpenShortForm({
                     balance: traderDeposit || 0n,
                     decimals: activeToken.decimals,
                     includeCommas: true,
-                    places: 6,
+                    places: activeToken.places,
                   })}{" "}
                   {activeToken.symbol}
                 </strong>{" "}
@@ -236,7 +236,7 @@ export function OpenShortForm({
                     balance: amountOfBondsToShortAsBigInt,
                     decimals: activeToken.decimals,
                     includeCommas: true,
-                    places: 6,
+                    places: activeToken.places,
                   })}{" "}
                   {baseToken.symbol}
                 </strong>{" "}

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
@@ -51,7 +51,7 @@ export function OpenShortPreview({
               ? `${formatBalance({
                   balance: shortSize,
                   decimals: baseToken.decimals,
-                  places: 6,
+                  places: baseToken.places,
                 })} hy${baseToken.symbol}`
               : `0 hy${baseToken.symbol}`}
           </span>
@@ -68,7 +68,7 @@ export function OpenShortPreview({
               ? `${formatBalance({
                   balance: curveFee,
                   decimals: tokenIn.decimals,
-                  places: 6,
+                  places: tokenIn.places,
                 })} ${tokenIn.symbol}`
               : `0 ${tokenIn.symbol}`}
           </span>
@@ -85,7 +85,7 @@ export function OpenShortPreview({
               ? `${formatBalance({
                   balance: costBasis,
                   decimals: tokenIn.decimals,
-                  places: 6,
+                  places: tokenIn.places,
                 })} ${tokenIn.symbol}`
               : `0 ${tokenIn.symbol}`}
           </span>

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/AccruedYieldCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/AccruedYieldCell.tsx
@@ -30,7 +30,7 @@ export function AccruedYieldCell({
         {formatBalance({
           balance: accruedYield || 0n,
           decimals: baseToken.decimals,
-          places: 3,
+          places: baseToken.places,
         })}
       </span>
     </div>

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/CurrentValueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/CurrentValueCell.tsx
@@ -45,7 +45,7 @@ export function CurrentValueCell({
   const currentValueLabel = formatBalance({
     balance: currentValueInBase || 0n,
     decimals: baseToken.decimals,
-    places: 4,
+    places: baseToken.places,
   });
 
   const isPositiveChangeInValue =
@@ -70,6 +70,7 @@ export function CurrentValueCell({
             endAmount: openShort.baseAmountPaid,
             decimals: baseToken.decimals,
             symbol: baseToken.symbol,
+            places: baseToken.places,
           })}
         </div>
       ) : (
@@ -84,11 +85,13 @@ function getProfitLossText({
   endAmount,
   symbol,
   decimals,
+  places,
 }: {
   startAmount: bigint;
   endAmount: bigint;
   symbol: string;
   decimals: number;
+  places: number;
 }): string {
   const profitOrLoss = startAmount - endAmount;
 
@@ -96,7 +99,7 @@ function getProfitLossText({
     balance: profitOrLoss,
     decimals: decimals,
     includeCommas: true,
-    places: 4,
+    places,
   })} ${symbol}`;
 
   return result;

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktop.tsx
@@ -148,7 +148,7 @@ function getColumns(
         return formatBalance({
           balance: bondAmountValue,
           decimals: baseToken.decimals,
-          places: 6,
+          places: baseToken.places,
         });
       },
     }),
@@ -159,7 +159,7 @@ function getColumns(
         return formatBalance({
           balance: amountPaid,
           decimals: baseToken.decimals,
-          places: 3,
+          places: baseToken.places,
         });
       },
     }),

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableMobile.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableMobile.tsx
@@ -184,7 +184,7 @@ function formatOpenShortMobileColumnData(
       value: formatBalance({
         balance: openShort.bondAmount,
         decimals: baseToken.decimals,
-        places: 6,
+        places: baseToken.places,
       }),
     },
     {
@@ -192,7 +192,7 @@ function formatOpenShortMobileColumnData(
       value: formatBalance({
         balance: openShort.baseAmountPaid,
         decimals: baseToken.decimals,
-        places: 6,
+        places: baseToken.places,
       }),
     },
     {

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/withdrawalShares/OpenWithdrawalSharesCard/OpenWithdrawalSharesCard.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/withdrawalShares/OpenWithdrawalSharesCard/OpenWithdrawalSharesCard.tsx
@@ -68,7 +68,7 @@ export function OpenWithdrawalSharesCard({
                       `${formatBalance({
                         balance: withdrawalSharesCurrentValue,
                         decimals: baseToken.decimals,
-                        places: 4,
+                        places: baseToken.places,
                       })} ${baseToken.symbol}`
                     ) : (
                       <Skeleton />
@@ -84,7 +84,7 @@ export function OpenWithdrawalSharesCard({
                       `${formatBalance({
                         balance: baseProceedsFromPreview,
                         decimals: baseToken.decimals,
-                        places: 4,
+                        places: baseToken.places,
                       })} ${baseToken.symbol}`
                     ) : (
                       <Skeleton />

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/withdrawalShares/RedeemWithdrawalSharesForm/RedeemWithdrawalSharesForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/withdrawalShares/RedeemWithdrawalSharesForm/RedeemWithdrawalSharesForm.tsx
@@ -129,7 +129,7 @@ export function RedeemWithdrawalSharesForm({
               ? maxRedeemableBaseProceeds || 0n
               : maxRedeemableSharesProceeds || 0n,
             decimals: activeWithdrawToken.decimals,
-            places: 4,
+            places: activeWithdrawToken.places,
           })} ${activeWithdrawToken.symbol}`}
           maxValue={formatUnits(
             isBaseTokenWithdrawal
@@ -151,7 +151,7 @@ export function RedeemWithdrawalSharesForm({
                       ? baseProceeds
                       : sharesProceeds,
                     decimals: activeWithdrawToken.decimals,
-                    places: 4,
+                    places: activeWithdrawToken.places,
                   })} ${activeWithdrawToken.symbol}`
                 : ""}
             </p>

--- a/apps/hyperdrive-trading/src/ui/markets/MarketDetailsBody/PriceBadges.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketDetailsBody/PriceBadges.tsx
@@ -35,7 +35,7 @@ export function PriceBadges({
         {formatBalance({
           balance: longPrice ?? 0n,
           decimals: baseToken.decimals,
-          places: 6,
+          places: baseToken.places,
         })}{" "}
         {baseToken.symbol}
       </div>
@@ -49,7 +49,7 @@ export function PriceBadges({
           ),
 
           decimals: baseToken.decimals,
-          places: 6,
+          places: baseToken.places,
         })}{" "}
         hy{baseToken.symbol}
       </div>

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/MarketStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/MarketStats.tsx
@@ -89,12 +89,12 @@ export function MarketStats({
           {
             balance: longVolume || 0n,
             decimals: baseToken.decimals,
-            places: 0,
+            places: baseToken.places,
           },
         )} hy${baseToken.symbol} \nShort volume: ${formatBalance({
           balance: shortVolume || 0n,
           decimals: baseToken.decimals,
-          places: 0,
+          places: baseToken.places,
         })} hy${baseToken.symbol}`}
         tooltipPosition={isTailwindSmallScreen ? "left" : "bottom"}
         label="Volume (24h)"

--- a/apps/hyperdrive-trading/src/ui/markets/YourBalanceWell/YourBalanceWell.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/YourBalanceWell/YourBalanceWell.tsx
@@ -110,7 +110,7 @@ function AvailableAsset({
             {formatBalance({
               balance: tokenBalance.value || 0n,
               decimals: token.decimals,
-              places: 4,
+              places: token.places,
             })}{" "}
             {token.symbol}
           </>
@@ -147,7 +147,7 @@ function AvailableAsset({
                       : formatBalance({
                           balance: allowance || 0n,
                           decimals: token.decimals,
-                          places: 4,
+                          places: token.places,
                         })}
                   </span>
                 </li>

--- a/apps/hyperdrive-trading/src/ui/token/RevokeAllowanceModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/token/RevokeAllowanceModalButton.tsx
@@ -119,11 +119,11 @@ export function RevokeAllowanceModalButton({
                         ? `Balance: ${formatBalance({
                             balance: tokenBalance?.value,
                             decimals: token.decimals,
-                            places: 4,
+                            places: token.places,
                           })} ${token.symbol}\nAllowance: ${formatBalance({
                             balance: allowance ?? 0n,
                             decimals: token.decimals,
-                            places: 4,
+                            places: token.places,
                           })} ${token.symbol}`
                         : undefined
                     }

--- a/apps/hyperdrive-trading/src/ui/token/TokenPicker.tsx
+++ b/apps/hyperdrive-trading/src/ui/token/TokenPicker.tsx
@@ -96,7 +96,7 @@ export function TokenPicker({
                         {formatBalance({
                           balance: tokenBalance || 0n,
                           decimals: tokenConfig?.decimals,
-                          places: 4,
+                          places: tokenConfig?.places,
                         })}
                         {` `}
                       </span>

--- a/packages/hyperdrive-appconfig/src/generated/11155111.appconfig.ts
+++ b/packages/hyperdrive-appconfig/src/generated/11155111.appconfig.ts
@@ -20,6 +20,7 @@ export const sepoliaAppConfig: AppConfig = {
     {
       address: "0xECa45b0391E81c311F1b390808a3BA3214d35eAA",
       decimals: 18,
+      places: 2,
       name: "sDAI",
       symbol: "SDAI",
       iconUrl: "https://etherscan.io/token/images/Badgedai_32.svg",
@@ -32,6 +33,7 @@ export const sepoliaAppConfig: AppConfig = {
     {
       address: "0x552ceaDf3B47609897279F42D3B3309B604896f3",
       decimals: 18,
+      places: 2,
       name: "DAI",
       symbol: "DAI",
       iconUrl:
@@ -42,6 +44,7 @@ export const sepoliaAppConfig: AppConfig = {
     {
       address: "0xECa45b0391E81c311F1b390808a3BA3214d35eAA",
       decimals: 18,
+      places: 2,
       name: "sDAI",
       symbol: "SDAI",
       iconUrl: "https://etherscan.io/token/images/Badgedai_32.svg",
@@ -54,6 +57,7 @@ export const sepoliaAppConfig: AppConfig = {
     {
       address: "0x552ceaDf3B47609897279F42D3B3309B604896f3",
       decimals: 18,
+      places: 2,
       name: "DAI",
       symbol: "DAI",
       iconUrl:
@@ -64,6 +68,7 @@ export const sepoliaAppConfig: AppConfig = {
     {
       address: "0x6977eC5fae3862D3471f0f5B6Dcc64cDF5Cfd959",
       decimals: 18,
+      places: 4,
       name: "Liquid staked Ether 2.0",
       symbol: "stETH",
       iconUrl: "https://cryptologos.cc/logos/steth-steth-logo.png?v=029",
@@ -78,6 +83,7 @@ export const sepoliaAppConfig: AppConfig = {
       name: "Ether",
       symbol: "ETH",
       decimals: 18,
+      places: 4,
       tags: [],
       extensions: {},
       iconUrl: "https://cryptologos.cc/logos/ethereum-eth-logo.png?v=029",
@@ -85,6 +91,7 @@ export const sepoliaAppConfig: AppConfig = {
     {
       address: "0x6977eC5fae3862D3471f0f5B6Dcc64cDF5Cfd959",
       decimals: 18,
+      places: 4,
       name: "Liquid staked Ether 2.0",
       symbol: "stETH",
       iconUrl: "https://cryptologos.cc/logos/steth-steth-logo.png?v=029",
@@ -99,44 +106,13 @@ export const sepoliaAppConfig: AppConfig = {
       name: "Ether",
       symbol: "ETH",
       decimals: 18,
+      places: 4,
       tags: [],
       extensions: {},
       iconUrl: "https://cryptologos.cc/logos/ethereum-eth-logo.png?v=029",
     },
   ],
   hyperdrives: [
-    {
-      address: "0x392839dA0dACAC790bd825C81ce2c5E264D793a8",
-      name: "14d DAI-Maker DSR",
-      decimals: 18,
-      baseToken: "0x552ceaDf3B47609897279F42D3B3309B604896f3",
-      sharesToken: "0xECa45b0391E81c311F1b390808a3BA3214d35eAA",
-      withdrawOptions: {
-        isBaseTokenWithdrawalEnabled: true,
-      },
-      poolConfig: {
-        baseToken: "0x552ceaDf3B47609897279F42D3B3309B604896f3",
-        vaultSharesToken: "0xECa45b0391E81c311F1b390808a3BA3214d35eAA",
-        linkerFactory: "0x13b0AcFA6B77C0464Ce26Ff80da7758b8e1f526E",
-        linkerCodeHash:
-          "0xbce832c0ea372ef949945c6a4846b1439b728e08890b93c2aa99e2e3c50ece34",
-        initialVaultSharePrice: 1000000000000000000n,
-        minimumShareReserves: 10000000000000000000n,
-        minimumTransactionAmount: 1000000000000000n,
-        positionDuration: 1209600n,
-        checkpointDuration: 86400n,
-        timeStretch: 1746050381163618n,
-        governance: "0xc187a246Ee5A4Fe4395a8f6C0f9F2AA3A5a06e9b",
-        feeCollector: "0xc187a246Ee5A4Fe4395a8f6C0f9F2AA3A5a06e9b",
-        sweepCollector: "0xc187a246Ee5A4Fe4395a8f6C0f9F2AA3A5a06e9b",
-        fees: {
-          curve: 10000000000000000n,
-          flat: 19178082191780n,
-          governanceLP: 150000000000000000n,
-          governanceZombie: 30000000000000000n,
-        },
-      },
-    },
     {
       address: "0xb932F8085399C228b16A9F7FC3219d47FfA2810d",
       name: "30d DAI-Maker DSR",
@@ -164,6 +140,38 @@ export const sepoliaAppConfig: AppConfig = {
         fees: {
           curve: 10000000000000000n,
           flat: 41095890410958n,
+          governanceLP: 150000000000000000n,
+          governanceZombie: 30000000000000000n,
+        },
+      },
+    },
+    {
+      address: "0x392839dA0dACAC790bd825C81ce2c5E264D793a8",
+      name: "14d DAI-Maker DSR",
+      decimals: 18,
+      baseToken: "0x552ceaDf3B47609897279F42D3B3309B604896f3",
+      sharesToken: "0xECa45b0391E81c311F1b390808a3BA3214d35eAA",
+      withdrawOptions: {
+        isBaseTokenWithdrawalEnabled: true,
+      },
+      poolConfig: {
+        baseToken: "0x552ceaDf3B47609897279F42D3B3309B604896f3",
+        vaultSharesToken: "0xECa45b0391E81c311F1b390808a3BA3214d35eAA",
+        linkerFactory: "0x13b0AcFA6B77C0464Ce26Ff80da7758b8e1f526E",
+        linkerCodeHash:
+          "0xbce832c0ea372ef949945c6a4846b1439b728e08890b93c2aa99e2e3c50ece34",
+        initialVaultSharePrice: 1000000000000000000n,
+        minimumShareReserves: 10000000000000000000n,
+        minimumTransactionAmount: 1000000000000000n,
+        positionDuration: 1209600n,
+        checkpointDuration: 86400n,
+        timeStretch: 1746050381163618n,
+        governance: "0xc187a246Ee5A4Fe4395a8f6C0f9F2AA3A5a06e9b",
+        feeCollector: "0xc187a246Ee5A4Fe4395a8f6C0f9F2AA3A5a06e9b",
+        sweepCollector: "0xc187a246Ee5A4Fe4395a8f6C0f9F2AA3A5a06e9b",
+        fees: {
+          curve: 10000000000000000n,
+          flat: 19178082191780n,
           governanceLP: 150000000000000000n,
           governanceZombie: 30000000000000000n,
         },

--- a/packages/hyperdrive-appconfig/src/generated/31337.appconfig.ts
+++ b/packages/hyperdrive-appconfig/src/generated/31337.appconfig.ts
@@ -20,6 +20,7 @@ export const localChainAppConfig: AppConfig = {
     {
       address: "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
       decimals: 18,
+      places: 2,
       name: "Delvnet Yield Source",
       symbol: "DELV",
       iconUrl: "https://etherscan.io/token/images/Badgedai_32.svg",
@@ -32,6 +33,7 @@ export const localChainAppConfig: AppConfig = {
     {
       address: "0x5FbDB2315678afecb367f032d93F642f64180aa3",
       decimals: 18,
+      places: 2,
       name: "Base",
       symbol: "BASE",
       iconUrl:
@@ -42,6 +44,7 @@ export const localChainAppConfig: AppConfig = {
     {
       address: "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9",
       decimals: 18,
+      places: 4,
       name: "Liquid staked Ether 2.0",
       symbol: "stETH",
       iconUrl: "https://cryptologos.cc/logos/steth-steth-logo.png?v=029",
@@ -56,6 +59,7 @@ export const localChainAppConfig: AppConfig = {
       name: "Ether",
       symbol: "ETH",
       decimals: 18,
+      places: 4,
       tags: [],
       extensions: {},
       iconUrl: "https://cryptologos.cc/logos/ethereum-eth-logo.png?v=029",

--- a/packages/hyperdrive-appconfig/src/generated/42069.appconfig.ts
+++ b/packages/hyperdrive-appconfig/src/generated/42069.appconfig.ts
@@ -20,6 +20,7 @@ export const cloudChainAppConfig: AppConfig = {
     {
       address: "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
       decimals: 18,
+      places: 2,
       name: "sDai",
       symbol: "SDAI",
       iconUrl: "https://etherscan.io/token/images/Badgedai_32.svg",
@@ -32,6 +33,7 @@ export const cloudChainAppConfig: AppConfig = {
     {
       address: "0x5FbDB2315678afecb367f032d93F642f64180aa3",
       decimals: 18,
+      places: 2,
       name: "Multi Collateral DAI",
       symbol: "DAI",
       iconUrl:
@@ -42,6 +44,7 @@ export const cloudChainAppConfig: AppConfig = {
     {
       address: "0x0165878A594ca255338adfa4d48449f69242Eb8F",
       decimals: 18,
+      places: 4,
       name: "Liquid staked Ether 2.0",
       symbol: "stETH",
       iconUrl: "https://cryptologos.cc/logos/steth-steth-logo.png?v=029",
@@ -56,6 +59,7 @@ export const cloudChainAppConfig: AppConfig = {
       name: "Ether",
       symbol: "ETH",
       decimals: 18,
+      places: 4,
       tags: [],
       extensions: {},
       iconUrl: "https://cryptologos.cc/logos/ethereum-eth-logo.png?v=029",

--- a/packages/hyperdrive-appconfig/src/hyperdrives/erc4626/getErc4626Hyperdrive.ts
+++ b/packages/hyperdrive-appconfig/src/hyperdrives/erc4626/getErc4626Hyperdrive.ts
@@ -47,6 +47,7 @@ export async function getErc4626Hyperdrive({
     extensions: {},
     tags: [],
     iconUrl: baseTokenIconUrl,
+    places: 2,
   });
 
   const hyperdriveName = formatHyperdriveName({

--- a/packages/hyperdrive-appconfig/src/hyperdrives/erc4626/getErc4626HyperdriveSharesToken.ts
+++ b/packages/hyperdrive-appconfig/src/hyperdrives/erc4626/getErc4626HyperdriveSharesToken.ts
@@ -16,5 +16,6 @@ export async function getErc4626HyperdriveSharesToken({
     tags: ["yieldSource", "erc4626"],
     extensions,
     iconUrl,
+    places: 2,
   });
 }

--- a/packages/hyperdrive-appconfig/src/hyperdrives/steth/getStethHyperdrive.ts
+++ b/packages/hyperdrive-appconfig/src/hyperdrives/steth/getStethHyperdrive.ts
@@ -37,6 +37,7 @@ export async function getStethHyperdrive({
     name: "Ether",
     symbol: "ETH",
     decimals: 18,
+    places: 4,
     tags: [],
     extensions: {},
     iconUrl: ETH_ICON_URL,

--- a/packages/hyperdrive-appconfig/src/hyperdrives/steth/getStethHyperdriveSharesToken.ts
+++ b/packages/hyperdrive-appconfig/src/hyperdrives/steth/getStethHyperdriveSharesToken.ts
@@ -15,5 +15,6 @@ export async function getStethHyperdriveSharesToken({
     tags: ["yieldSource", "steth"],
     extensions,
     iconUrl: STETH_ICON_URL,
+    places: 4,
   });
 }

--- a/packages/hyperdrive-appconfig/src/tokens/getTokenConfig.ts
+++ b/packages/hyperdrive-appconfig/src/tokens/getTokenConfig.ts
@@ -10,6 +10,7 @@ export interface TokenConfig<
   name: string;
   symbol: string;
   decimals: number;
+  places: number;
   iconUrl: string;
   tags: string[];
   extensions: Extensions;
@@ -20,17 +21,20 @@ export async function getTokenConfig<
 >({
   token,
   iconUrl,
+  places,
   tags,
   extensions,
 }: {
   token: ReadErc20 | ReadEth;
   tags: string[];
   iconUrl: string;
+  places: number;
   extensions: Extensions;
 }): Promise<TokenConfig<Extensions>> {
   return {
     address: token.address,
     decimals: await token.getDecimals(),
+    places,
     name: await token.getName(),
     symbol: await token.getSymbol(),
     iconUrl,


### PR DESCRIPTION
This PR adds a "places" figure to the AppConfig. This way any spot where we use `formatBalance` we can pull the number of places to round to by the specific token. 2 for dai, 4 for eth.

Question for @DannyDelott: Are there any spots where we should leave this hardcoded?

Closes #938 