### PR TITLE
Move getYieldSourceRate into SDK

### DIFF
--- a/apps/hyperdrive-trading/src/hyperdrive/model/ReadHyperdriveModel.ts
+++ b/apps/hyperdrive-trading/src/hyperdrive/model/ReadHyperdriveModel.ts
@@ -1,4 +1,3 @@
-import { MockERC4626 } from "@delvtech/hyperdrive-artifacts/MockERC4626";
 import { ContractReadOptions, ReadHyperdrive } from "@delvtech/hyperdrive-viem";
 import {
   AppConfig,
@@ -24,8 +23,6 @@ export interface IReadHyperdriveModel {
   hyperdriveConfig: HyperdriveConfig;
 
   publicClient: PublicClient;
-
-  getYieldSourceRate(): Promise<bigint>;
 
   // Open Longs
   previewOpenLongWithBase(params: {
@@ -162,22 +159,6 @@ export class ReadHyperdriveModel implements IReadHyperdriveModel {
       yieldSourceTokenAddress: this.hyperdriveConfig.sharesToken,
       tokens: appConfig.tokens,
     });
-  }
-  async getYieldSourceRate(): Promise<bigint> {
-    const chainId = await this.publicClient.getChainId();
-    switch (chainId) {
-      case 31337:
-      case 42069:
-      default:
-        const rate = await this.publicClient.readContract({
-          address: this.sharesToken.address,
-          // Both MockLido and MockERC4626 contain the getRate method, so this
-          // abi can be used for both
-          abi: MockERC4626.abi,
-          functionName: "getRate",
-        });
-        return rate;
-    }
   }
   async previewCloseShortWithBase({
     account,

--- a/apps/hyperdrive-trading/src/ui/vaults/useYieldSourceRate.ts
+++ b/apps/hyperdrive-trading/src/ui/vaults/useYieldSourceRate.ts
@@ -20,7 +20,10 @@ export function useYieldSourceRate({
   const hyperdriveModel = useReadHyperdriveModel(hyperdriveAddress);
   const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
   const queryEnabled =
-    !!hyperdriveAddress && !!hyperdriveModel && !!publicClient;
+    !!hyperdriveAddress &&
+    !!hyperdriveModel &&
+    !!publicClient &&
+    !!readHyperdrive;
   const { data: vaultRate, status: vaultRateStatus } = useQuery({
     enabled: queryEnabled,
     queryKey: makeQueryKey("vaultRate", {
@@ -28,10 +31,10 @@ export function useYieldSourceRate({
     }),
     queryFn: queryEnabled
       ? async () => {
-          const rate = await readHyperdrive?.getYieldSourceRate();
+          const rate = await readHyperdrive.getYieldSourceRate({});
           return {
-            vaultRate: rate || 0n,
-            formatted: formatRate(rate || 0n),
+            vaultRate: rate,
+            formatted: formatRate(rate),
           };
         }
       : undefined,

--- a/apps/hyperdrive-trading/src/ui/vaults/useYieldSourceRate.ts
+++ b/apps/hyperdrive-trading/src/ui/vaults/useYieldSourceRate.ts
@@ -28,7 +28,7 @@ export function useYieldSourceRate({
     }),
     queryFn: queryEnabled
       ? async () => {
-          const rate = await readHyperdrive?.getYieldSourceRate({});
+          const rate = await readHyperdrive?.getYieldSourceRate();
           return {
             vaultRate: rate || 0n,
             formatted: formatRate(rate || 0n),

--- a/apps/hyperdrive-trading/src/ui/vaults/useYieldSourceRate.ts
+++ b/apps/hyperdrive-trading/src/ui/vaults/useYieldSourceRate.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { formatRate } from "src/base/formatRate";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { useReadHyperdriveModel } from "src/ui/hyperdrive/hooks/model/useReadHyperdriveModel";
+import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
 import { usePublicClient } from "wagmi";
 
@@ -17,7 +18,7 @@ export function useYieldSourceRate({
 } {
   const publicClient = usePublicClient();
   const hyperdriveModel = useReadHyperdriveModel(hyperdriveAddress);
-
+  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
   const queryEnabled =
     !!hyperdriveAddress && !!hyperdriveModel && !!publicClient;
   const { data: vaultRate, status: vaultRateStatus } = useQuery({
@@ -27,10 +28,10 @@ export function useYieldSourceRate({
     }),
     queryFn: queryEnabled
       ? async () => {
-          const rate = await hyperdriveModel.getYieldSourceRate();
+          const rate = await readHyperdrive?.getYieldSourceRate({});
           return {
-            vaultRate: rate,
-            formatted: formatRate(rate),
+            vaultRate: rate || 0n,
+            formatted: formatRate(rate || 0n),
           };
         }
       : undefined,

--- a/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
@@ -107,11 +107,7 @@ export class ReadHyperdrive extends ReadModel {
     return this.contract.read("decimals");
   }
 
-  async getYieldSourceRate({
-    options,
-  }: {
-    options?: ContractReadOptions;
-  }): Promise<bigint> {
+  async getYieldSourceRate(options?: ContractReadOptions): Promise<bigint> {
     const { vaultSharesToken } = await this.getPoolConfig(options);
     const vault = new ReadMockErc4626({
       address: vaultSharesToken,

--- a/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
@@ -107,7 +107,11 @@ export class ReadHyperdrive extends ReadModel {
     return this.contract.read("decimals");
   }
 
-  async getYieldSourceRate(options?: ContractReadOptions): Promise<bigint> {
+  async getYieldSourceRate({
+    options,
+  }: {
+    options?: ContractReadOptions;
+  }): Promise<bigint> {
     const { vaultSharesToken } = await this.getPoolConfig(options);
     const vault = new ReadMockErc4626({
       address: vaultSharesToken,

--- a/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
@@ -33,6 +33,7 @@ import { getCheckpointId } from "src/pool/getCheckpointId";
 import { calculateShortAccruedYield } from "src/shorts/calculateShortAccruedYield";
 import { ClosedShort, OpenShort } from "src/shorts/types";
 import { ReadErc20 } from "src/token/erc20/ReadErc20";
+import { ReadMockErc4626 } from "src/token/erc4626/ReadMockErc4626";
 import { ReadEth } from "src/token/eth/ReadEth";
 import { RedeemedWithdrawalShares } from "src/withdrawalShares/RedeemedWithdrawalShares";
 import { WITHDRAW_SHARES_ASSET_ID } from "src/withdrawalShares/assetId";
@@ -104,6 +105,21 @@ export class ReadHyperdrive extends ReadModel {
 
   getDecimals(): Promise<number> {
     return this.contract.read("decimals");
+  }
+
+  async getYieldSourceRate({
+    options,
+  }: {
+    options?: ContractReadOptions;
+  }): Promise<bigint> {
+    const { vaultSharesToken } = await this.getPoolConfig(options);
+    const vault = new ReadMockErc4626({
+      address: vaultSharesToken,
+      contractFactory: this.contractFactory,
+      namespace: this.contract.namespace,
+      network: this.network,
+    });
+    return vault.getRate(options);
   }
 
   getCheckpoint({

--- a/packages/hyperdrive-js-core/src/hyperdrive/erc4626/ReadMockErc4626Hyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/erc4626/ReadMockErc4626Hyperdrive.ts
@@ -40,10 +40,5 @@ export function readMockErc4626HyperdriveMixin<
         network: this.network,
       });
     }
-
-    async getYieldSourceRate(options?: ContractReadOptions): Promise<bigint> {
-      const vault = await this.getSharesToken();
-      return vault.getRate(options);
-    }
   };
 }

--- a/packages/hyperdrive-js-core/src/hyperdrive/erc4626/ReadMockErc4626Hyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/erc4626/ReadMockErc4626Hyperdrive.ts
@@ -41,11 +41,7 @@ export function readMockErc4626HyperdriveMixin<
       });
     }
 
-    async getYieldSourceRate({
-      options,
-    }: {
-      options?: ContractReadOptions;
-    }): Promise<bigint> {
+    async getYieldSourceRate(options?: ContractReadOptions): Promise<bigint> {
       const vault = await this.getSharesToken();
       return vault.getRate(options);
     }


### PR DESCRIPTION
This PR removes the getYieldSourceRate from ReadHyperdriveModel and places it in the SDK.