### PR TITLE
Fix widths of table and faq on All Markets page

### DIFF
--- a/apps/hyperdrive-trading/src/ui/markets/AllMarketsTable/AllMarketsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/AllMarketsTable/AllMarketsTable.tsx
@@ -8,7 +8,7 @@ export function AllMarketsTable(): ReactElement {
   return (
     <div className="flex w-full flex-col items-center">
       <h3 className="gradient-text mb-8 text-center">Available Markets</h3>
-      <div className="daisy-card daisy-card-bordered flex w-full md:w-5/6 md:p-6">
+      <div className="daisy-card daisy-card-bordered flex w-full md:w-auto md:p-6">
         {isTailwindSmallScreen ? (
           <AllMarketsTableMobile />
         ) : (

--- a/apps/hyperdrive-trading/src/ui/markets/AllMarketsTable/AllMarketsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/AllMarketsTable/AllMarketsTableDesktop.tsx
@@ -173,7 +173,7 @@ export function AllMarketsTableDesktop(): ReactElement {
     return <LoadingState />;
   }
   return (
-    <table className="daisy-table daisy-table-zebra daisy-table-lg ">
+    <table className="daisy-table daisy-table-zebra daisy-table-lg w-[1200px]">
       <thead>
         {tableInstance.getHeaderGroups().map((headerGroup) => (
           <tr key={headerGroup.id}>

--- a/apps/hyperdrive-trading/src/ui/onboarding/FAQ/FAQ.tsx
+++ b/apps/hyperdrive-trading/src/ui/onboarding/FAQ/FAQ.tsx
@@ -6,11 +6,11 @@ import { faqData } from "src/ui/onboarding/FAQ/faqData";
 
 export function FAQ(): ReactElement {
   return (
-    <div className="mt-8 flex w-full flex-col">
+    <div className="mt-8 flex w-full flex-col items-center">
       <h3 className="gradient-text mb-8 text-center">
         Frequently Asked Questions
       </h3>
-      <div className="mx-8 flex flex-row gap-6 rounded-box bg-base-200 p-12">
+      <div className="mx-8 flex w-[1200px] flex-row gap-6 rounded-box bg-base-200 p-12">
         <FAQEntries />
       </div>
     </div>


### PR DESCRIPTION
Tighten up the landing page layout a bit so it's easier to read/scan

|Before|After|
|---|---|
|![image](https://github.com/delvtech/hyperdrive-frontend/assets/4524175/160fbfd4-006d-4936-97a2-50efa3f4c88f)|![image](https://github.com/delvtech/hyperdrive-frontend/assets/4524175/1f558040-6ca6-42a2-b79e-f7a50781c228)|