### PR TITLE
Adds LP Slippage

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
@@ -184,6 +184,7 @@ export function OpenLongForm({
               decimals={activeToken.decimals}
               activeOption={activeSlippageOption}
               onActiveOptionChange={setActiveSlippageOption}
+              tooltip="Your transaction will revert if the price changes unfavorably by more than this percentage."
             />
           }
           name={activeToken.symbol}

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
@@ -175,6 +175,7 @@ export function AddLiquidityForm({
               decimals={activeToken.decimals}
               activeOption={activeOption}
               onActiveOptionChange={setActiveOption}
+              tooltip="Your transaction will revert if the liquidity provider share price changes unfavorably by more than this percentage."
             />
           }
           name={activeToken.symbol}

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
@@ -1,3 +1,4 @@
+import { adjustAmountByPercentage } from "@delvtech/hyperdrive-viem";
 import {
   EmptyExtensions,
   findBaseToken,
@@ -16,6 +17,7 @@ import { ConnectWalletButton } from "src/ui/base/components/ConnectWallet";
 import { LoadingButton } from "src/ui/base/components/LoadingButton";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { useNumericInput } from "src/ui/base/hooks/useNumericInput";
+import { usePoolInfo } from "src/ui/hyperdrive/hooks/usePoolInfo";
 import { AddLiquidityPreview } from "src/ui/hyperdrive/lp/AddLiquidityPreview/AddLiquidityPreview";
 import { useAddLiquidity } from "src/ui/hyperdrive/lp/hooks/useAddLiquidity";
 import { useLpShares } from "src/ui/hyperdrive/lp/hooks/useLpShares";
@@ -24,11 +26,13 @@ import { usePreviewAddLiquidity } from "src/ui/hyperdrive/lp/hooks/usePreviewAdd
 import { TransactionView } from "src/ui/hyperdrive/TransactionView";
 import { ApproveTokenChoices } from "src/ui/token/ApproveTokenChoices";
 import { useActiveToken } from "src/ui/token/hooks/useActiveToken";
+import { useSlippageSettings } from "src/ui/token/hooks/useSlippageSettings";
 import { useTokenAllowance } from "src/ui/token/hooks/useTokenAllowance";
 import { useTokenBalance } from "src/ui/token/hooks/useTokenBalance";
+import { SlippageSettings } from "src/ui/token/SlippageSettings";
 import { TokenInput } from "src/ui/token/TokenInput";
 import { TokenPicker } from "src/ui/token/TokenPicker";
-import { useAccount, useChainId } from "wagmi";
+import { useAccount } from "wagmi";
 
 interface AddLiquidityFormProps {
   hyperdrive: HyperdriveConfig;
@@ -40,7 +44,7 @@ export function AddLiquidityForm({
   onAddLiquidity,
 }: AddLiquidityFormProps): ReactElement {
   const { address: account } = useAccount();
-  const chainId = useChainId();
+  const { poolInfo } = usePoolInfo({ hyperdriveAddress: hyperdrive.address });
   const appConfig = useAppConfig();
   const baseToken = findBaseToken({
     baseTokenAddress: hyperdrive.baseToken,
@@ -110,15 +114,24 @@ export function AddLiquidityForm({
     amount: depositAmountAsBigInt,
   });
 
+  const { activeOption, setActiveOption, setSlippage, slippage } =
+    useSlippageSettings({ decimals: activeToken.decimals });
+
+  const minLpSharePriceAfterSlippage = adjustAmountByPercentage({
+    amount: poolInfo?.lpSharePrice || 0n,
+    percentage: slippage,
+    decimals: activeToken.decimals,
+    direction: "down",
+  });
+
   const isBaseActiveToken = activeToken.address === baseToken.address;
   // Shared params with the preview and the write method
   const addLiquidityParams = {
     hyperdriveAddress: hyperdrive.address,
     contribution: depositAmountAsBigInt,
-    // TODO: Add slippage control
     minAPR: parseUnits("0", baseToken.decimals),
     maxAPR: parseUnits("999", baseToken.decimals),
-    minLpSharePrice: parseUnits("0", baseToken.decimals),
+    minLpSharePrice: minLpSharePriceAfterSlippage,
     asBase: isBaseActiveToken,
     destination: account,
     ethValue: isActiveTokenEth ? depositAmountAsBigInt : undefined,
@@ -155,6 +168,15 @@ export function AddLiquidityForm({
     <TransactionView
       tokenInput={
         <TokenInput
+          settings={
+            <SlippageSettings
+              onSlippageChange={setSlippage}
+              slippage={slippage}
+              decimals={activeToken.decimals}
+              activeOption={activeOption}
+              onActiveOptionChange={setActiveOption}
+            />
+          }
           name={activeToken.symbol}
           token={
             <TokenPicker

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
@@ -196,6 +196,7 @@ export function OpenShortForm({
               decimals={activeToken.decimals}
               activeOption={activeSlippageOption}
               onActiveOptionChange={setActiveSlippageOption}
+              tooltip="Your transaction will revert if the price changes unfavorably by more than this percentage."
             />
           }
         />

--- a/apps/hyperdrive-trading/src/ui/token/SlippageSettings.tsx
+++ b/apps/hyperdrive-trading/src/ui/token/SlippageSettings.tsx
@@ -12,12 +12,14 @@ export function SlippageSettings({
   decimals,
   activeOption,
   onActiveOptionChange,
+  tooltip,
 }: {
   slippage: bigint;
   onSlippageChange: (slippage: bigint) => void;
   decimals: number;
   activeOption: "auto" | "custom";
   onActiveOptionChange: (activeTab: "auto" | "custom") => void;
+  tooltip?: string;
 }): JSX.Element {
   return (
     <>
@@ -25,9 +27,7 @@ export function SlippageSettings({
         <span className="ml-1">Max. Slippage</span>
         <div
           className="daisy-tooltip ml-1 before:w-48 before:border before:text-xs"
-          data-tip={
-            "Your transaction will revert if the price changes unfavorably by more than this percentage."
-          }
+          data-tip={tooltip}
         >
           <InformationCircleIcon className="size-4" />
         </div>


### PR DESCRIPTION
This PR adds LP slippage adjustments the same way it does for Long and Short. The only difference is the adjustment is done on the lpSharePrice the user will receive. I've also added a tooltip prop to the settings component to clarify this difference a bit more.