### PR TITLE
separate market impact and term

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
@@ -91,44 +91,52 @@ export function OpenShortPreview({
           </span>
         }
       />
-      <LabelValue
-        label="Fixed APR after open"
-        value={
-          <span
-            className={classNames(
-              "daisy-tooltip daisy-tooltip-top daisy-tooltip-left cursor-help before:border",
-              { "border-b border-dashed border-current": spotRateAfterOpen },
-            )}
-            data-tip="The market fixed rate after opening the short."
-          >
-            {spotRateAfterOpen ? `${formatRate(spotRateAfterOpen)}% APR` : "-"}
-          </span>
-        }
-      />
-      <LabelValue
-        label="Fixed APR impact"
-        value={
-          <span
-            className={classNames(
-              "daisy-tooltip daisy-tooltip-top daisy-tooltip-left cursor-help  before:border",
-              {
-                "border-b border-dashed border-success text-success":
-                  spotRateAfterOpen,
-              },
-            )}
-            data-tip={`The net market impact on the fixed rate after opening the short.`}
-          >
-            {getMarketImpactLabel(fixedAPR?.apr, spotRateAfterOpen)}
-          </span>
-        }
-      />
+      <div className="flex flex-col gap-3">
+        <h6 className="font-medium">Market Impact</h6>
+        <LabelValue
+          label="Fixed APR after open"
+          value={
+            <span
+              className={classNames(
+                "daisy-tooltip daisy-tooltip-top daisy-tooltip-left cursor-help before:border",
+                { "border-b border-dashed border-current": spotRateAfterOpen },
+              )}
+              data-tip="The market fixed rate after opening the short."
+            >
+              {spotRateAfterOpen
+                ? `${formatRate(spotRateAfterOpen)}% APR`
+                : "-"}
+            </span>
+          }
+        />
+        <LabelValue
+          label="Fixed APR impact"
+          value={
+            <span
+              className={classNames(
+                "daisy-tooltip daisy-tooltip-top daisy-tooltip-left cursor-help  before:border",
+                {
+                  "border-b border-dashed border-success text-success":
+                    spotRateAfterOpen,
+                },
+              )}
+              data-tip={`The net market impact on the fixed rate after opening the short.`}
+            >
+              {getMarketImpactLabel(fixedAPR?.apr, spotRateAfterOpen)}
+            </span>
+          }
+        />
+      </div>
 
-      <LabelValue
-        label="Matures in"
-        value={`${convertMillisecondsToDays(termLengthMS)} days, ${formatDate(
-          Date.now() + termLengthMS,
-        )}`}
-      />
+      <div className="flex flex-col gap-3">
+        <h6 className="font-medium">Term</h6>
+        <LabelValue
+          label="Matures in"
+          value={`${convertMillisecondsToDays(termLengthMS)} days, ${formatDate(
+            Date.now() + termLengthMS,
+          )}`}
+        />
+      </div>
     </div>
   );
 }

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
@@ -132,9 +132,12 @@ export function OpenShortPreview({
         <h6 className="font-medium">Term</h6>
         <LabelValue
           label="Matures in"
-          value={`${convertMillisecondsToDays(termLengthMS)} days, ${formatDate(
-            Date.now() + termLengthMS,
-          )}`}
+          value={`${convertMillisecondsToDays(termLengthMS)} days
+          `}
+        />
+        <LabelValue
+          label="Matures on"
+          value={`${formatDate(Date.now() + termLengthMS)}`}
         />
       </div>
     </div>


### PR DESCRIPTION
This PR separates the market impact and term into new sections in the OpenShortPreview:
![image](https://github.com/delvtech/hyperdrive-frontend/assets/22210106/41adc663-2083-40b2-b072-fb75636fb65a)
