### PR TITLE
Add groupings to Market Stats

### DIFF
--- a/apps/hyperdrive-trading/index.html
+++ b/apps/hyperdrive-trading/index.html
@@ -9,7 +9,7 @@
   <body>
     <div id="root" class=""></div>
     <svg
-      class="pointer-events-none absolute top-0 z-0 mx-auto mt-20 w-full opacity-50"
+      class="pointer-events-none absolute top-0 z-0 mx-auto mt-20 w-full opacity-30"
       width="1440"
       height="524"
       viewBox="0 0 1440 524"

--- a/apps/hyperdrive-trading/src/ui/base/components/Well/Well.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/Well/Well.tsx
@@ -24,7 +24,7 @@ export function Well({
   const isInteractive = !disabled && (interactive || onClick);
   const className = classNames(
     "daisy-card p-7 border",
-    outlined ? "border-1 border-lime" : "border-1 border-gray-700",
+    outlined ? "border-1 border-lime" : "border-1 border-neutral-content/20",
     {
       "shadow-md": elevation === "elevated",
       "bg-base-200": !transparent,

--- a/apps/hyperdrive-trading/src/ui/markets/MarketDetailsBody/MarketDetailsBody.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketDetailsBody/MarketDetailsBody.tsx
@@ -1,11 +1,13 @@
 import { HyperdriveConfig } from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
 import CustomBanner from "src/ui/base/components/CustomBanner";
+import { Well } from "src/ui/base/components/Well/Well";
 import { useMarketState } from "src/ui/hyperdrive/hooks/useMarketState";
 import { LongsShortsLpTabs } from "src/ui/markets/LongsShortsLpTabs/LongsShortsLpTabs";
 import { MarketBreadcrumbs } from "src/ui/markets/MarketDetailsBody/MarketBreadcrumbs";
 import { MarketHeader } from "src/ui/markets/MarketDetailsBody/MarketHeader";
-import { MarketStats } from "src/ui/markets/MarketStats/MarketStats";
+import { LiquidityStats } from "src/ui/markets/MarketStats/LiquidityStats";
+import { YieldStats } from "src/ui/markets/MarketStats/YieldStats";
 import { TransactionAndFaqTabs } from "src/ui/markets/TransactionsAndFaqTabs/TransactionsAndFaqTabs";
 import { YourBalanceWell } from "src/ui/markets/YourBalanceWell/YourBalanceWell";
 import { useAccount } from "wagmi";
@@ -28,8 +30,22 @@ export function MarketDetailsBody({
         {!account ? undefined : <YourBalanceWell hyperdrive={hyperdrive} />}
       </div>
 
-      {/* Stats row */}
-      <MarketStats hyperdrive={hyperdrive} />
+      {/* Stats section */}
+      <div className="flex flex-wrap gap-16 ">
+        <Well transparent>
+          <div className="space-y-6">
+            <h5 className="flex items-center gap-2 text-gray-400">Yield</h5>
+            <YieldStats hyperdrive={hyperdrive} />
+          </div>
+        </Well>
+        <Well transparent>
+          <div className="space-y-6">
+            <h5 className="flex items-center gap-2 text-gray-400">Liquidity</h5>
+            <LiquidityStats hyperdrive={hyperdrive} />
+          </div>
+        </Well>
+      </div>
+
       {marketState?.isPaused && (
         <CustomBanner description="This market has been paused. You may close your positions, but no new positions may be opened." />
       )}

--- a/apps/hyperdrive-trading/src/ui/markets/MarketDetailsBody/MarketHeader.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketDetailsBody/MarketHeader.tsx
@@ -46,7 +46,7 @@ export function MarketHeader({
           </div>
           {hyperdrive.name}
         </h1>{" "}
-        <div className="flex w-full items-center gap-8">
+        <div className="flex w-full flex-wrap items-center gap-8">
           <PriceBadges hyperdrive={hyperdrive} />
           {analyticsUrl ? (
             <a

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/LiquidityStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/LiquidityStats.tsx
@@ -6,13 +6,10 @@ import { Stat } from "src/ui/base/components/Stat";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { formatCompact } from "src/ui/base/formatting/formatCompact";
 import { useIsTailwindSmallScreen } from "src/ui/base/mediaBreakpoints";
-import { useCurrentFixedAPR } from "src/ui/hyperdrive/hooks/useCurrentFixedAPR";
 import { useLiquidity } from "src/ui/hyperdrive/hooks/useLiquidity";
-import { useLpApy } from "src/ui/hyperdrive/hooks/useLpApy";
 import { useTradingVolume } from "src/ui/hyperdrive/hooks/useTradingVolume";
-import { useYieldSourceRate } from "src/ui/vaults/useYieldSourceRate";
 import { useBlockNumber } from "wagmi";
-export function MarketStats({
+export function LiquidityStats({
   hyperdrive,
 }: {
   hyperdrive: HyperdriveConfig;
@@ -32,89 +29,31 @@ export function MarketStats({
     hyperdriveAddress: hyperdrive.address,
     decimals: baseToken.decimals,
   });
-  const { fixedAPR, fixedAPRStatus } = useCurrentFixedAPR(hyperdrive.address);
-  const { lpApy, lpApyStatus } = useLpApy(hyperdrive.address);
-
-  const { vaultRate, vaultRateStatus } = useYieldSourceRate({
-    hyperdriveAddress: hyperdrive.address,
-  });
 
   return (
-    <div className="grid grid-cols-2 gap-6 border-y border-neutral-content/20 py-8 sm:grid-cols-3 lg:grid-cols-5">
-      <Stat
-        label="Yield Source APY"
+    <div className="flex gap-16">
+      {/* TODO: Add this stat in next PR */}
+      {/* <Stat
+        label="Total (DAI)"
         value={
-          vaultRateStatus === "loading" && vaultRate === undefined ? (
-            <Skeleton className="w-20" />
-          ) : (
-            <div className="flex flex-row">{vaultRate?.formatted || 0}%</div>
-          )
-        }
-        description={`The yield source backing the hy${baseToken.symbol} in this pool.`}
-        tooltipPosition={"right"}
-      />
-      <Stat
-        label="Fixed APR"
-        value={
-          fixedAPRStatus === "loading" && fixedAPR === undefined ? (
-            <Skeleton className="w-20" />
-          ) : (
-            <span className="flex items-center gap-1.5">
-              {fixedAPR?.formatted || "0"}%
-            </span>
-          )
-        }
-        description="Fixed rate earned from opening longs, before fees and slippage are applied."
-      />
-      <Stat
-        label="LP APY (7d)"
-        value={
-          lpApyStatus !== "loading" ? (
-            <span className="flex items-center gap-1.5">
-              {lpApy === undefined
-                ? "no data"
-                : `${(lpApy * 100).toFixed(2) === "-0.00" ? "0.00" : (lpApy * 100).toFixed(2)}%`}{" "}
-            </span>
-          ) : (
-            <Skeleton className="w-20" />
-          )
-        }
-        description={`The LP's annual return projection assuming the past 7-day performance rate continues for a year.`}
-        tooltipPosition={isTailwindSmallScreen ? "right" : "bottom"}
-      />
-      <Stat
-        description={`The amount of hy${
-          baseToken.symbol
-        } (either longs or shorts) that have been traded in the last 24 hours.\n\nLong volume: ${formatBalance(
-          {
-            balance: longVolume || 0n,
-            decimals: baseToken.decimals,
-            places: baseToken.places,
-          },
-        )} hy${baseToken.symbol} \nShort volume: ${formatBalance({
-          balance: shortVolume || 0n,
-          decimals: baseToken.decimals,
-          places: baseToken.places,
-        })} hy${baseToken.symbol}`}
-        tooltipPosition={isTailwindSmallScreen ? "left" : "bottom"}
-        label="Volume (24h)"
-        value={
-          tradingVolumeStatus === "loading" && totalVolume === undefined ? (
-            <Skeleton className="w-20" />
-          ) : (
-            <AmountLabel
-              symbol={`hy${baseToken.symbol}`}
-              value={formatCompact({
-                value: totalVolume || 0n,
+          <AmountLabel
+            icon={baseToken.iconUrl || ""}
+            symbol={baseToken.symbol}
+            value={
+              // TODO: Wire this up
+              formatCompact({
+                value: parseUnits("517826", 18) || 0n,
                 decimals: baseToken.decimals,
-              })}
-            />
-          )
+              })
+            }
+          />
         }
-      />
+        description={`The present value in the pool`}
+        tooltipPosition={isTailwindSmallScreen ? "right" : "bottom"}
+      /> */}
       <Stat
-        label="Available Liquidity"
-        description={`The amount of capital that has been deployed by LPs in the pool.`}
+        label={`Available (${baseToken.symbol})`}
+        description={`The amount of liquidity available for trading`}
         value={
           liquidityStatus === "loading" && liquidity === undefined ? (
             <Skeleton className="w-20" />
@@ -131,13 +70,42 @@ export function MarketStats({
         }
         tooltipPosition={isTailwindSmallScreen ? "right" : "left"}
       />
+      <Stat
+        description={`The amount of hy${
+          baseToken.symbol
+        } (either longs or shorts) that have been traded in the last 24 hours.\n\nLong volume: ${formatBalance(
+          {
+            balance: longVolume || 0n,
+            decimals: baseToken.decimals,
+            places: baseToken.places,
+          },
+        )} hy${baseToken.symbol} \nShort volume: ${formatBalance({
+          balance: shortVolume || 0n,
+          decimals: baseToken.decimals,
+          places: baseToken.places,
+        })} hy${baseToken.symbol}`}
+        tooltipPosition={isTailwindSmallScreen ? "left" : "bottom"}
+        label={`hy${baseToken.symbol} Volume (24h)`}
+        value={
+          tradingVolumeStatus === "loading" && totalVolume === undefined ? (
+            <Skeleton className="w-20" />
+          ) : (
+            <AmountLabel
+              symbol={`hy${baseToken.symbol}`}
+              value={formatCompact({
+                value: totalVolume || 0n,
+                decimals: baseToken.decimals,
+              })}
+            />
+          )
+        }
+      />
     </div>
   );
 }
 
 function AmountLabel({
   value,
-  symbol,
   icon,
   tooltip,
 }: {
@@ -154,11 +122,8 @@ function AmountLabel({
         "daisy-tooltip daisy-tooltip-bottom flex flex-row items-center justify-start before:whitespace-pre-wrap before:font-normal before:content-[attr(data-tip)]"
       }
     >
+      {icon ? <img src={icon} className="h-7 rounded-full  p-1" /> : undefined}
       {value}
-      <span className="ml-1">{symbol}</span>
-      {icon ? (
-        <img src={icon} className="ml-1 h-8 rounded-full  p-1" />
-      ) : undefined}
     </p>
   );
 }

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/YieldStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/YieldStats.tsx
@@ -1,0 +1,74 @@
+import { HyperdriveConfig, findBaseToken } from "@hyperdrive/appconfig";
+import { ReactElement } from "react";
+import Skeleton from "react-loading-skeleton";
+import { useAppConfig } from "src/ui/appconfig/useAppConfig";
+import { Stat } from "src/ui/base/components/Stat";
+import { useIsTailwindSmallScreen } from "src/ui/base/mediaBreakpoints";
+import { useCurrentFixedAPR } from "src/ui/hyperdrive/hooks/useCurrentFixedAPR";
+import { useLpApy } from "src/ui/hyperdrive/hooks/useLpApy";
+import { useYieldSourceRate } from "src/ui/vaults/useYieldSourceRate";
+export function YieldStats({
+  hyperdrive,
+}: {
+  hyperdrive: HyperdriveConfig;
+}): ReactElement {
+  const isTailwindSmallScreen = useIsTailwindSmallScreen();
+  const appConfig = useAppConfig();
+  const baseToken = findBaseToken({
+    baseTokenAddress: hyperdrive.baseToken,
+    tokens: appConfig.tokens,
+  });
+
+  const { fixedAPR, fixedAPRStatus } = useCurrentFixedAPR(hyperdrive.address);
+  const { lpApy, lpApyStatus } = useLpApy(hyperdrive.address);
+
+  const { vaultRate, vaultRateStatus } = useYieldSourceRate({
+    hyperdriveAddress: hyperdrive.address,
+  });
+
+  return (
+    <div className="flex flex-wrap gap-16">
+      <Stat
+        label="Fixed APR"
+        value={
+          fixedAPRStatus === "loading" && fixedAPR === undefined ? (
+            <Skeleton className="w-20" />
+          ) : (
+            <span className="flex items-center gap-1.5">
+              {fixedAPR?.formatted || "0"}%
+            </span>
+          )
+        }
+        description="Fixed rate earned from opening longs, before fees and slippage are applied."
+      />
+      <Stat
+        label="Yield Source APY"
+        value={
+          vaultRateStatus === "loading" && vaultRate === undefined ? (
+            <Skeleton className="w-20" />
+          ) : (
+            <div className="flex flex-row">{vaultRate?.formatted || 0}%</div>
+          )
+        }
+        description={`The yield source backing the hy${baseToken.symbol} in this pool.`}
+        tooltipPosition={"right"}
+      />
+      <Stat
+        label="LP APY (7d)"
+        value={
+          lpApyStatus !== "loading" ? (
+            <span className="flex items-center gap-1.5">
+              {lpApy === undefined
+                ? "no data"
+                : `${(lpApy * 100).toFixed(2) === "-0.00" ? "0.00" : (lpApy * 100).toFixed(2)}%`}{" "}
+            </span>
+          ) : (
+            <Skeleton className="w-20" />
+          )
+        }
+        description={`The LP's annual return projection assuming the past 7-day performance rate continues for a year.`}
+        tooltipPosition={isTailwindSmallScreen ? "right" : "bottom"}
+      />
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "postinstall": "husky install",
     "typecheck": "turbo run typecheck",
     "reset-node-modules": "find . -name 'node_modules' -type d -prune -exec rm -rf '{}' + && yarn cache clean && yarn",
-    "new-hyperwasm-just-dropped": "reset-node-modules && rm -rf packages/{hyperdrive-js-core,hyperdrive-viem}/dist && yarn workspace @delvtech/hyperdrive-js-core run build && yarn workspace @delvtech/hyperdrive-viem run build",
+    "new-hyperwasm-just-dropped": "yarn run reset-node-modules && rm -rf packages/{hyperdrive-js-core,hyperdrive-viem}/dist && yarn workspace @delvtech/hyperdrive-js-core run build && yarn workspace @delvtech/hyperdrive-viem run build",
     "release": "yarn build:packages && changeset publish"
   },
   "devDependencies": {


### PR DESCRIPTION
Related to #977 

This PR adds logical groups to the market stats. In the next PR,I'll add the present value stat (aka: Total liquidity) under the Liquidity section.

<img width="1471" alt="image" src="https://github.com/delvtech/hyperdrive-frontend/assets/4524175/16c8e4cc-d3f2-401d-bdf6-24f4c08ab067">
