### PR TITLE
Specify minimum rust compiler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,4 @@
 [workspace]
 resolver = "2"
 members = ["crates/hyperdrive-wasm"]
+rust-version = "1.80.0"


### PR DESCRIPTION
Hyperdrive-wasm needs at least this version to compile correctly. 

You can upgrade to the latest version of rust by running `rustup update`
 or checking your existing version with `rustup -V`.