### PR TITLE
Right align position table stats

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/CurrentValueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/CurrentValueCell.tsx
@@ -65,21 +65,18 @@ export function CurrentValueCell({
     return <div>Insufficient Liquidity</div>;
   }
   return (
-    <div className="daisy-stat flex flex-row p-0 xl:flex-col">
-      <span
-        className={classNames("daisy-stat-value text-xs font-bold md:text-md", {
-          "flex w-32 justify-end": !isTailwindSmallScreen,
-        })}
-      >
+    <div
+      className={classNames("daisy-stat flex flex-row p-0 xl:flex-col", {
+        "flex w-32 flex-col items-end": !isTailwindSmallScreen,
+      })}
+    >
+      <span className="daisy-stat-value text-xs font-bold md:text-md">
         {currentValueLabel}
       </span>
       <div
         data-tip={"Profit/Loss since open, after closing fees."}
         className={classNames(
           "daisy-tooltip daisy-tooltip-left mt-1 flex text-xs before:border",
-          {
-            "flex w-32 justify-end": !isTailwindSmallScreen,
-          },
           { "text-success": isPositiveChangeInValue },
           {
             "text-error":

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/CurrentValueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/CurrentValueCell.tsx
@@ -5,6 +5,7 @@ import { ReactElement } from "react";
 import { convertSharesToBase } from "src/hyperdrive/convertSharesToBase";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
+import { useIsTailwindSmallScreen } from "src/ui/base/mediaBreakpoints";
 import { usePoolInfo } from "src/ui/hyperdrive/hooks/usePoolInfo";
 import { usePreviewCloseLong } from "src/ui/hyperdrive/longs/hooks/usePreviewCloseLong";
 import { parseUnits } from "viem";
@@ -18,6 +19,7 @@ export function CurrentValueCell({
   hyperdrive: HyperdriveConfig;
 }): ReactElement {
   const { address: account } = useAccount();
+  const isTailwindSmallScreen = useIsTailwindSmallScreen();
   const appConfig = useAppConfig();
   const baseToken = findBaseToken({
     baseTokenAddress: hyperdrive.baseToken,
@@ -64,13 +66,20 @@ export function CurrentValueCell({
   }
   return (
     <div className="daisy-stat flex flex-row p-0 xl:flex-col">
-      <span className="daisy-stat-value text-xs font-bold md:text-md">
+      <span
+        className={classNames("daisy-stat-value text-xs font-bold md:text-md", {
+          "flex w-32 justify-end": !isTailwindSmallScreen,
+        })}
+      >
         {currentValueLabel}
       </span>
       <div
         data-tip={"Profit/Loss since open, after closing fees."}
         className={classNames(
           "daisy-tooltip daisy-tooltip-left mt-1 flex text-xs before:border",
+          {
+            "flex w-32 justify-end": !isTailwindSmallScreen,
+          },
           { "text-success": isPositiveChangeInValue },
           {
             "text-error":

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/FixedRateCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/FixedRateCell.tsx
@@ -44,22 +44,21 @@ export function FixedRateCell({
 
   return (
     <div
-      className={classNames("daisy-stat flex p-0", { "flex-col": vertical })}
+      className={classNames(
+        "daisy-stat flex p-0",
+        { "flex-col": vertical },
+        {
+          "w-16 items-end": !isTailwindSmallScreen,
+        },
+      )}
     >
-      <span
-        className={classNames("daisy-stat-value text-md font-bold", {
-          "flex w-16 justify-end": !isTailwindSmallScreen,
-        })}
-      >
+      <span className={classNames("daisy-stat-value text-md font-bold")}>
         {formatRate(fixedRate)}%
       </span>
       <div
         data-tip={"Yield after fees if held to maturity"}
         className={classNames(
           "daisy-stat-desc daisy-tooltip mt-1 inline-flex text-xs text-success",
-          {
-            "flex w-16 justify-end": !isTailwindSmallScreen,
-          },
         )}
       >
         <span>{"+"}</span>

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/FixedRateCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/FixedRateCell.tsx
@@ -8,6 +8,7 @@ import { ReactElement } from "react";
 import { formatRate } from "src/base/formatRate";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
+import { useIsTailwindSmallScreen } from "src/ui/base/mediaBreakpoints";
 
 export function FixedRateCell({
   baseAmountPaid,
@@ -21,6 +22,7 @@ export function FixedRateCell({
   vertical?: boolean;
 }): ReactElement {
   const appConfig = useAppConfig();
+  const isTailwindSmallScreen = useIsTailwindSmallScreen();
   const { poolConfig, baseToken: baseTokenAddress } = hyperdrive;
   const baseToken = findBaseToken({
     baseTokenAddress,
@@ -44,14 +46,21 @@ export function FixedRateCell({
     <div
       className={classNames("daisy-stat flex p-0", { "flex-col": vertical })}
     >
-      <span className="daisy-stat-value text-md font-bold">
+      <span
+        className={classNames("daisy-stat-value text-md font-bold", {
+          "flex w-16 justify-end": !isTailwindSmallScreen,
+        })}
+      >
         {formatRate(fixedRate)}%
       </span>
       <div
         data-tip={"Yield after fees if held to maturity"}
-        className={
-          "daisy-stat-desc daisy-tooltip mt-1 inline-flex text-xs text-success"
-        }
+        className={classNames(
+          "daisy-stat-desc daisy-tooltip mt-1 inline-flex text-xs text-success",
+          {
+            "flex w-16 justify-end": !isTailwindSmallScreen,
+          },
+        )}
       >
         <span>{"+"}</span>
         {formatBalance({

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/FixedRateCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/FixedRateCell.tsx
@@ -52,14 +52,12 @@ export function FixedRateCell({
         },
       )}
     >
-      <span className={classNames("daisy-stat-value text-md font-bold")}>
+      <span className="daisy-stat-value text-md font-bold">
         {formatRate(fixedRate)}%
       </span>
       <div
         data-tip={"Yield after fees if held to maturity"}
-        className={classNames(
-          "daisy-stat-desc daisy-tooltip mt-1 inline-flex text-xs text-success",
-        )}
+        className="daisy-stat-desc daisy-tooltip mt-1 inline-flex text-xs text-success"
       >
         <span>{"+"}</span>
         {formatBalance({

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
@@ -192,7 +192,7 @@ function getColumns({
       header: `Size (hy${baseToken.symbol})`,
       cell: ({ row }) => {
         return (
-          <span>
+          <span className="flex w-20 justify-end">
             {formatBalance({
               balance: row.original.bondAmount,
               decimals: baseToken.decimals,
@@ -207,11 +207,15 @@ function getColumns({
       header: `Cost (${baseToken.symbol})`,
       cell: (baseAmountPaid) => {
         const amountPaid = baseAmountPaid.getValue();
-        return formatBalance({
-          balance: amountPaid,
-          decimals: baseToken.decimals,
-          places: baseToken.places,
-        });
+        return (
+          <span className="flex w-16 justify-end">
+            {formatBalance({
+              balance: amountPaid,
+              decimals: baseToken.decimals,
+              places: baseToken.places,
+            })}
+          </span>
+        );
       },
     }),
     columnHelper.accessor("assetId", {

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/AccruedYieldCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/AccruedYieldCell.tsx
@@ -1,8 +1,10 @@
 import { OpenShort } from "@delvtech/hyperdrive-viem";
 import { HyperdriveConfig, findBaseToken } from "@hyperdrive/appconfig";
+import classNames from "classnames";
 import { ReactElement } from "react";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
+import { useIsTailwindSmallScreen } from "src/ui/base/mediaBreakpoints";
 import { useAccruedYield } from "src/ui/hyperdrive/hooks/useAccruedYield";
 
 export function AccruedYieldCell({
@@ -13,6 +15,7 @@ export function AccruedYieldCell({
   hyperdrive: HyperdriveConfig;
 }): ReactElement {
   const { bondAmount, checkpointId } = openShort;
+  const isTailwindSmallScreen = useIsTailwindSmallScreen();
   const appConfig = useAppConfig();
   const baseToken = findBaseToken({
     baseTokenAddress: hyperdrive.baseToken,
@@ -25,14 +28,16 @@ export function AccruedYieldCell({
   });
 
   return (
-    <div className="flex flex-col gap-1">
-      <span>
-        {formatBalance({
-          balance: accruedYield || 0n,
-          decimals: baseToken.decimals,
-          places: baseToken.places,
-        })}
-      </span>
-    </div>
+    <span
+      className={classNames({
+        "flex w-28 justify-end": !isTailwindSmallScreen,
+      })}
+    >
+      {formatBalance({
+        balance: accruedYield || 0n,
+        decimals: baseToken.decimals,
+        places: baseToken.places,
+      })}
+    </span>
   );
 }

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/CurrentValueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/CurrentValueCell.tsx
@@ -6,6 +6,7 @@ import { parseUnits } from "src/base/parseUnits";
 import { convertSharesToBase } from "src/hyperdrive/convertSharesToBase";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
+import { useIsTailwindSmallScreen } from "src/ui/base/mediaBreakpoints";
 import { usePoolInfo } from "src/ui/hyperdrive/hooks/usePoolInfo";
 import { usePreviewCloseShort } from "src/ui/hyperdrive/shorts/hooks/usePreviewCloseShort";
 import { useAccount } from "wagmi";
@@ -18,6 +19,7 @@ export function CurrentValueCell({
   hyperdrive: HyperdriveConfig;
 }): ReactElement {
   const { address: account } = useAccount();
+  const isTailwindSmallScreen = useIsTailwindSmallScreen();
   const appConfig = useAppConfig();
   const baseToken = findBaseToken({
     baseTokenAddress: hyperdrive.baseToken,
@@ -59,7 +61,11 @@ export function CurrentValueCell({
     currentValueInBase && currentValueInBase > openShort.baseAmountPaid;
 
   return (
-    <div className="daisy-stat p-0">
+    <div
+      className={classNames("daisy-stat p-0", {
+        "flex w-32 flex-col items-end": !isTailwindSmallScreen,
+      })}
+    >
       <span className="daisy-stat-value text-md font-bold">
         {currentValueLabel?.toString()}
       </span>
@@ -69,6 +75,7 @@ export function CurrentValueCell({
           className={classNames(
             "daisy-tooltip daisy-tooltip-left mt-1 flex text-xs before:border",
             { "text-success": isPositiveChangeInValue },
+
             {
               "text-error":
                 !isPositiveChangeInValue &&

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/CurrentValueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/CurrentValueCell.tsx
@@ -75,7 +75,6 @@ export function CurrentValueCell({
           className={classNames(
             "daisy-tooltip daisy-tooltip-left mt-1 flex text-xs before:border",
             { "text-success": isPositiveChangeInValue },
-
             {
               "text-error":
                 !isPositiveChangeInValue &&

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktop.tsx
@@ -172,7 +172,7 @@ function getColumns(
         const amountPaid = baseAmountPaid.getValue();
         return (
           <div className="daisy-stat flex flex-row p-0 xl:flex-col">
-            <span className="daisy-stat-value text-xs font-normal lg:flex lg:w-16 lg:justify-end lg:text-md">
+            <span className="daisy-stat-value flex w-16 justify-end text-md font-normal">
               {formatBalance({
                 balance: amountPaid,
                 decimals: baseToken.decimals,
@@ -181,7 +181,7 @@ function getColumns(
             </span>
             <div
               className={classNames(
-                "daisy-stat-desc inline-flex text-xs lg:mt-1 lg:flex lg:w-16 lg:justify-end",
+                "daisy-stat-desc mt-1 flex w-16 justify-end text-xs",
               )}
             >
               <span>{formatRate(fixedRate)}% APR</span>

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktop.tsx
@@ -147,11 +147,15 @@ function getColumns(
       header: `Size (hy${baseToken.symbol})`,
       cell: (bondAmount) => {
         const bondAmountValue = bondAmount.getValue();
-        return formatBalance({
-          balance: bondAmountValue,
-          decimals: baseToken.decimals,
-          places: baseToken.places,
-        });
+        return (
+          <span className="flex w-20 justify-end">
+            {formatBalance({
+              balance: bondAmountValue,
+              decimals: baseToken.decimals,
+              places: baseToken.places,
+            })}
+          </span>
+        );
       },
     }),
     columnHelper.accessor("baseAmountPaid", {
@@ -168,14 +172,18 @@ function getColumns(
         const amountPaid = baseAmountPaid.getValue();
         return (
           <div className="daisy-stat flex flex-row p-0 xl:flex-col">
-            <span className="daisy-stat-value text-xs font-normal lg:text-md">
+            <span className="daisy-stat-value text-xs font-normal lg:flex lg:w-16 lg:justify-end lg:text-md">
               {formatBalance({
                 balance: amountPaid,
                 decimals: baseToken.decimals,
                 places: baseToken.places,
               })}
             </span>
-            <div className={"daisy-stat-desc inline-flex text-xs lg:mt-1"}>
+            <div
+              className={classNames(
+                "daisy-stat-desc inline-flex text-xs lg:mt-1 lg:flex lg:w-16 lg:justify-end",
+              )}
+            >
               <span>{formatRate(fixedRate)}% APR</span>
             </div>
           </div>


### PR DESCRIPTION
This PR right aligns some of stats in the position table. I've only done this for values where decimals could appear so the decimals will always be aligned vertically (see screenshots below). I couldn't rely on the standard `align-right` from tailwind here because of the way react-table maps over the data, as well as how it handles column widths.
Before Longs:
![image](https://github.com/delvtech/hyperdrive-frontend/assets/22210106/bd38cb86-aa05-4a1d-8ea1-89f256a92979)
After Longs:
![image](https://github.com/delvtech/hyperdrive-frontend/assets/22210106/372d4b99-eaa1-47f5-a2a8-227de4416204)
Before Shorts:
![image](https://github.com/delvtech/hyperdrive-frontend/assets/22210106/181a86c6-0f82-4e27-837a-07b08192cb3a)
After Shorts:
![image](https://github.com/delvtech/hyperdrive-frontend/assets/22210106/5b35473c-b835-49ff-8b8f-8d0be749ba91)

