### PR TITLE
Add decorator for `syncCacheWithTransaction`

### DIFF
--- a/apps/hyperdrive-trading/src/hyperdrive/model/ReadWriteHyperdriveModel.ts
+++ b/apps/hyperdrive-trading/src/hyperdrive/model/ReadWriteHyperdriveModel.ts
@@ -27,7 +27,7 @@ export interface IReadWriteHyperdriveModel extends IReadHyperdriveModel {
       baseAmount: bigint;
     };
     options?: ContractWriteOptions;
-    onTransactionMined?: (hash: Hash) => void;
+    onTransactionCompleted?: (hash: Hash) => void;
   }): Promise<Hash>;
   openLongWithShares(params: {
     args: {
@@ -37,7 +37,7 @@ export interface IReadWriteHyperdriveModel extends IReadHyperdriveModel {
       minBondsOut: bigint;
     };
     options?: ContractWriteOptions;
-    onTransactionMined?: (hash: Hash) => void;
+    onTransactionCompleted?: (hash: Hash) => void;
   }): Promise<Hash>;
 
   // Close Longs
@@ -49,7 +49,7 @@ export interface IReadWriteHyperdriveModel extends IReadHyperdriveModel {
       destination: Address;
     };
     options?: ContractWriteOptions;
-    onTransactionMined?: (hash: Hash) => void;
+    onTransactionCompleted?: (hash: Hash) => void;
   }): Promise<Hash>;
   closeLongWithShares(params: {
     args: {
@@ -59,7 +59,7 @@ export interface IReadWriteHyperdriveModel extends IReadHyperdriveModel {
       destination: Address;
     };
     options?: ContractWriteOptions;
-    onTransactionMined?: (hash: Hash) => void;
+    onTransactionCompleted?: (hash: Hash) => void;
   }): Promise<Hash>;
 
   // Open Shorts
@@ -72,7 +72,7 @@ export interface IReadWriteHyperdriveModel extends IReadHyperdriveModel {
       maxDeposit: bigint;
     };
     options?: ContractWriteOptions;
-    onTransactionMined?: (hash: Hash) => void;
+    onTransactionCompleted?: (hash: Hash) => void;
   }): Promise<Hash>;
 
   openShortWithShares(params: {
@@ -83,7 +83,7 @@ export interface IReadWriteHyperdriveModel extends IReadHyperdriveModel {
       maxDeposit: bigint;
     };
     options?: ContractWriteOptions;
-    onTransactionMined?: (hash: Hash) => void;
+    onTransactionCompleted?: (hash: Hash) => void;
   }): Promise<Hash>;
 
   // Close Shorts
@@ -96,7 +96,7 @@ export interface IReadWriteHyperdriveModel extends IReadHyperdriveModel {
       destination: Address;
     };
     options?: ContractWriteOptions;
-    onTransactionMined?: (hash: Hash) => void;
+    onTransactionCompleted?: (hash: Hash) => void;
   }): Promise<Hash>;
   closeShortWithShares(params: {
     args: {
@@ -106,7 +106,7 @@ export interface IReadWriteHyperdriveModel extends IReadHyperdriveModel {
       destination: Address;
     };
     options?: ContractWriteOptions;
-    onTransactionMined?: (hash: Hash) => void;
+    onTransactionCompleted?: (hash: Hash) => void;
   }): Promise<Hash>;
 
   // Add LP
@@ -120,7 +120,7 @@ export interface IReadWriteHyperdriveModel extends IReadHyperdriveModel {
       maxAPR: bigint;
     };
     options?: ContractWriteOptions;
-    onTransactionMined?: (hash: Hash) => void;
+    onTransactionCompleted?: (hash: Hash) => void;
   }): Promise<Hash>;
   addLiquidityWithShares(params: {
     args: {
@@ -131,7 +131,7 @@ export interface IReadWriteHyperdriveModel extends IReadHyperdriveModel {
       maxAPR: bigint;
     };
     options?: ContractWriteOptions;
-    onTransactionMined?: (hash: Hash) => void;
+    onTransactionCompleted?: (hash: Hash) => void;
   }): Promise<Hash>;
 
   // Remove LP
@@ -142,7 +142,7 @@ export interface IReadWriteHyperdriveModel extends IReadHyperdriveModel {
       destination: Address;
     };
     options?: ContractWriteOptions;
-    onTransactionMined?: (hash: Hash) => void;
+    onTransactionCompleted?: (hash: Hash) => void;
   }): Promise<Hash>;
   removeLiquidityWithShares(params: {
     args: {
@@ -151,7 +151,7 @@ export interface IReadWriteHyperdriveModel extends IReadHyperdriveModel {
       destination: Address;
     };
     options?: ContractWriteOptions;
-    onTransactionMined?: (hash: Hash) => void;
+    onTransactionCompleted?: (hash: Hash) => void;
   }): Promise<Hash>;
 }
 
@@ -187,7 +187,7 @@ export class ReadWriteHyperdriveModel
   openShortWithBase({
     args: { bondAmount, destination, minVaultSharePrice, maxDeposit },
     options,
-    onTransactionMined,
+    onTransactionCompleted,
   }: ExtractMethodParams<
     IReadWriteHyperdriveModel,
     "openShortWithBase"
@@ -201,13 +201,13 @@ export class ReadWriteHyperdriveModel
         asBase: true,
       },
       options,
-      onTransactionMined,
+      onTransactionCompleted,
     });
   }
   openShortWithShares({
     args: { bondAmount, destination, minVaultSharePrice, maxDeposit },
     options,
-    onTransactionMined,
+    onTransactionCompleted,
   }: ExtractMethodParams<
     IReadWriteHyperdriveModel,
     "openShortWithShares"
@@ -221,12 +221,12 @@ export class ReadWriteHyperdriveModel
         asBase: false,
       },
       options,
-      onTransactionMined,
+      onTransactionCompleted,
     });
   }
   removeLiquidityWithBase({
     args: { destination, lpSharesIn, minOutputPerShare },
-    onTransactionMined,
+    onTransactionCompleted,
     options,
   }: ExtractMethodParams<
     IReadWriteHyperdriveModel,
@@ -240,13 +240,13 @@ export class ReadWriteHyperdriveModel
         asBase: true,
       },
       options,
-      onTransactionMined,
+      onTransactionCompleted,
     });
   }
   removeLiquidityWithShares({
     args: { destination, lpSharesIn, minOutputPerShare },
     options,
-    onTransactionMined,
+    onTransactionCompleted,
   }: ExtractMethodParams<
     IReadWriteHyperdriveModel,
     "removeLiquidityWithShares"
@@ -258,14 +258,14 @@ export class ReadWriteHyperdriveModel
         minOutputPerShare,
         asBase: false,
       },
-      onTransactionMined,
+      onTransactionCompleted,
       options,
     });
   }
   closeShortWithBase({
     args: { bondAmountIn, destination, maturityTime, minAmountOut },
     options,
-    onTransactionMined,
+    onTransactionCompleted,
   }: ExtractMethodParams<
     IReadWriteHyperdriveModel,
     "closeShortWithBase"
@@ -279,13 +279,13 @@ export class ReadWriteHyperdriveModel
         asBase: true,
       },
       options,
-      onTransactionMined,
+      onTransactionCompleted,
     });
   }
   closeShortWithShares({
     args: { bondAmountIn, destination, maturityTime, minAmountOut },
     options,
-    onTransactionMined,
+    onTransactionCompleted,
   }: ExtractMethodParams<
     IReadWriteHyperdriveModel,
     "closeShortWithShares"
@@ -298,14 +298,14 @@ export class ReadWriteHyperdriveModel
         minAmountOut,
         asBase: false,
       },
-      onTransactionMined,
+      onTransactionCompleted,
       options,
     });
   }
   closeLongWithBase({
     args: { bondAmountIn, destination, maturityTime, minAmountOut },
     options,
-    onTransactionMined,
+    onTransactionCompleted,
   }: ExtractMethodParams<
     IReadWriteHyperdriveModel,
     "closeLongWithBase"
@@ -319,13 +319,13 @@ export class ReadWriteHyperdriveModel
         asBase: true,
       },
       options,
-      onTransactionMined,
+      onTransactionCompleted,
     });
   }
   closeLongWithShares({
     args: { bondAmountIn, destination, maturityTime, minAmountOut },
     options,
-    onTransactionMined,
+    onTransactionCompleted,
   }: ExtractMethodParams<
     IReadWriteHyperdriveModel,
     "closeLongWithShares"
@@ -338,7 +338,7 @@ export class ReadWriteHyperdriveModel
         minAmountOut,
         asBase: false,
       },
-      onTransactionMined,
+      onTransactionCompleted,
       options,
     });
   }
@@ -346,7 +346,7 @@ export class ReadWriteHyperdriveModel
   addLiquidityWithBase({
     args: { destination, contribution, maxAPR, minAPR, minLpSharePrice },
     options,
-    onTransactionMined,
+    onTransactionCompleted,
   }: ExtractMethodParams<
     IReadWriteHyperdriveModel,
     "addLiquidityWithBase"
@@ -361,13 +361,13 @@ export class ReadWriteHyperdriveModel
         asBase: true,
       },
       options,
-      onTransactionMined,
+      onTransactionCompleted,
     });
   }
   addLiquidityWithShares({
     args: { destination, contribution, maxAPR, minAPR, minLpSharePrice },
     options,
-    onTransactionMined,
+    onTransactionCompleted,
   }: ExtractMethodParams<
     IReadWriteHyperdriveModel,
     "addLiquidityWithShares"
@@ -382,13 +382,13 @@ export class ReadWriteHyperdriveModel
         asBase: false,
       },
       options,
-      onTransactionMined,
+      onTransactionCompleted,
     });
   }
   openLongWithBase({
     args: { destination, minBondsOut, minVaultSharePrice, baseAmount },
     options,
-    onTransactionMined,
+    onTransactionCompleted,
   }: ExtractMethodParams<
     IReadWriteHyperdriveModel,
     "openLongWithBase"
@@ -402,13 +402,13 @@ export class ReadWriteHyperdriveModel
         asBase: true,
       },
       options,
-      onTransactionMined,
+      onTransactionCompleted,
     });
   }
   openLongWithShares({
     args: { destination, minBondsOut, minVaultSharePrice, sharesAmount },
     options,
-    onTransactionMined,
+    onTransactionCompleted,
   }: ExtractMethodParams<
     IReadWriteHyperdriveModel,
     "openLongWithShares"
@@ -422,7 +422,7 @@ export class ReadWriteHyperdriveModel
         asBase: false,
       },
       options,
-      onTransactionMined,
+      onTransactionCompleted,
     });
   }
 }

--- a/apps/hyperdrive-trading/src/hyperdrive/model/steth/ReadWriteStethHyperdriveModel.ts
+++ b/apps/hyperdrive-trading/src/hyperdrive/model/steth/ReadWriteStethHyperdriveModel.ts
@@ -59,7 +59,7 @@ export class ReadWriteStethHyperdriveModel extends ReadWriteHyperdriveModel {
   async openLongWithShares({
     args: { destination, minBondsOut, minVaultSharePrice, sharesAmount },
     options,
-    onTransactionMined,
+    onTransactionCompleted,
   }: Parameters<
     IReadWriteHyperdriveModel["openLongWithShares"]
   >[0]): Promise<Hash> {
@@ -73,7 +73,7 @@ export class ReadWriteStethHyperdriveModel extends ReadWriteHyperdriveModel {
         sharesAmount: convertedSharesAmount,
       },
       options,
-      onTransactionMined,
+      onTransactionCompleted,
     });
   }
 
@@ -102,7 +102,7 @@ export class ReadWriteStethHyperdriveModel extends ReadWriteHyperdriveModel {
   async closeLongWithShares({
     args: { bondAmountIn, destination, maturityTime, minAmountOut },
     options,
-    onTransactionMined,
+    onTransactionCompleted,
   }: ExtractMethodParams<
     IReadWriteHyperdriveModel,
     "closeLongWithShares"
@@ -117,7 +117,7 @@ export class ReadWriteStethHyperdriveModel extends ReadWriteHyperdriveModel {
         minAmountOut: convertedMinAmountOut,
       },
       options,
-      onTransactionMined,
+      onTransactionCompleted,
     });
   }
   async previewOpenShortWithShares({
@@ -138,7 +138,7 @@ export class ReadWriteStethHyperdriveModel extends ReadWriteHyperdriveModel {
   async openShortWithShares({
     args: { bondAmount, destination, maxDeposit, minVaultSharePrice },
     options,
-    onTransactionMined,
+    onTransactionCompleted,
   }: ExtractMethodParams<
     IReadWriteHyperdriveModel,
     "openShortWithShares"
@@ -153,7 +153,7 @@ export class ReadWriteStethHyperdriveModel extends ReadWriteHyperdriveModel {
         minVaultSharePrice,
       },
       options,
-      onTransactionMined,
+      onTransactionCompleted,
     });
   }
 
@@ -182,7 +182,7 @@ export class ReadWriteStethHyperdriveModel extends ReadWriteHyperdriveModel {
   async closeShortWithShares({
     args: { bondAmountIn, destination, maturityTime, minAmountOut },
     options,
-    onTransactionMined,
+    onTransactionCompleted,
   }: ExtractMethodParams<
     IReadWriteHyperdriveModel,
     "closeShortWithShares"
@@ -197,7 +197,7 @@ export class ReadWriteStethHyperdriveModel extends ReadWriteHyperdriveModel {
         minAmountOut: convertedMinAmountOut,
       },
       options,
-      onTransactionMined,
+      onTransactionCompleted,
     });
   }
 
@@ -208,7 +208,7 @@ export class ReadWriteStethHyperdriveModel extends ReadWriteHyperdriveModel {
   async addLiquidityWithShares({
     args: { destination, contribution, maxAPR, minAPR, minLpSharePrice },
     options,
-    onTransactionMined,
+    onTransactionCompleted,
   }: ExtractMethodParams<
     IReadWriteHyperdriveModel,
     "addLiquidityWithShares"
@@ -225,7 +225,7 @@ export class ReadWriteStethHyperdriveModel extends ReadWriteHyperdriveModel {
         minLpSharePrice,
       },
       options,
-      onTransactionMined,
+      onTransactionCompleted,
     });
   }
 
@@ -276,7 +276,7 @@ export class ReadWriteStethHyperdriveModel extends ReadWriteHyperdriveModel {
   async removeLiquidityWithShares({
     args: { destination, lpSharesIn, minOutputPerShare },
     options,
-    onTransactionMined,
+    onTransactionCompleted,
   }: ExtractMethodParams<
     IReadWriteHyperdriveModel,
     "removeLiquidityWithShares"
@@ -290,7 +290,7 @@ export class ReadWriteStethHyperdriveModel extends ReadWriteHyperdriveModel {
         minOutputPerShare: convertedMinOutputPerShare,
       },
       options,
-      onTransactionMined,
+      onTransactionCompleted,
     });
   }
   /**

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useCloseLong.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useCloseLong.tsx
@@ -57,7 +57,7 @@ export function useCloseLong({
   const { mutate: closeLong, status } = useMutation({
     mutationFn: async () => {
       if (mutationEnabled) {
-        function onTransactionMined(txHash: Hash) {
+        function onTransactionCompleted(txHash: Hash) {
           queryClient.invalidateQueries();
           toast.success(
             <TransactionToast message="Long closed" txHash={hash} />,
@@ -74,7 +74,7 @@ export function useCloseLong({
                 destination,
                 maturityTime,
               },
-              onTransactionMined,
+              onTransactionCompleted,
             })
           : await hyperdriveModel.closeLongWithShares({
               args: {
@@ -83,7 +83,7 @@ export function useCloseLong({
                 destination,
                 maturityTime,
               },
-              onTransactionMined,
+              onTransactionCompleted,
             });
 
         toast.loading(

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useOpenLong.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useOpenLong.tsx
@@ -64,7 +64,7 @@ export function useOpenLong({
         value: ethValue,
       };
 
-      function onTransactionMined(txHash: Hash) {
+      function onTransactionCompleted(txHash: Hash) {
         queryClient.invalidateQueries();
         toast.success(
           <TransactionToast message="Long opened" txHash={txHash} />,
@@ -85,7 +85,7 @@ export function useOpenLong({
               minVaultSharePrice: minSharePrice,
             },
             options,
-            onTransactionMined,
+            onTransactionCompleted,
           })
         : await hyperdriveModel.openLongWithShares({
             args: {
@@ -95,7 +95,7 @@ export function useOpenLong({
               minVaultSharePrice: minSharePrice,
             },
             options,
-            onTransactionMined,
+            onTransactionCompleted,
           });
 
       toast.loading(

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useAddLiquidity.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useAddLiquidity.tsx
@@ -64,7 +64,7 @@ export function useAddLiquidity({
   const { mutate: addLiquidity, status } = useMutation({
     mutationFn: async () => {
       if (mutationEnabled) {
-        function onTransactionMined(txHash: Hash) {
+        function onTransactionCompleted(txHash: Hash) {
           queryClient.invalidateQueries();
           toast.success(
             <TransactionToast message="Liquidity added" txHash={txHash} />,
@@ -83,7 +83,7 @@ export function useAddLiquidity({
                 destination,
               },
               options: { value: ethValue },
-              onTransactionMined,
+              onTransactionCompleted,
             })
           : await hyperdriveModel.addLiquidityWithShares({
               args: {
@@ -94,7 +94,7 @@ export function useAddLiquidity({
                 destination,
               },
               options: { value: ethValue },
-              onTransactionMined,
+              onTransactionCompleted,
             });
 
         toast.loading(

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useRedeemWithdrawalShares.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useRedeemWithdrawalShares.ts
@@ -53,7 +53,7 @@ export function useRedeemWithdrawalShares({
             destination,
             asBase,
           },
-          onTransactionMined: () => {
+          onTransactionCompleted: () => {
             queryClient.invalidateQueries();
           },
         });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useRemoveLiquidity.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useRemoveLiquidity.tsx
@@ -53,7 +53,7 @@ export function useRemoveLiquidity({
   const { mutate: removeLiquidity, status } = useMutation({
     mutationFn: async () => {
       if (mutationEnabled) {
-        function onTransactionMined(txHash: Hash) {
+        function onTransactionCompleted(txHash: Hash) {
           queryClient.invalidateQueries();
           toast.success(
             <TransactionToast message="Liquidity removed" txHash={txHash} />,
@@ -70,7 +70,7 @@ export function useRemoveLiquidity({
                 minOutputPerShare,
                 destination,
               },
-              onTransactionMined,
+              onTransactionCompleted,
             })
           : await hyperdriveModel.removeLiquidityWithShares({
               args: {
@@ -78,7 +78,7 @@ export function useRemoveLiquidity({
                 lpSharesIn,
                 minOutputPerShare,
               },
-              onTransactionMined,
+              onTransactionCompleted,
             });
 
         toast.loading(

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useCloseShort.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useCloseShort.tsx
@@ -56,7 +56,7 @@ export function useCloseShort({
   const { mutate: closeShort, status } = useMutation({
     mutationFn: async () => {
       if (isMutationEnabled) {
-        function onTransactionMined(txHash: Hash) {
+        function onTransactionCompleted(txHash: Hash) {
           queryClient.invalidateQueries();
           toast.success(
             <TransactionToast message="Short closed" txHash={txHash} />,
@@ -74,7 +74,7 @@ export function useCloseShort({
                 destination,
                 maturityTime,
               },
-              onTransactionMined,
+              onTransactionCompleted,
             })
           : await hyperdriveModel.closeShortWithShares({
               args: {
@@ -83,7 +83,7 @@ export function useCloseShort({
                 maturityTime,
                 minAmountOut,
               },
-              onTransactionMined,
+              onTransactionCompleted,
             });
 
         toast.loading(

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useOpenShort.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useOpenShort.tsx
@@ -73,7 +73,7 @@ export function useOpenShort({
             : undefined,
         };
 
-        function onTransactionMined(txHash: `0x${string}`) {
+        function onTransactionCompleted(txHash: `0x${string}`) {
           queryClient.invalidateQueries();
           toast.success(
             <TransactionToast message="Short opened" txHash={txHash} />,
@@ -91,7 +91,7 @@ export function useOpenShort({
                 maxDeposit: maxDeposit,
               },
               options: openShortOptions,
-              onTransactionMined,
+              onTransactionCompleted,
             })
           : await hyperdriveModel.openShortWithShares({
               args: {
@@ -101,7 +101,7 @@ export function useOpenShort({
                 maxDeposit: maxDeposit,
               },
               options: openShortOptions,
-              onTransactionMined,
+              onTransactionCompleted,
             });
 
         toast.loading(

--- a/packages/hyperdrive-js-core/package.json
+++ b/packages/hyperdrive-js-core/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "@delvtech/evm-client": "^0.3.1",
+    "@delvtech/evm-client": "^0.4.2",
     "@delvtech/hyperdrive-artifacts": "^0.1.0"
   },
   "dependencies": {
@@ -20,7 +20,7 @@
     "lodash.mapvalues": "^4.6.0"
   },
   "devDependencies": {
-    "@delvtech/evm-client": "^0.3.1",
+    "@delvtech/evm-client": "^0.4.2",
     "@delvtech/hyperdrive-artifacts": "^0.1.0",
     "@hyperdrive/eslint-config": "*",
     "@hyperdrive/prettier-config": "*",

--- a/packages/hyperdrive-js-core/src/evm-client/syncCacheWithTransaction.ts
+++ b/packages/hyperdrive-js-core/src/evm-client/syncCacheWithTransaction.ts
@@ -1,0 +1,83 @@
+import {
+  CachedReadWriteContract,
+  ContractReadOptions,
+  FunctionArgs,
+  FunctionName,
+} from "@delvtech/evm-client";
+import { Abi } from "abitype";
+
+/**
+ * Clears the cache and calls the transaction handlers provided to a "Write"
+ * method on any CachedReadWriteContract class.
+ *
+ * This decorator accepts an argument of cache keys to clear. By default it will
+ * clear the entire cache.
+ *
+ * Example:
+ *
+ * class ReadWriteFooBar extends CachedReadWriteContract {
+ *
+ *   // Listen for tx complete and clear the entire cache
+ *   @syncCacheWithTransaction()
+ *   setFoo() {
+ *    return this.contract.write("setFoo", []);
+ *   }
+ *
+ *   // Listen for tx complete and clear a partial or specific cache entry
+ *   @syncCacheWithTransaction({ cacheEntries: [{ functionName: "getBar" }]})
+ *   setBar() {
+ *    return this.contract.write("setBar", []);
+ *   }
+ * }
+ *
+ */
+export function syncCacheWithTransaction<TAbi extends Abi>(options?: {
+  cacheEntries?: {
+    functionName?: FunctionName<TAbi>;
+    args?: FunctionArgs<TAbi, FunctionName<TAbi>>;
+    options?: ContractReadOptions;
+  }[];
+}) {
+  return function (
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+    target: any,
+    propertyKey: string,
+    descriptor: PropertyDescriptor,
+  ): void {
+    const originalMethod = descriptor.value;
+
+    // Wrap the original method in a function that does the transaction
+    // side-effects we want after the tx completes
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    descriptor.value = async function (...args: any[]) {
+      // Access the target class instance from within a decorator
+      // @ts-expect-error The `this` keyword will be the target class instance
+      const network = this.network;
+      // @ts-expect-error The `this` keyword will be the target class instance
+      const contract = this.contract as CachedReadWriteContract;
+
+      // call the original function and await the hash
+      const hash = await originalMethod.apply(this, args);
+
+      // Dont await this part, we want it to happen in the background once the
+      // tx is completed
+      network.waitForTransaction(hash).then(() => {
+        if (options?.cacheEntries) {
+          options.cacheEntries.forEach((cacheKey) => {
+            return contract.deleteReadMatch(
+              cacheKey.functionName,
+              cacheKey.args,
+              cacheKey.options,
+            );
+          });
+        } else {
+          contract.clearCache();
+        }
+        args[0]?.onTransactionCompleted?.(hash);
+      });
+
+      // Return the original method's result hash
+      return hash;
+    };
+  };
+}

--- a/packages/hyperdrive-js-core/src/hyperdrive/ReadWriteHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/ReadWriteHyperdrive.ts
@@ -77,7 +77,9 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
    * Allows an authorized address to pause this contract
    * @param paused - True to pause all deposits and false to unpause them
    */
-  @syncCacheWithTransaction<HyperdriveAbi>({ cacheKeys: ["getMarketState"] })
+  @syncCacheWithTransaction<HyperdriveAbi>({
+    cacheEntries: [{ functionName: "getMarketState" }],
+  })
   async pause({
     args: { paused },
     options,

--- a/packages/hyperdrive-js-core/src/hyperdrive/ReadWriteHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/ReadWriteHyperdrive.ts
@@ -56,7 +56,7 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
   async checkpoint({
     args: { time },
     options,
-    onTransactionMined,
+    onTransactionCompleted,
   }: ReadWriteParams<{ time: number }>): Promise<`0x${string}`> {
     const hash = await this.contract.write(
       "checkpoint",
@@ -65,7 +65,7 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
     );
     this.network.waitForTransaction(hash).then(() => {
       this.contract.clearCache();
-      onTransactionMined?.(hash);
+      onTransactionCompleted?.(hash);
     });
     return hash;
   }
@@ -77,7 +77,7 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
   async pause({
     args: { paused },
     options,
-    onTransactionMined,
+    onTransactionCompleted,
   }: ReadWriteParams<{
     paused: boolean;
   }>): Promise<`0x${string}`> {
@@ -88,7 +88,7 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
     );
     this.network.waitForTransaction(hash).then(() => {
       this.contract.deleteRead("getMarketState");
-      onTransactionMined?.(hash);
+      onTransactionCompleted?.(hash);
     });
     return hash;
   }
@@ -113,7 +113,7 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
       extraData = DEFAULT_EXTRA_DATA,
     },
     options,
-    onTransactionMined,
+    onTransactionCompleted,
   }: ReadWriteParams<{
     contribution: bigint;
     apr: bigint;
@@ -136,7 +136,7 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
     );
     this.network.waitForTransaction(hash).then(() => {
       this.contract.clearCache();
-      onTransactionMined?.(hash);
+      onTransactionCompleted?.(hash);
     });
     return hash;
   }
@@ -161,7 +161,7 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
       extraData = DEFAULT_EXTRA_DATA,
     },
     options,
-    onTransactionMined,
+    onTransactionCompleted,
   }: ReadWriteParams<{
     destination: `0x${string}`;
     amount: bigint;
@@ -182,7 +182,7 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
     );
     this.network.waitForTransaction(hash).then(() => {
       this.contract.clearCache();
-      onTransactionMined?.(hash);
+      onTransactionCompleted?.(hash);
     });
     return hash;
   }
@@ -207,7 +207,7 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
       extraData = DEFAULT_EXTRA_DATA,
     },
     options,
-    onTransactionMined,
+    onTransactionCompleted,
   }: ReadWriteParams<{
     destination: `0x${string}`;
     minVaultSharePrice: bigint;
@@ -228,7 +228,7 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
     );
     this.network.waitForTransaction(hash).then(() => {
       this.contract.clearCache();
-      onTransactionMined?.(hash);
+      onTransactionCompleted?.(hash);
     });
     return hash;
   }
@@ -253,7 +253,7 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
       extraData = DEFAULT_EXTRA_DATA,
     },
     options,
-    onTransactionMined,
+    onTransactionCompleted,
   }: ReadWriteParams<{
     maturityTime: bigint;
     bondAmountIn: bigint;
@@ -274,7 +274,7 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
     );
     this.network.waitForTransaction(hash).then(() => {
       this.contract.clearCache();
-      onTransactionMined?.(hash);
+      onTransactionCompleted?.(hash);
     });
     return hash;
   }
@@ -299,7 +299,7 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
       extraData = DEFAULT_EXTRA_DATA,
     },
     options,
-    onTransactionMined,
+    onTransactionCompleted,
   }: ReadWriteParams<{
     maturityTime: bigint;
     bondAmountIn: bigint;
@@ -320,7 +320,7 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
     );
     this.network.waitForTransaction(hash).then(() => {
       this.contract.clearCache();
-      onTransactionMined?.(hash);
+      onTransactionCompleted?.(hash);
     });
     return hash;
   }
@@ -347,7 +347,7 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
       extraData = DEFAULT_EXTRA_DATA,
     },
     options,
-    onTransactionMined,
+    onTransactionCompleted,
   }: ReadWriteParams<{
     destination: `0x${string}`;
     contribution: bigint;
@@ -370,7 +370,7 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
     );
     this.network.waitForTransaction(hash).then(() => {
       this.contract.clearCache();
-      onTransactionMined?.(hash);
+      onTransactionCompleted?.(hash);
     });
     return hash;
   }
@@ -395,7 +395,7 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
       extraData = DEFAULT_EXTRA_DATA,
     },
     options,
-    onTransactionMined,
+    onTransactionCompleted,
   }: ReadWriteParams<{
     destination: `0x${string}`;
     lpSharesIn: bigint;
@@ -414,7 +414,7 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
     );
     this.network.waitForTransaction(hash).then(() => {
       this.contract.clearCache();
-      onTransactionMined?.(hash);
+      onTransactionCompleted?.(hash);
     });
     return hash;
   }
@@ -438,7 +438,7 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
       extraData = DEFAULT_EXTRA_DATA,
     },
     options,
-    onTransactionMined,
+    onTransactionCompleted,
   }: ReadWriteParams<{
     withdrawalSharesIn: bigint;
     minOutputPerShare: bigint;
@@ -457,7 +457,7 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
     );
     this.network.waitForTransaction(hash).then(() => {
       this.contract.clearCache();
-      onTransactionMined?.(hash);
+      onTransactionCompleted?.(hash);
     });
     return hash;
   }
@@ -466,5 +466,5 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
 type ReadWriteParams<Args> = {
   args: Args;
   options?: ContractWriteOptions;
-  onTransactionMined?: (hash: `0x${string}`) => void;
+  onTransactionCompleted?: (hash: `0x${string}`) => void;
 };

--- a/packages/hyperdrive-js-core/src/hyperdrive/ReadWriteHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/ReadWriteHyperdrive.ts
@@ -4,12 +4,19 @@ import {
   ContractWriteOptions,
 } from "@delvtech/evm-client";
 import { ReadWriteContractFactory } from "src/evm-client/contractFactory";
+import { syncCacheWithTransaction } from "src/evm-client/syncCacheWithTransaction";
 import { ReadHyperdrive } from "src/hyperdrive/ReadHyperdrive/ReadHyperdrive";
 import { HyperdriveAbi } from "src/hyperdrive/abi";
 import { DEFAULT_EXTRA_DATA } from "src/hyperdrive/constants";
 import { ReadWriteContractModelOptions } from "src/model/ReadWriteModel";
 import { ReadWriteErc20 } from "src/token/erc20/ReadWriteErc20";
 import { ReadWriteEth } from "src/token/eth/ReadWriteEth";
+
+type ReadWriteParams<Args> = {
+  args: Args;
+  options?: ContractWriteOptions;
+  onTransactionCompleted?: (hash: `0x${string}`) => void;
+};
 
 export interface ReadWriteHyperdriveOptions
   extends ReadWriteContractModelOptions {}
@@ -53,20 +60,16 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
    * Allows anyone to mint a new checkpoint.
    * @param time - The time (in seconds) of the checkpoint to create.
    */
+  @syncCacheWithTransaction()
   async checkpoint({
     args: { time },
     options,
-    onTransactionCompleted,
   }: ReadWriteParams<{ time: number }>): Promise<`0x${string}`> {
     const hash = await this.contract.write(
       "checkpoint",
       { _checkpointTime: BigInt(time), _maxIterations: 4n },
       options,
     );
-    this.network.waitForTransaction(hash).then(() => {
-      this.contract.clearCache();
-      onTransactionCompleted?.(hash);
-    });
     return hash;
   }
 
@@ -74,10 +77,10 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
    * Allows an authorized address to pause this contract
    * @param paused - True to pause all deposits and false to unpause them
    */
+  @syncCacheWithTransaction<HyperdriveAbi>({ cacheKeys: ["getMarketState"] })
   async pause({
     args: { paused },
     options,
-    onTransactionCompleted,
   }: ReadWriteParams<{
     paused: boolean;
   }>): Promise<`0x${string}`> {
@@ -86,10 +89,6 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
       { _status: paused },
       options,
     );
-    this.network.waitForTransaction(hash).then(() => {
-      this.contract.deleteRead("getMarketState");
-      onTransactionCompleted?.(hash);
-    });
     return hash;
   }
 
@@ -104,6 +103,7 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
    *                      blocked.
    * @returns The initial number of LP shares created.
    */
+  @syncCacheWithTransaction()
   async initialize({
     args: {
       contribution,
@@ -113,7 +113,6 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
       extraData = DEFAULT_EXTRA_DATA,
     },
     options,
-    onTransactionCompleted,
   }: ReadWriteParams<{
     contribution: bigint;
     apr: bigint;
@@ -134,10 +133,6 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
       },
       options,
     );
-    this.network.waitForTransaction(hash).then(() => {
-      this.contract.clearCache();
-      onTransactionCompleted?.(hash);
-    });
     return hash;
   }
 
@@ -151,6 +146,7 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
    * @return bondProceeds - The amount of bonds the user received
    *
    */
+  @syncCacheWithTransaction()
   async openLong({
     args: {
       destination,
@@ -161,7 +157,6 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
       extraData = DEFAULT_EXTRA_DATA,
     },
     options,
-    onTransactionCompleted,
   }: ReadWriteParams<{
     destination: `0x${string}`;
     amount: bigint;
@@ -180,10 +175,6 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
       },
       options,
     );
-    this.network.waitForTransaction(hash).then(() => {
-      this.contract.clearCache();
-      onTransactionCompleted?.(hash);
-    });
     return hash;
   }
 
@@ -197,6 +188,7 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
    * @return maturityTime - The maturity time of the short.
    * @return traderDeposit - The amount the user deposited for this trade.
    */
+  @syncCacheWithTransaction()
   async openShort({
     args: {
       destination,
@@ -207,7 +199,6 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
       extraData = DEFAULT_EXTRA_DATA,
     },
     options,
-    onTransactionCompleted,
   }: ReadWriteParams<{
     destination: `0x${string}`;
     minVaultSharePrice: bigint;
@@ -226,10 +217,6 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
       },
       options,
     );
-    this.network.waitForTransaction(hash).then(() => {
-      this.contract.clearCache();
-      onTransactionCompleted?.(hash);
-    });
     return hash;
   }
 
@@ -243,6 +230,7 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
    * @param options - Contract Write Options
    * @return The amount of underlying asset the user receives.
    */
+  @syncCacheWithTransaction()
   async closeLong({
     args: {
       maturityTime,
@@ -253,7 +241,6 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
       extraData = DEFAULT_EXTRA_DATA,
     },
     options,
-    onTransactionCompleted,
   }: ReadWriteParams<{
     maturityTime: bigint;
     bondAmountIn: bigint;
@@ -272,10 +259,6 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
       },
       options,
     );
-    this.network.waitForTransaction(hash).then(() => {
-      this.contract.clearCache();
-      onTransactionCompleted?.(hash);
-    });
     return hash;
   }
 
@@ -289,6 +272,7 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
    * @param options - Contract Write Options
    * @return The amount of base tokens produced by closing this short
    */
+  @syncCacheWithTransaction()
   async closeShort({
     args: {
       maturityTime,
@@ -299,7 +283,6 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
       extraData = DEFAULT_EXTRA_DATA,
     },
     options,
-    onTransactionCompleted,
   }: ReadWriteParams<{
     maturityTime: bigint;
     bondAmountIn: bigint;
@@ -318,10 +301,6 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
       },
       options,
     );
-    this.network.waitForTransaction(hash).then(() => {
-      this.contract.clearCache();
-      onTransactionCompleted?.(hash);
-    });
     return hash;
   }
 
@@ -336,6 +315,7 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
    * @param options - Contract Write Options
    * @return lpShares The number of LP tokens created
    */
+  @syncCacheWithTransaction()
   async addLiquidity({
     args: {
       destination,
@@ -347,7 +327,6 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
       extraData = DEFAULT_EXTRA_DATA,
     },
     options,
-    onTransactionCompleted,
   }: ReadWriteParams<{
     destination: `0x${string}`;
     contribution: bigint;
@@ -368,10 +347,6 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
       },
       options,
     );
-    this.network.waitForTransaction(hash).then(() => {
-      this.contract.clearCache();
-      onTransactionCompleted?.(hash);
-    });
     return hash;
   }
 
@@ -386,6 +361,7 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
    receives a proportional amount of the pool's idle capital
    * @returns withdrawShares - The base that the LP receives buys out some of their LP  shares, but it may not be sufficient to fully buy the LP out. In this case, the LP receives withdrawal shares equal in value to the present value they are owed. As idle capital becomes available, the pool will buy back these shares.
    */
+  @syncCacheWithTransaction()
   async removeLiquidity({
     args: {
       destination,
@@ -395,7 +371,6 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
       extraData = DEFAULT_EXTRA_DATA,
     },
     options,
-    onTransactionCompleted,
   }: ReadWriteParams<{
     destination: `0x${string}`;
     lpSharesIn: bigint;
@@ -412,10 +387,7 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
       },
       options,
     );
-    this.network.waitForTransaction(hash).then(() => {
-      this.contract.clearCache();
-      onTransactionCompleted?.(hash);
-    });
+
     return hash;
   }
 
@@ -429,6 +401,7 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
    * @return baseProceeds The amount of base the LP received.
    * @return sharesRedeemed The amount of withdrawal shares that were redeemed.
    */
+  @syncCacheWithTransaction()
   async redeemWithdrawalShares({
     args: {
       withdrawalSharesIn,
@@ -438,7 +411,6 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
       extraData = DEFAULT_EXTRA_DATA,
     },
     options,
-    onTransactionCompleted,
   }: ReadWriteParams<{
     withdrawalSharesIn: bigint;
     minOutputPerShare: bigint;
@@ -455,16 +427,6 @@ export class ReadWriteHyperdrive extends ReadHyperdrive {
       },
       options,
     );
-    this.network.waitForTransaction(hash).then(() => {
-      this.contract.clearCache();
-      onTransactionCompleted?.(hash);
-    });
     return hash;
   }
 }
-
-type ReadWriteParams<Args> = {
-  args: Args;
-  options?: ContractWriteOptions;
-  onTransactionCompleted?: (hash: `0x${string}`) => void;
-};

--- a/packages/hyperdrive-js-core/src/index.ts
+++ b/packages/hyperdrive-js-core/src/index.ts
@@ -1,5 +1,4 @@
 // Main Hyperdrive sdk entrypoint for consumers
-export type { Network } from "@delvtech/evm-client";
 export {
   ReadHyperdrive,
   type ReadHyperdriveOptions,

--- a/packages/hyperdrive-js-core/src/token/erc20/ReadWriteErc20.ts
+++ b/packages/hyperdrive-js-core/src/token/erc20/ReadWriteErc20.ts
@@ -3,6 +3,7 @@ import {
   ContractWriteOptions,
 } from "@delvtech/evm-client";
 import { ReadWriteContractFactory } from "src/evm-client/contractFactory";
+import { syncCacheWithTransaction } from "src/evm-client/syncCacheWithTransaction";
 import { ReadWriteContractModelOptions } from "src/model/ReadWriteModel";
 import { ReadWriteToken } from "src/token/ReadWriteToken";
 import { ReadErc20 } from "src/token/erc20/ReadErc20";
@@ -18,6 +19,9 @@ export class ReadWriteErc20 extends ReadErc20 implements ReadWriteToken {
     super(options);
   }
 
+  @syncCacheWithTransaction<Erc20Abi>({
+    cacheEntries: [{ functionName: "allowance" }],
+  })
   async approve({
     spender,
     amount,
@@ -33,10 +37,6 @@ export class ReadWriteErc20 extends ReadErc20 implements ReadWriteToken {
       { spender, amount },
       options,
     );
-    this.contract.deleteRead("allowance", {
-      owner: await this.contract.getSignerAddress(),
-      spender,
-    });
     return hash;
   }
 }

--- a/packages/hyperdrive-js-core/tsconfig.json
+++ b/packages/hyperdrive-js-core/tsconfig.json
@@ -6,6 +6,7 @@
     "rootDir": ".",
     "baseUrl": ".",
     "moduleResolution": "Bundler",
+    "experimentalDecorators": true,
     "target": "esnext",
     "module": "ESNext",
     "paths": {

--- a/packages/hyperdrive-viem/package.json
+++ b/packages/hyperdrive-viem/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@delvtech/hyperdrive-artifacts": "^0.1.0",
     "@delvtech/hyperdrive-js-core": "^0.0.4",
-    "@delvtech/evm-client-viem": "^0.3.1"
+    "@delvtech/evm-client-viem": "^0.4.2"
   },
   "devDependencies": {
     "@hyperdrive/eslint-config": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1469,19 +1469,21 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@delvtech/evm-client-viem@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@delvtech/evm-client-viem/-/evm-client-viem-0.3.1.tgz#e1591b9c66e75143a011636a6c383a8e90aeb0e0"
-  integrity sha512-MuGNeca7klznTT0FLx0Y6DxSHBqRMmBrkfTzaj65ykofClt297R86lLGbyk/xw8AR8UIeHSYivAzM3iPk8ZW5A==
+"@delvtech/evm-client-viem@^0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@delvtech/evm-client-viem/-/evm-client-viem-0.4.2.tgz#feddd8a4793cf342e8d03f34b4146858cd0f27bc"
+  integrity sha512-WvC7V+Sg+i0T44aZ58zqNyDRksZpGwLRhguaEQEqwkKMJffSs2u1foUEE92oTEnNfKMrsx33i6/by05tlKkYTw==
   dependencies:
-    "@delvtech/evm-client" "0.3.1"
+    "@delvtech/evm-client" "0.4.2"
 
-"@delvtech/evm-client@0.3.1", "@delvtech/evm-client@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@delvtech/evm-client/-/evm-client-0.3.1.tgz#96382a6a99d3297d61662d7619a48c5e12347601"
-  integrity sha512-eqWkSCppWiQ9fq9m+iToVxyHlvwQ3amCNLqfFby3v0+9EgJeHD5ZqtnZZym4pEp7oufNdV2hbEgdJWjiM7Z1FQ==
+"@delvtech/evm-client@0.4.2", "@delvtech/evm-client@^0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@delvtech/evm-client/-/evm-client-0.4.2.tgz#11a26ec4e9ddf6093771edb09343d9d5d1b3dc3f"
+  integrity sha512-9aJvszoCg3sfWwo4uHDS/S5nlJ8rIgsqD2nwbKjO/hn/lYFKYViOLMJVIY+vcmyhZpvjgU+ihdpbPnDZe4LHkw==
   dependencies:
+    "@types/lodash.ismatch" "^4.4.9"
     fast-safe-stringify "^2.1.1"
+    lodash.ismatch "^4.4.0"
     lru-cache "^10.0.1"
 
 "@delvtech/hyperdrive-wasm@^0.13.0":
@@ -3996,6 +3998,13 @@
   version "4.6.9"
   resolved "https://registry.yarnpkg.com/@types/lodash.groupby/-/lodash.groupby-4.6.9.tgz#ea1aa9da1038ca50894d1fe1a3b5dabdf865d99c"
   integrity sha512-z2xtCX2ko7GrqORnnYea4+ksT7jZNAvaOcLd6mP9M7J09RHvJs06W8BGdQQAX8ARef09VQLdeRilSOcfHlDQJQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash.ismatch@^4.4.9":
+  version "4.4.9"
+  resolved "https://registry.yarnpkg.com/@types/lodash.ismatch/-/lodash.ismatch-4.4.9.tgz#97b4317f7dc3975bb51660a0f9a055ac7b67b134"
+  integrity sha512-qWihnStOPKH8urljLGm6ZOEdN/5Bt4vxKR81tL3L4ArUNLvcf9RW3QSnPs21eix5BiqioSWq4aAXD4Iep+d0fw==
   dependencies:
     "@types/lodash" "*"
 
@@ -10416,6 +10425,11 @@ lodash.isequal@4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==
+
+lodash.ismatch@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz#756cb5150ca3ba6f11085a78849645f188f85f37"
+  integrity sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==
 
 lodash.mapvalues@^4.6.0:
   version "4.6.0"


### PR DESCRIPTION
This PR adds a new decorator to the hyperdrive-core-js package, `syncCacheWithTransaction`.

This decorator wraps any cached write contract method and listens for the tx to complete then invalidates the cache.