### PR TITLE
update hyperwasm

### DIFF
--- a/packages/hyperdrive-js-core/package.json
+++ b/packages/hyperdrive-js-core/package.json
@@ -15,7 +15,7 @@
     "@delvtech/hyperdrive-artifacts": "^0.0.3"
   },
   "dependencies": {
-    "@delvtech/hyperdrive-wasm": "^0.9.1",
+    "@delvtech/hyperdrive-wasm": "^0.11.0",
     "lodash.groupby": "^4.6.0",
     "lodash.mapvalues": "^4.6.0"
   },

--- a/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
@@ -148,7 +148,7 @@ export class ReadHyperdrive extends ReadModel {
     const config = await this.getPoolConfig(options);
     const info = await this.getPoolInfo(options);
 
-    const aprString = hyperwasm.getSpotRate(
+    const aprString = hyperwasm.spotRate(
       convertBigIntsToStrings(info),
       convertBigIntsToStrings(config),
     );
@@ -286,7 +286,7 @@ export class ReadHyperdrive extends ReadModel {
     const poolConfig = await this.getPoolConfig(options);
     const poolInfo = await this.getPoolInfo(options);
 
-    const spotPrice = hyperwasm.getSpotPrice(
+    const spotPrice = hyperwasm.spotPrice(
       convertBigIntsToStrings(poolInfo),
       convertBigIntsToStrings(poolConfig),
     );

--- a/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
@@ -163,7 +163,7 @@ export class ReadHyperdrive extends ReadModel {
     const poolConfig = await this.getPoolConfig(options);
     const poolInfo = await this.getPoolInfo(options);
 
-    const liquidityString = hyperwasm.getIdleShareReservesInBase(
+    const liquidityString = hyperwasm.idleShareReservesInBase(
       convertBigIntsToStrings(poolInfo),
       convertBigIntsToStrings(poolConfig),
     );

--- a/packages/hyperdrive-js-core/src/hyperwasm.ts
+++ b/packages/hyperdrive-js-core/src/hyperwasm.ts
@@ -1,7 +1,7 @@
 // NOTE: Make sure to add the hyperwasm version number to the end of the import. Adding a query parameter to the import path will cause the esm cache to be invalidated and the latest version of the wasm package will be loaded.
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import * as hyperwasm from "@delvtech/hyperdrive-wasm?v0.9.1";
+import * as hyperwasm from "@delvtech/hyperdrive-wasm?v0.11.0";
 
 hyperwasm.initSync(hyperwasm.wasmBuffer);
 

--- a/packages/hyperdrive-js-core/vite.config.ts
+++ b/packages/hyperdrive-js-core/vite.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   plugins: [tsconfigPaths()],
   test: {
     alias: {
-      "@delvtech/hyperdrive-wasm?v0.9.1": "@delvtech/hyperdrive-wasm",
+      "@delvtech/hyperdrive-wasm?v0.11.0": "@delvtech/hyperdrive-wasm",
     },
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1485,9 +1485,9 @@
     lru-cache "^10.0.1"
 
 "@delvtech/hyperdrive-wasm@^0.11.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@delvtech/hyperdrive-wasm/-/hyperdrive-wasm-0.10.0.tgz#805eed7d405faccc9cffdc87abd7d0c2c4fa52ff"
-  integrity sha512-0gGn8Wbu5D70DFXeTgPYUd/ejPVVFLnDCC3zFgzOMbsh88wrxLfp/LM3SXHKfI6pETcMZOaw0E4rhyn4FpZWEQ==
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@delvtech/hyperdrive-wasm/-/hyperdrive-wasm-0.11.0.tgz#9aaff670283a1eb93cf50bf5eca5050db5309e28"
+  integrity sha512-tYDs2sLpeVFN7Dxg7Dd27xjLsnW8vsj+tlDoYUiOvnizicC8kvjYnZjcE90M+yPcMBjqqu5dtiXxltULj6s/BQ==
 
 "@discoveryjs/json-ext@0.5.7":
   version "0.5.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1484,10 +1484,10 @@
     fast-safe-stringify "^2.1.1"
     lru-cache "^10.0.1"
 
-"@delvtech/hyperdrive-wasm@^0.9.1":
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/@delvtech/hyperdrive-wasm/-/hyperdrive-wasm-0.9.1.tgz#29f8b5c45d2d8190ab92bbda76d43729dda020e6"
-  integrity sha512-DntJqQsMEcMJB+EbspceFyfwuWAgth8S1md4w43CTAKPgDpnNkYrZfzoFtGQY6hSvqcj1KTnpE+N9hSxcUzUMA==
+"@delvtech/hyperdrive-wasm@^0.11.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@delvtech/hyperdrive-wasm/-/hyperdrive-wasm-0.10.0.tgz#805eed7d405faccc9cffdc87abd7d0c2c4fa52ff"
+  integrity sha512-0gGn8Wbu5D70DFXeTgPYUd/ejPVVFLnDCC3zFgzOMbsh88wrxLfp/LM3SXHKfI6pETcMZOaw0E4rhyn4FpZWEQ==
 
 "@discoveryjs/json-ext@0.5.7":
   version "0.5.7"


### PR DESCRIPTION
This also updates a few of the hyperwasm function names that changed in v0.10.0:
- getSpotRate -> spotRate
- getSpotPrice -> spotPrice
- getIdleShareReservesInBase -> idleShareReservesInBase

More details here: https://github.com/delvtech/hyperdrive-bindings/pull/85/files