### PR TITLE
Add metamask to wallets

### DIFF
--- a/apps/hyperdrive-trading/src/network/wagmiClient.ts
+++ b/apps/hyperdrive-trading/src/network/wagmiClient.ts
@@ -1,6 +1,7 @@
 import { getDefaultConfig } from "@rainbow-me/rainbowkit";
 import {
   injectedWallet,
+  metaMaskWallet,
   rainbowWallet,
   safeWallet,
   walletConnectWallet,
@@ -25,7 +26,12 @@ const {
 export const chains: Chain[] = [];
 const transports: Record<string, Transport> = {};
 
-const recommendedWallets = [injectedWallet, safeWallet, rainbowWallet];
+const recommendedWallets = [
+  injectedWallet,
+  safeWallet,
+  rainbowWallet,
+  metaMaskWallet,
+];
 const customWallets: CreateWalletFn[] = [];
 
 // WalletConnect


### PR DESCRIPTION
This wasn't explicitly included in the recommended wallets list, so it wasn't showing on mobile. On desktop this is a no-op, as rainbowkit can discover the installed browser wallet.