### PR TITLE
Add `getPresentValue` to ReadHyperdrive

### DIFF
--- a/apps/hyperdrive-sdk-docs/docs/sdk/index.md
+++ b/apps/hyperdrive-sdk-docs/docs/sdk/index.md
@@ -13,9 +13,13 @@ AMM](https://www.github.com/delvtech/hyperdrive).
 The SDK has been designed to seamlessly integrate with multiple web3 libraries.
 Choose one below to get started:
 
-- [Viem Quickstart](#viem-quickstart)
-- [Ethers Quickstart](#ethers-quickstart)
-- [Web3.js Quickstart](#web3js-quickstart)
+- [Getting Started](#getting-started)
+  - [Viem Quickstart](#viem-quickstart)
+    - [Install](#install)
+    - [Using the `ReadHyperdrive`](#using-the-readhyperdrive)
+    - [Using the `ReadWriteHyperdrive`](#using-the-readwritehyperdrive)
+  - [Ethers Quickstart](#ethers-quickstart)
+  - [Web3.js Quickstart](#web3js-quickstart)
 
 ## Viem Quickstart
 
@@ -50,7 +54,7 @@ const hyperdrive = createReadHyperdrive({
 });
 
 // 3. Get data from the contracts
-const liquidity = await hyperdrive.getLiquidity();
+const liquidity = await hyperdrive.getIdleLiquidity();
 ```
 
 ### Using the `ReadWriteHyperdrive`

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useLiquidity.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useLiquidity.ts
@@ -25,7 +25,7 @@ export function useLiquidity({
     queryKey: makeQueryKey("liquidity", { hyperdriveAddress }),
     queryFn: queryEnabled
       ? async () => {
-          const liquidity = await readHyperdrive.getLiquidity();
+          const liquidity = await readHyperdrive.getIdleLiquidity();
           return {
             liquidity: liquidity,
             formatted: dnum.format([liquidity, decimals], { digits: 0 }),

--- a/apps/hyperdrive-trading/src/ui/markets/AllMarketsTable/useMarketRowData.ts
+++ b/apps/hyperdrive-trading/src/ui/markets/AllMarketsTable/useMarketRowData.ts
@@ -49,7 +49,7 @@ export function useMarketRowData(): UseQueryResult<MarketTableRowData[]> {
                   baseTokenAddress: hyperdrive.baseToken,
                   tokens: appConfig.tokens,
                 });
-                const liquidity = await readHyperdrive.getLiquidity();
+                const liquidity = await readHyperdrive.getIdleLiquidity();
 
                 const longApr = await readHyperdrive.getSpotRate();
 

--- a/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
@@ -159,7 +159,7 @@ export class ReadHyperdrive extends ReadModel {
   /**
    * This function retrieves the available market liquidity
    */
-  async getLiquidity(options?: ContractReadOptions): Promise<bigint> {
+  async getIdleLiquidity(options?: ContractReadOptions): Promise<bigint> {
     const poolConfig = await this.getPoolConfig(options);
     const poolInfo = await this.getPoolInfo(options);
 

--- a/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
@@ -181,7 +181,7 @@ export class ReadHyperdrive extends ReadModel {
     const poolConfig = await this.getPoolConfig(options);
     const poolInfo = await this.getPoolInfo(options);
 
-    const liquidityString = hyperwasm.getPresentValue(
+    const liquidityString = hyperwasm.presentValue(
       convertBigIntsToStrings(poolInfo),
       convertBigIntsToStrings(poolConfig),
       Math.floor(Date.now() / 1000).toString(),
@@ -823,7 +823,7 @@ export class ReadHyperdrive extends ReadModel {
     const stringifiedPoolInfo = convertBigIntsToStrings(poolInfo);
     const stringifiedPoolConfig = convertBigIntsToStrings(poolConfig);
 
-    const maxBondsOut = hyperwasm.getMaxShort(
+    const maxBondsOut = hyperwasm.maxShort(
       stringifiedPoolInfo,
       stringifiedPoolConfig,
       MAX_UINT256.toString(),
@@ -875,7 +875,7 @@ export class ReadHyperdrive extends ReadModel {
     const stringifiedPoolInfo = convertBigIntsToStrings(poolInfo);
     const stringifiedPoolConfig = convertBigIntsToStrings(poolConfig);
 
-    const maxBaseIn = hyperwasm.getMaxLong(
+    const maxBaseIn = hyperwasm.maxLong(
       stringifiedPoolInfo,
       stringifiedPoolConfig,
       MAX_UINT256.toString(),
@@ -1204,7 +1204,7 @@ export class ReadHyperdrive extends ReadModel {
     }
 
     const spotPriceAfterOpen = BigInt(
-      hyperwasm.calcSpotPriceAfterLong(
+      hyperwasm.spotPriceAfterLong(
         convertBigIntsToStrings(poolInfo),
         convertBigIntsToStrings(poolConfig),
         depositAmountConvertedToBase.toString(),
@@ -1231,7 +1231,7 @@ export class ReadHyperdrive extends ReadModel {
     );
 
     const curveFeeInBonds = BigInt(
-      hyperwasm.getOpenLongCurveFees(
+      hyperwasm.openLongCurveFee(
         convertBigIntsToStrings(poolInfo),
         convertBigIntsToStrings(poolConfig),
         depositAmountConvertedToBase.toString(),
@@ -1304,7 +1304,7 @@ export class ReadHyperdrive extends ReadModel {
     }
 
     const spotPriceAfterOpen = BigInt(
-      hyperwasm.calcSpotPriceAfterShort(
+      hyperwasm.spotPriceAfterShort(
         convertBigIntsToStrings(poolInfo),
         convertBigIntsToStrings(poolConfig),
         amountOfBondsToShort.toString(),
@@ -1325,11 +1325,11 @@ export class ReadHyperdrive extends ReadModel {
     )[0];
 
     const curveFeeInBase = BigInt(
-      hyperwasm.getOpenShortCurveFees(
+      hyperwasm.openShortCurveFee(
         convertBigIntsToStrings(poolInfo),
         convertBigIntsToStrings(poolConfig),
         amountOfBondsToShort.toString(),
-        hyperwasm.getSpotPrice(
+        hyperwasm.spotPrice(
           convertBigIntsToStrings(poolInfo),
           convertBigIntsToStrings(poolConfig),
         ),

--- a/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
@@ -157,7 +157,8 @@ export class ReadHyperdrive extends ReadModel {
   }
 
   /**
-   * This function retrieves the available market liquidity
+   * This function retrieves the market liquidity available for trading and LP
+   * removal
    */
   async getIdleLiquidity(options?: ContractReadOptions): Promise<bigint> {
     const poolConfig = await this.getPoolConfig(options);
@@ -166,6 +167,24 @@ export class ReadHyperdrive extends ReadModel {
     const liquidityString = hyperwasm.idleShareReservesInBase(
       convertBigIntsToStrings(poolInfo),
       convertBigIntsToStrings(poolConfig),
+    );
+
+    return BigInt(liquidityString);
+  }
+
+  /**
+   * Gets the total present value of the pool.
+   * @param options
+   * @returns
+   */
+  async getPresentValue(options?: ContractReadOptions): Promise<bigint> {
+    const poolConfig = await this.getPoolConfig(options);
+    const poolInfo = await this.getPoolInfo(options);
+
+    const liquidityString = hyperwasm.getPresentValue(
+      convertBigIntsToStrings(poolInfo),
+      convertBigIntsToStrings(poolConfig),
+      Math.floor(Date.now() / 1000).toString(),
     );
 
     return BigInt(liquidityString);


### PR DESCRIPTION
Depends on https://github.com/delvtech/hyperdrive-bindings/pull/96

Related to #977 

Adding the ReadHyperdrive method for `getPresentValue` so we can display Total Liquidity in the All Markets table and in the market details pages.

While here I fixed a few spots where hyperwasm name had changed from our previous version. See #989 for original work. 