### PR TITLE
Fix bug causing morpho yield source apy to not show

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/model/useReadHyperdriveModel.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/model/useReadHyperdriveModel.ts
@@ -15,6 +15,10 @@ import { getIsSteth } from "src/vaults/isSteth";
 import { Address } from "viem";
 import { usePublicClient } from "wagmi";
 
+/**
+ * @deprecated use useReadHyperdrive instead to get back an sdk instance instead
+ * of a model
+ */
 export function useReadHyperdriveModel(
   hyperdriveAddress: Address | undefined,
 ): IReadHyperdriveModel | undefined {

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useReadHyperdrive.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useReadHyperdrive.ts
@@ -1,4 +1,8 @@
-import { ReadHyperdrive, ReadStEthHyperdrive } from "@delvtech/hyperdrive-viem";
+import {
+  ReadHyperdrive,
+  ReadMetaMorphoHyperdrive,
+  ReadStEthHyperdrive,
+} from "@delvtech/hyperdrive-viem";
 import {
   findHyperdriveConfig,
   findYieldSourceToken,
@@ -6,6 +10,7 @@ import {
 import { useMemo } from "react";
 import { sdkCache } from "src/sdk/sdkCache";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
+import { getIsMetaMorpho } from "src/vaults/isMetaMorpho";
 import { getIsSteth } from "src/vaults/isSteth";
 import { Address } from "viem";
 import { useChainId, usePublicClient } from "wagmi";
@@ -31,6 +36,7 @@ export function useReadHyperdrive(
       })
     : undefined;
   const isSteth = !!sharesToken && getIsSteth(sharesToken);
+  const isMetaMorpho = !!sharesToken && getIsMetaMorpho(sharesToken);
 
   return useMemo(() => {
     if (!address || !publicClient) {
@@ -45,6 +51,14 @@ export function useReadHyperdrive(
         namespace: chainId.toString(),
       });
     }
+    if (isMetaMorpho) {
+      return new ReadMetaMorphoHyperdrive({
+        address,
+        publicClient,
+        cache: sdkCache,
+        namespace: chainId.toString(),
+      });
+    }
 
     return new ReadHyperdrive({
       address,
@@ -52,5 +66,5 @@ export function useReadHyperdrive(
       cache: sdkCache,
       namespace: chainId.toString(),
     });
-  }, [address, chainId, publicClient, isSteth]);
+  }, [address, publicClient, isSteth, isMetaMorpho, chainId]);
 }

--- a/packages/hyperdrive-js-core/src/hyperdrive/metamorpho/ReadMetaMorphoHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/metamorpho/ReadMetaMorphoHyperdrive.ts
@@ -5,7 +5,9 @@ import {
   ReadHyperdriveOptions,
 } from "src/hyperdrive/ReadHyperdrive/ReadHyperdrive";
 
-const SEPOLIA_METAMORPHO_ADDRESS = "0xf5461A30b3723085F8E702fCc7461db85481c173";
+// See: https://www.notion.so/delv-tech/Testnet-Addresses-911a0f422f374059afa5c40d76373de6
+const SEPOLIA_METAMORPHO_SNIPPETS_ADDRESS =
+  "0xf5461A30b3723085F8E702fCc7461db85481c173";
 
 export class ReadMetaMorphoHyperdrive extends readMetaMorphoHyperdriveMixin(
   ReadHyperdrive,
@@ -43,7 +45,7 @@ export function readMetaMorphoHyperdriveMixin<
         abi: MetaMorphoSnippetsABI,
         // TODO: Refactor to a switch/case on chainId once evm-client has chainId
         // support on the Network interface
-        address: SEPOLIA_METAMORPHO_ADDRESS,
+        address: SEPOLIA_METAMORPHO_SNIPPETS_ADDRESS,
         cache,
         namespace,
       });

--- a/packages/hyperdrive-js-core/src/hyperdrive/metamorpho/ReadMetaMorphoHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/metamorpho/ReadMetaMorphoHyperdrive.ts
@@ -1,0 +1,126 @@
+import { ContractReadOptions, ReadContract } from "@delvtech/evm-client";
+import { Constructor } from "src/base/types";
+import {
+  ReadHyperdrive,
+  ReadHyperdriveOptions,
+} from "src/hyperdrive/ReadHyperdrive/ReadHyperdrive";
+
+const SEPOLIA_METAMORPHO_ADDRESS = "0xf5461A30b3723085F8E702fCc7461db85481c173";
+
+export class ReadMetaMorphoHyperdrive extends readMetaMorphoHyperdriveMixin(
+  ReadHyperdrive,
+) {}
+
+/**
+ * @internal
+ */
+export interface ReadMetaMorphoHyperdriveMixin {
+  getYieldSourceRate(options?: {
+    options?: ContractReadOptions;
+  }): Promise<bigint>;
+}
+
+/**
+ * @internal
+ */
+export function readMetaMorphoHyperdriveMixin<
+  T extends Constructor<ReadHyperdrive>,
+>(Base: T): Constructor<ReadMetaMorphoHyperdriveMixin> & T {
+  return class extends Base implements ReadMetaMorphoHyperdriveMixin {
+    metaMorphoContract: ReadContract<typeof MetaMorphoSnippetsABI>;
+    constructor(...[options]: any[]) {
+      const {
+        name = "MetaMorpho Hyperdrive",
+        address,
+        contractFactory,
+        network,
+        cache,
+        namespace,
+      } = options as ReadHyperdriveOptions;
+      super({ address, contractFactory, network, cache, name, namespace });
+
+      this.metaMorphoContract = this.contractFactory({
+        abi: MetaMorphoSnippetsABI,
+        // TODO: Refactor to a switch/case on chainId once evm-client has chainId
+        // support on the Network interface
+        address: SEPOLIA_METAMORPHO_ADDRESS,
+        cache,
+        namespace,
+      });
+    }
+    async getYieldSourceRate({
+      options,
+    }: {
+      options?: ContractReadOptions | undefined;
+    }): Promise<bigint> {
+      const sharesToken = await this.getSharesToken();
+      const rate = await this.metaMorphoContract.read(
+        "supplyAPYVault",
+        { vault: sharesToken.address },
+        options,
+      );
+      return rate;
+    }
+  };
+}
+
+const MetaMorphoSnippetsABI = [
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: "address", name: "loanToken", type: "address" },
+          { internalType: "address", name: "collateralToken", type: "address" },
+          { internalType: "address", name: "oracle", type: "address" },
+          { internalType: "address", name: "irm", type: "address" },
+          { internalType: "uint256", name: "lltv", type: "uint256" },
+        ],
+        internalType: "struct MarketParams",
+        name: "marketParams",
+        type: "tuple",
+      },
+      {
+        components: [
+          {
+            internalType: "uint128",
+            name: "totalSupplyAssets",
+            type: "uint128",
+          },
+          {
+            internalType: "uint128",
+            name: "totalSupplyShares",
+            type: "uint128",
+          },
+          {
+            internalType: "uint128",
+            name: "totalBorrowAssets",
+            type: "uint128",
+          },
+          {
+            internalType: "uint128",
+            name: "totalBorrowShares",
+            type: "uint128",
+          },
+          { internalType: "uint128", name: "lastUpdate", type: "uint128" },
+          { internalType: "uint128", name: "fee", type: "uint128" },
+        ],
+        internalType: "struct Market",
+        name: "market",
+        type: "tuple",
+      },
+    ],
+    name: "supplyAPYMarket",
+    outputs: [{ internalType: "uint256", name: "supplyApy", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "vault", type: "address" }],
+    name: "supplyAPYVault",
+    outputs: [
+      { internalType: "uint256", name: "avgSupplyApy", type: "uint256" },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;

--- a/packages/hyperdrive-js-core/src/index.ts
+++ b/packages/hyperdrive-js-core/src/index.ts
@@ -15,6 +15,7 @@ export { ReadEzEthHyperdrive } from "src/hyperdrive/ezeth/ReadEzEthHyperdrive";
 export { ReadWriteEzEthHyperdrive } from "src/hyperdrive/ezeth/ReadWriteEzEthHyperdrive";
 export { ReadLsEthHyperdrive } from "src/hyperdrive/lseth/ReadLsEthHyperdrive";
 export { ReadWriteLsEthHyperdrive } from "src/hyperdrive/lseth/ReadWriteLsEthHyperdrive";
+export { ReadMetaMorphoHyperdrive } from "src/hyperdrive/metamorpho/ReadMetaMorphoHyperdrive";
 export { ReadREthHyperdrive } from "src/hyperdrive/reth/ReadREthHyperdrive";
 export { ReadWriteREthHyperdrive } from "src/hyperdrive/reth/ReadWriteREthHyperdrive";
 export {

--- a/packages/hyperdrive-viem/src/hyperdrive/metamorpho/ReadMetaMorphoHyperdrive.ts
+++ b/packages/hyperdrive-viem/src/hyperdrive/metamorpho/ReadMetaMorphoHyperdrive.ts
@@ -1,0 +1,27 @@
+import { createNetwork } from "@delvtech/evm-client-viem";
+import { ReadMetaMorphoHyperdrive as ReadMetaMorphoHyperdriveBase } from "@delvtech/hyperdrive-js-core";
+import { createReadContractFactory } from "src/evm-client/createReadContractFactory";
+import { ReadHyperdriveOptions } from "src/hyperdrive/ReadHyperdrive";
+
+export class ReadMetaMorphoHyperdrive extends ReadMetaMorphoHyperdriveBase {
+  constructor({
+    address,
+    cache,
+    name,
+    namespace,
+    publicClient,
+  }: ReadHyperdriveOptions) {
+    super({
+      address,
+      cache,
+      contractFactory: createReadContractFactory({
+        publicClient,
+        cache,
+        namespace,
+      }),
+      name,
+      namespace,
+      network: createNetwork(publicClient),
+    });
+  }
+}

--- a/packages/hyperdrive-viem/src/index.ts
+++ b/packages/hyperdrive-viem/src/index.ts
@@ -1,4 +1,5 @@
 // client
+
 // Re-export all of evm-client-viem
 export * from "@delvtech/evm-client-viem";
 // Re-export all of hyperdrive-js-core
@@ -19,6 +20,7 @@ export { ReadEzEthHyperdrive } from "src/hyperdrive/ezeth/ReadEzEthHyperdrive";
 export { ReadWriteEzEthHyperdrive } from "src/hyperdrive/ezeth/ReadWriteEzEthHyperdrive";
 export { ReadLsEthHyperdrive } from "src/hyperdrive/lseth/ReadLsEthHyperdrive";
 export { ReadWriteLsEthHyperdrive } from "src/hyperdrive/lseth/ReadWriteLsEthHyperdrive";
+export { ReadMetaMorphoHyperdrive } from "src/hyperdrive/metamorpho/ReadMetaMorphoHyperdrive";
 export { ReadREthHyperdrive } from "src/hyperdrive/reth/ReadREthHyperdrive";
 export { ReadWriteREthHyperdrive } from "src/hyperdrive/reth/ReadWriteREthHyperdrive";
 export {


### PR DESCRIPTION
Add `ReadMetaMorphoHyperdrive` so we can implement getVariableRate in the sdk and consume it anywhere.