### PR TITLE
Animate yield stat based on active position

### DIFF
--- a/apps/hyperdrive-trading/src/ui/base/components/Stat.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/Stat.tsx
@@ -2,7 +2,7 @@ import { InformationCircleIcon } from "@heroicons/react/24/outline";
 import classNames from "classnames";
 import { ReactElement, ReactNode } from "react";
 
-interface StatProps {
+export interface StatProps {
   label: string;
   value: ReactNode;
   description?: string;

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/YieldStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/YieldStats.tsx
@@ -129,7 +129,7 @@ function Animated({
   return (
     <div
       className={classNames("transition-all duration-200 ease-in-out", {
-        "gradient-text -translate-y-1 scale-105": isActive,
+        "gradient-text z-20 -translate-y-1 scale-105": isActive,
       })}
     >
       {children}

--- a/packages/hyperdrive-js-core/src/token/reth/ReadREth.ts
+++ b/packages/hyperdrive-js-core/src/token/reth/ReadREth.ts
@@ -12,7 +12,7 @@ export interface ReadREthMixin {
   rEthContract: CachedReadContract<REthAbi>;
 
   /**
-   * Get the total supply of underlying eth in the lsEth contract.
+   * Get the total supply of underlying eth in the rETH contract.
    */
   getTotalEthSupply(options?: ContractReadOptions): Promise<bigint>;
 


### PR DESCRIPTION
Adding a simple animation to help users draw the connection between the position types and their respective rates.

https://github.com/delvtech/hyperdrive-frontend/assets/4524175/b5ac3bcf-f8c2-47da-ac14-a6d45ca87fd3

