### PR TITLE
Upgrade hyperwasm to v0.13.0, add getImpliedRate to ReadHyperdrive, add stat to Yield section

### DIFF
--- a/apps/hyperdrive-trading/src/base/formatRate.test.ts
+++ b/apps/hyperdrive-trading/src/base/formatRate.test.ts
@@ -1,0 +1,29 @@
+import { formatRate } from "src/base/formatRate";
+import { parseUnits } from "viem";
+import { expect, test } from "vitest";
+
+test("formatRate should return positive bigints formatted as a percent", async () => {
+  const value = formatRate(parseUnits("1", 18), 18);
+  expect(value).toEqual("100.00");
+
+  // rounds down
+  const value2 = formatRate(parseUnits("0.056721", 18), 18);
+  expect(value2).toEqual("5.67");
+
+  // rounds up
+  const value3 = formatRate(parseUnits("0.056781", 18), 18);
+  expect(value3).toEqual("5.68");
+});
+
+test("formatRate should return negative bigints formatted as a percent", async () => {
+  const value = formatRate(parseUnits("-1", 18), 18);
+  expect(value).toEqual("-100.00");
+
+  // rounds down
+  const value2 = formatRate(parseUnits("-1.0281219", 18), 18);
+  expect(value2).toEqual("-102.81");
+
+  // rounds up
+  const value3 = formatRate(parseUnits("-0.0297902", 18), 18);
+  expect(value3).toEqual("-2.98");
+});

--- a/apps/hyperdrive-trading/src/base/formatRate.ts
+++ b/apps/hyperdrive-trading/src/base/formatRate.ts
@@ -1,10 +1,6 @@
 import { formatUnits } from "viem";
 
 export function formatRate(rate: bigint, decimals = 18): string {
-  if (rate < 0n) {
-    return "0";
-  }
-
   // APR is stored in 18 decimals, so to avoid rounding errors, eg:
   // 0.049999999999999996 * 100 = 5, we just take the first 10 characters after
   // the decimal, and format those to a percent, eg: 0.0499999999 * 100 = 4.99.

--- a/apps/hyperdrive-trading/src/ui/app/Navbar/FeatureFlagPicker.tsx
+++ b/apps/hyperdrive-trading/src/ui/app/Navbar/FeatureFlagPicker.tsx
@@ -13,6 +13,10 @@ export function FeatureFlagPicker(): ReactElement {
       >
         <li className="daisy-menu-title">Feature flags</li>
         {/* Place your feature flag menu items here */}
+        {/* TODO: Remove implied-yield once calculation is fixed in rust sdk */}
+        <FeatureFlagMenuItem flagName={"implied-yield"}>
+          Show Implied Yield
+        </FeatureFlagMenuItem>
       </ul>
     </div>
   );

--- a/apps/hyperdrive-trading/src/ui/base/components/Badge.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/Badge.tsx
@@ -1,0 +1,9 @@
+import { PropsWithChildren, ReactElement } from "react";
+
+export function Badge({ children }: PropsWithChildren): ReactElement {
+  return (
+    <div className="daisy-badge daisy-badge-neutral daisy-badge-lg py-4">
+      {children}
+    </div>
+  );
+}

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useImpliedRate.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useImpliedRate.ts
@@ -1,0 +1,51 @@
+import { useQuery } from "@tanstack/react-query";
+import { makeQueryKey } from "src/base/makeQueryKey";
+import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
+import { Address } from "viem";
+interface UseImpliedRateOptions {
+  account: Address | undefined;
+  hyperdriveAddress: Address | undefined;
+  bondAmount: bigint | undefined;
+  openVaultSharePrice: bigint | undefined;
+  variableApy: bigint | undefined;
+}
+
+/**
+ * Returns the list of shorts that the account currently has open.
+ */
+export function useImpliedRate({
+  bondAmount,
+  openVaultSharePrice,
+  variableApy,
+  hyperdriveAddress,
+}: UseImpliedRateOptions): {
+  impliedRate: bigint | undefined;
+  impledRateStatus: "error" | "success" | "loading";
+} {
+  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
+  const queryEnabled =
+    !!readHyperdrive &&
+    bondAmount !== undefined &&
+    openVaultSharePrice !== undefined &&
+    variableApy !== undefined;
+
+  const { data: impliedRate, status: impliedRateStatus } = useQuery({
+    queryKey: makeQueryKey("impliedRate", {
+      hyperdriveAddress,
+      bondAmount: bondAmount?.toString(),
+      openVaultSharePrice: openVaultSharePrice?.toString(),
+      variableApy: variableApy?.toString(),
+    }),
+    queryFn: queryEnabled
+      ? async () =>
+          await readHyperdrive.getImpliedRate({
+            bondAmount,
+            openVaultSharePrice,
+            variableApy,
+          })
+      : undefined,
+    enabled: queryEnabled,
+  });
+
+  return { impliedRate, impledRateStatus: impliedRateStatus };
+}

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useImpliedRate.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useImpliedRate.ts
@@ -3,10 +3,9 @@ import { makeQueryKey } from "src/base/makeQueryKey";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
 interface UseImpliedRateOptions {
-  account: Address | undefined;
   hyperdriveAddress: Address | undefined;
   bondAmount: bigint | undefined;
-  openVaultSharePrice: bigint | undefined;
+  timestamp: bigint | undefined;
   variableApy: bigint | undefined;
 }
 
@@ -15,37 +14,39 @@ interface UseImpliedRateOptions {
  */
 export function useImpliedRate({
   bondAmount,
-  openVaultSharePrice,
+  timestamp,
   variableApy,
   hyperdriveAddress,
 }: UseImpliedRateOptions): {
   impliedRate: bigint | undefined;
-  impledRateStatus: "error" | "success" | "loading";
+  impliedRateStatus: "error" | "success" | "loading";
 } {
   const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
   const queryEnabled =
     !!readHyperdrive &&
     bondAmount !== undefined &&
-    openVaultSharePrice !== undefined &&
+    timestamp !== undefined &&
     variableApy !== undefined;
 
   const { data: impliedRate, status: impliedRateStatus } = useQuery({
     queryKey: makeQueryKey("impliedRate", {
       hyperdriveAddress,
       bondAmount: bondAmount?.toString(),
-      openVaultSharePrice: openVaultSharePrice?.toString(),
+      timestamp: timestamp?.toString(),
       variableApy: variableApy?.toString(),
     }),
     queryFn: queryEnabled
-      ? async () =>
-          await readHyperdrive.getImpliedRate({
+      ? async () => {
+          const result = await readHyperdrive.getImpliedRate({
             bondAmount,
-            openVaultSharePrice,
+            timestamp,
             variableApy,
-          })
+          });
+          return result;
+        }
       : undefined,
     enabled: queryEnabled,
   });
 
-  return { impliedRate, impledRateStatus: impliedRateStatus };
+  return { impliedRate, impliedRateStatus };
 }

--- a/apps/hyperdrive-trading/src/ui/markets/MarketDetailsBody/MarketDetailsBody.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketDetailsBody/MarketDetailsBody.tsx
@@ -1,7 +1,6 @@
 import { HyperdriveConfig } from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
 import CustomBanner from "src/ui/base/components/CustomBanner";
-import { Well } from "src/ui/base/components/Well/Well";
 import { useMarketState } from "src/ui/hyperdrive/hooks/useMarketState";
 import { LongsShortsLpTabs } from "src/ui/markets/LongsShortsLpTabs/LongsShortsLpTabs";
 import { MarketBreadcrumbs } from "src/ui/markets/MarketDetailsBody/MarketBreadcrumbs";
@@ -32,18 +31,8 @@ export function MarketDetailsBody({
 
       {/* Stats section */}
       <div className="flex flex-wrap gap-16 ">
-        <Well transparent>
-          <div className="space-y-6">
-            <h5 className="flex items-center gap-2 text-gray-400">Yield</h5>
-            <YieldStats hyperdrive={hyperdrive} />
-          </div>
-        </Well>
-        <Well transparent>
-          <div className="space-y-6">
-            <h5 className="flex items-center gap-2 text-gray-400">Liquidity</h5>
-            <LiquidityStats hyperdrive={hyperdrive} />
-          </div>
-        </Well>
+        <YieldStats hyperdrive={hyperdrive} />
+        <LiquidityStats hyperdrive={hyperdrive} />
       </div>
 
       {marketState?.isPaused && (

--- a/apps/hyperdrive-trading/src/ui/markets/MarketDetailsBody/PriceBadges.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketDetailsBody/PriceBadges.tsx
@@ -4,6 +4,7 @@ import Skeleton from "react-loading-skeleton";
 import { divideBigInt } from "src/base/divideBigInt";
 import { parseUnits } from "src/base/parseUnits";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
+import { Badge } from "src/ui/base/components/Badge";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { useCurrentLongPrice } from "src/ui/hyperdrive/longs/hooks/useCurrentLongPrice";
 
@@ -30,7 +31,7 @@ export function PriceBadges({
   }
   return (
     <div className="flex flex-col gap-2 font-dmMono md:flex-row md:gap-4">
-      <div className="daisy-badge daisy-badge-neutral daisy-badge-lg py-4 text-md text-neutral-content">
+      <Badge>
         1 hy{baseToken.symbol} ≈{" "}
         {formatBalance({
           balance: longPrice ?? 0n,
@@ -38,8 +39,8 @@ export function PriceBadges({
           places: baseToken.places,
         })}{" "}
         {baseToken.symbol}
-      </div>
-      <div className="daisy-badge daisy-badge-neutral daisy-badge-lg py-4 text-md text-neutral-content">
+      </Badge>
+      <Badge>
         1 {baseToken.symbol} ≈{" "}
         {formatBalance({
           balance: divideBigInt(
@@ -52,7 +53,7 @@ export function PriceBadges({
           places: baseToken.places,
         })}{" "}
         hy{baseToken.symbol}
-      </div>
+      </Badge>
     </div>
   );
 }

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/LiquidityStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/LiquidityStats.tsx
@@ -3,6 +3,7 @@ import { ReactElement } from "react";
 import Skeleton from "react-loading-skeleton";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { Stat } from "src/ui/base/components/Stat";
+import { Well } from "src/ui/base/components/Well/Well";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { formatCompact } from "src/ui/base/formatting/formatCompact";
 import { useIdleLiquidity } from "src/ui/hyperdrive/hooks/useIdleLiquidity";
@@ -33,73 +34,79 @@ export function LiquidityStats({
   });
 
   return (
-    <div className="flex gap-16">
-      <Stat
-        label={`Total (${baseToken.symbol})`}
-        value={
-          presentValueStatus === "loading" && presentValue === undefined ? (
-            <Skeleton className="w-20" />
-          ) : (
-            <AmountLabel
-              icon={baseToken.iconUrl || ""}
-              symbol={baseToken.symbol}
-              value={formatCompact({
-                value: presentValue || 0n,
+    <Well transparent>
+      <div className="space-y-8">
+        <h5 className="flex items-center gap-2 text-gray-400">Liquidity</h5>
+        <div className="flex gap-16">
+          <Stat
+            label={`Total (${baseToken.symbol})`}
+            value={
+              presentValueStatus === "loading" && presentValue === undefined ? (
+                <Skeleton className="w-20" />
+              ) : (
+                <AmountLabel
+                  icon={baseToken.iconUrl || ""}
+                  symbol={baseToken.symbol}
+                  value={formatCompact({
+                    value: presentValue || 0n,
+                    decimals: baseToken.decimals,
+                  })}
+                />
+              )
+            }
+            description={`The present value in the pool`}
+          />
+          <Stat
+            label={`Available (${baseToken.symbol})`}
+            description={`The idle liquidity available for trading and exiting LP positions`}
+            value={
+              idleLiquidityStatus === "loading" &&
+              idleLiquidity === undefined ? (
+                <Skeleton className="w-20" />
+              ) : (
+                <AmountLabel
+                  icon={baseToken.iconUrl || ""}
+                  symbol={baseToken.symbol}
+                  value={formatCompact({
+                    value: idleLiquidity || 0n,
+                    decimals: baseToken.decimals,
+                  })}
+                />
+              )
+            }
+          />
+          <Stat
+            description={`The amount of hy${
+              baseToken.symbol
+            } (either longs or shorts) that have been traded in the last 24 hours.\n\nLong volume: ${formatBalance(
+              {
+                balance: longVolume || 0n,
                 decimals: baseToken.decimals,
-              })}
-            />
-          )
-        }
-        description={`The present value in the pool`}
-      />
-      <Stat
-        label={`Available (${baseToken.symbol})`}
-        description={`The idle liquidity available for trading and exiting LP positions`}
-        value={
-          idleLiquidityStatus === "loading" && idleLiquidity === undefined ? (
-            <Skeleton className="w-20" />
-          ) : (
-            <AmountLabel
-              icon={baseToken.iconUrl || ""}
-              symbol={baseToken.symbol}
-              value={formatCompact({
-                value: idleLiquidity || 0n,
-                decimals: baseToken.decimals,
-              })}
-            />
-          )
-        }
-      />
-      <Stat
-        description={`The amount of hy${
-          baseToken.symbol
-        } (either longs or shorts) that have been traded in the last 24 hours.\n\nLong volume: ${formatBalance(
-          {
-            balance: longVolume || 0n,
-            decimals: baseToken.decimals,
-            places: baseToken.places,
-          },
-        )} hy${baseToken.symbol} \nShort volume: ${formatBalance({
-          balance: shortVolume || 0n,
-          decimals: baseToken.decimals,
-          places: baseToken.places,
-        })} hy${baseToken.symbol}`}
-        label={`24h Volume (hy${baseToken.symbol})`}
-        value={
-          tradingVolumeStatus === "loading" && totalVolume === undefined ? (
-            <Skeleton className="w-20" />
-          ) : (
-            <AmountLabel
-              symbol={`hy${baseToken.symbol}`}
-              value={formatCompact({
-                value: totalVolume || 0n,
-                decimals: baseToken.decimals,
-              })}
-            />
-          )
-        }
-      />
-    </div>
+                places: baseToken.places,
+              },
+            )} hy${baseToken.symbol} \nShort volume: ${formatBalance({
+              balance: shortVolume || 0n,
+              decimals: baseToken.decimals,
+              places: baseToken.places,
+            })} hy${baseToken.symbol}`}
+            label={`24h Volume (hy${baseToken.symbol})`}
+            value={
+              tradingVolumeStatus === "loading" && totalVolume === undefined ? (
+                <Skeleton className="w-20" />
+              ) : (
+                <AmountLabel
+                  symbol={`hy${baseToken.symbol}`}
+                  value={formatCompact({
+                    value: totalVolume || 0n,
+                    decimals: baseToken.decimals,
+                  })}
+                />
+              )
+            }
+          />
+        </div>
+      </div>
+    </Well>
   );
 }
 

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/YieldStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/YieldStats.tsx
@@ -1,10 +1,16 @@
-import { HyperdriveConfig, findBaseToken } from "@hyperdrive/appconfig";
+import {
+  HyperdriveConfig,
+  findBaseToken,
+  findYieldSourceToken,
+} from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
 import Skeleton from "react-loading-skeleton";
 import { formatRate } from "src/base/formatRate";
 import { parseUnits } from "src/base/parseUnits";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
+import { Badge } from "src/ui/base/components/Badge";
 import { Stat } from "src/ui/base/components/Stat";
+import { Well } from "src/ui/base/components/Well/Well";
 import { useFeatureFlag } from "src/ui/base/featureFlags/featureFlags";
 import { useIsTailwindSmallScreen } from "src/ui/base/mediaBreakpoints";
 import { useCurrentFixedAPR } from "src/ui/hyperdrive/hooks/useCurrentFixedAPR";
@@ -20,6 +26,10 @@ export function YieldStats({
   const appConfig = useAppConfig();
   const baseToken = findBaseToken({
     baseTokenAddress: hyperdrive.baseToken,
+    tokens: appConfig.tokens,
+  });
+  const sharesToken = findYieldSourceToken({
+    yieldSourceTokenAddress: hyperdrive.sharesToken,
     tokens: appConfig.tokens,
   });
 
@@ -40,65 +50,64 @@ export function YieldStats({
     timestamp: BigInt(Math.floor(Date.now() / 1000)),
   });
 
-  const formattedRate = impliedRate ? formatRate(impliedRate) : "-";
+  const formattedRate = impliedRate ? formatRate(impliedRate) : "0";
 
   return (
-    <div className="flex flex-wrap gap-16">
-      <Stat
-        label="Fixed APR"
-        value={
-          fixedAPRStatus === "loading" && fixedAPR === undefined ? (
-            <Skeleton className="w-20" />
-          ) : (
-            <span className="flex items-center gap-1.5">
-              {fixedAPR?.formatted || "0"}%
-            </span>
-          )
-        }
-        description="Fixed rate earned from opening longs, before fees and slippage are applied."
-      />
-      {isImpliedYieldFeatureFlagEnabled ? (
-        <Stat
-          label="Implied Variable Rate"
-          value={
-            impliedRateStatus === "loading" && impliedRate === undefined ? (
+    <Well transparent>
+      <div className="space-y-8">
+        <div className="flex justify-between gap-20">
+          <h5 className="flex items-center gap-2 text-gray-400">Yield</h5>
+          <div className="font-dmMono text-neutral-content">
+            {vaultRateStatus === "loading" && vaultRate === undefined ? (
               <Skeleton className="w-20" />
             ) : (
-              <div className="flex flex-row">{formattedRate}%</div>
-            )
-          }
-          description={`The yield source backing the hy${baseToken.symbol} in this pool.`}
-          tooltipPosition={"right"}
-        />
-      ) : undefined}
-      <Stat
-        label="Yield Source APY"
-        value={
-          vaultRateStatus === "loading" && vaultRate === undefined ? (
-            <Skeleton className="w-20" />
-          ) : (
-            <div className="flex flex-row">{vaultRate?.formatted || 0}%</div>
-          )
-        }
-        description={`The yield source backing the hy${baseToken.symbol} in this pool.`}
-        tooltipPosition={"right"}
-      />
-      <Stat
-        label="LP APY (7d)"
-        value={
-          lpApyStatus !== "loading" ? (
-            <span className="flex items-center gap-1.5">
-              {lpApy === undefined
-                ? "no data"
-                : `${(lpApy * 100).toFixed(2) === "-0.00" ? "0.00" : (lpApy * 100).toFixed(2)}%`}{" "}
-            </span>
-          ) : (
-            <Skeleton className="w-20" />
-          )
-        }
-        description={`The LP's annual return projection assuming the past 7-day performance rate continues for a year.`}
-        tooltipPosition={isTailwindSmallScreen ? "right" : "bottom"}
-      />
-    </div>
+              <Badge>
+                {sharesToken.extensions.shortName} @ {vaultRate?.formatted || 0}
+                % APY
+              </Badge>
+            )}
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-16">
+          <Stat
+            label="Fixed APR"
+            value={
+              fixedAPRStatus === "loading" && fixedAPR === undefined ? (
+                <Skeleton className="w-20" />
+              ) : (
+                <span className="flex items-center gap-1.5">
+                  {fixedAPR?.formatted || "0"}%
+                </span>
+              )
+            }
+            description="Fixed rate earned from opening longs, before fees and slippage are applied."
+          />
+          {isImpliedYieldFeatureFlagEnabled ? (
+            <Stat
+              label="Implied Variable Rate"
+              value={`${formattedRate}%`}
+              description={`The yield source backing the hy${baseToken.symbol} in this pool.`}
+              tooltipPosition={"right"}
+            />
+          ) : undefined}
+          <Stat
+            label="LP APY (7d)"
+            value={
+              lpApyStatus !== "loading" ? (
+                <span className="flex items-center gap-1.5">
+                  {lpApy === undefined
+                    ? "no data"
+                    : `${(lpApy * 100).toFixed(2) === "-0.00" ? "0.00" : (lpApy * 100).toFixed(2)}%`}{" "}
+                </span>
+              ) : (
+                <Skeleton className="w-20" />
+              )
+            }
+            description={`The LP's annual return projection assuming the past 7-day performance rate continues for a year.`}
+            tooltipPosition={isTailwindSmallScreen ? "right" : "bottom"}
+          />
+        </div>
+      </div>
+    </Well>
   );
 }

--- a/packages/hyperdrive-js-core/package.json
+++ b/packages/hyperdrive-js-core/package.json
@@ -15,7 +15,7 @@
     "@delvtech/hyperdrive-artifacts": "^0.1.0"
   },
   "dependencies": {
-    "@delvtech/hyperdrive-wasm": "^0.12.0",
+    "@delvtech/hyperdrive-wasm": "^0.13.0",
     "lodash.groupby": "^4.6.0",
     "lodash.mapvalues": "^4.6.0"
   },

--- a/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
@@ -176,6 +176,35 @@ export class ReadHyperdrive extends ReadModel {
   }
 
   /**
+   * Gets the implied variable rate of opening a short
+   */
+  async getImpliedRate({
+    bondAmount,
+    openVaultSharePrice,
+    variableApy,
+    options,
+  }: {
+    bondAmount: bigint;
+    openVaultSharePrice: bigint;
+    // TODO: Get this from sdk instead
+    variableApy: bigint;
+    options?: ContractReadOptions;
+  }): Promise<bigint> {
+    const poolConfig = await this.getPoolConfig(options);
+    const poolInfo = await this.getPoolInfo(options);
+
+    const impliedRateString = hyperwasm.calcImpliedRate(
+      convertBigIntsToStrings(poolInfo),
+      convertBigIntsToStrings(poolConfig),
+      bondAmount.toString(),
+      openVaultSharePrice.toString(),
+      variableApy.toString(),
+    );
+
+    return BigInt(impliedRateString);
+  }
+
+  /**
    * Gets the market liquidity available for trading and removing LP.
    */
   async getIdleLiquidity(options?: ContractReadOptions): Promise<bigint> {

--- a/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
@@ -180,18 +180,26 @@ export class ReadHyperdrive extends ReadModel {
    */
   async getImpliedRate({
     bondAmount,
-    openVaultSharePrice,
+    timestamp,
     variableApy,
     options,
   }: {
     bondAmount: bigint;
-    openVaultSharePrice: bigint;
+    timestamp: bigint;
     // TODO: Get this from sdk instead
     variableApy: bigint;
     options?: ContractReadOptions;
   }): Promise<bigint> {
     const poolConfig = await this.getPoolConfig(options);
     const poolInfo = await this.getPoolInfo(options);
+
+    const checkpointId = getCheckpointId(
+      timestamp,
+      poolConfig.checkpointDuration,
+    );
+    const { vaultSharePrice: openVaultSharePrice } = await this.getCheckpoint({
+      checkpointId,
+    });
 
     const impliedRateString = hyperwasm.calcImpliedRate(
       convertBigIntsToStrings(poolInfo),

--- a/packages/hyperdrive-js-core/src/hyperdrive/steth/ReadWriteStEthHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/steth/ReadWriteStEthHyperdrive.ts
@@ -13,7 +13,7 @@ import { ReadWriteEth } from "src/token/eth/ReadWriteEth";
 import { ReadWriteStEth } from "src/token/steth/ReadWriteStEth";
 
 export interface ReadWriteStEthHyperdriveOptions
-  extends Overwrite<ReadStEthHyperdriveOptions, ReadWriteHyperdriveOptions> {}
+  extends Overwrite<ReadWriteHyperdriveOptions, ReadStEthHyperdriveOptions> {}
 
 export class ReadWriteStEthHyperdrive extends readStEthHyperdriveMixin(
   ReadWriteHyperdrive,

--- a/packages/hyperdrive-js-core/src/hyperwasm.ts
+++ b/packages/hyperdrive-js-core/src/hyperwasm.ts
@@ -1,7 +1,7 @@
 // NOTE: Make sure to add the hyperwasm version number to the end of the import. Adding a query parameter to the import path will cause the esm cache to be invalidated and the latest version of the wasm package will be loaded.
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import * as hyperwasm from "@delvtech/hyperdrive-wasm?v0.12.0";
+import * as hyperwasm from "@delvtech/hyperdrive-wasm?v0.13.0";
 
 hyperwasm.initSync(hyperwasm.wasmBuffer);
 

--- a/packages/hyperdrive-js-core/vite.config.ts
+++ b/packages/hyperdrive-js-core/vite.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   plugins: [tsconfigPaths()],
   test: {
     alias: {
-      "@delvtech/hyperdrive-wasm?v0.12.0": "@delvtech/hyperdrive-wasm",
+      "@delvtech/hyperdrive-wasm?v0.13.0": "@delvtech/hyperdrive-wasm",
     },
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1484,10 +1484,10 @@
     fast-safe-stringify "^2.1.1"
     lru-cache "^10.0.1"
 
-"@delvtech/hyperdrive-wasm@^0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@delvtech/hyperdrive-wasm/-/hyperdrive-wasm-0.12.0.tgz#1ba563a4de0b7968b216c74946868f1db217b1b9"
-  integrity sha512-MnPUdhMOoWxFAAiaHtxboSEX9N4SA9Y3Uq22A4tiPoQmWTcH1nAc0GzecFrle0LzQ0Wfi2QZ3BG68FzI8XKUAw==
+"@delvtech/hyperdrive-wasm@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@delvtech/hyperdrive-wasm/-/hyperdrive-wasm-0.13.0.tgz#1698644fc170abe99688c54c4daab641748551fe"
+  integrity sha512-2zBD21ajcA76EJ89Jslq38mKEoIlMVyqWxBiEuM8Ivi2t6WlbTK61l2C9ZE+Lf7uNia42GJB1s17ZXL1/27UfA==
 
 "@discoveryjs/json-ext@0.5.7":
   version "0.5.7"


### PR DESCRIPTION
This connects the `getImpliedRate` function from the new hyperdrive-wasm to both core-js and the frontend. 

Currently, a bug in the rust SDK's `calculate_implied_rate method` is returning incorrect values. I've placed this feature behind a flag until we resolve the issue described in https://github.com/delvtech/hyperdrive/issues/1003.


To view this feature, turn on the feature flag:
![image](https://github.com/delvtech/hyperdrive-frontend/assets/4524175/c8540ea4-3c83-4423-98c8-014ca26d41f4)