### PR TITLE
Fix adjustAmountByPercentage decimals

### DIFF
--- a/apps/hyperdrive-sdk-docs/docs/sdk/guides/open-a-position.md
+++ b/apps/hyperdrive-sdk-docs/docs/sdk/guides/open-a-position.md
@@ -50,7 +50,7 @@ const { bondProceeds } = await hyperdrive.previewOpenLong({
 // 2. Adjust by your slippage tolerance
 const minBondsOut = adjustAmountByPercentage({
   amount: bondProceeds,
-  percentage: parseUnits("1", 18), // <- Adjust for your tolerance
+  percentage: 1n, // <- Adjust for your tolerance
   decimals: 18,
   direction: "down",
 });

--- a/apps/hyperdrive-sdk-docs/docs/sdk/guides/open-a-position.md
+++ b/apps/hyperdrive-sdk-docs/docs/sdk/guides/open-a-position.md
@@ -50,7 +50,7 @@ const { bondProceeds } = await hyperdrive.previewOpenLong({
 // 2. Adjust by your slippage tolerance
 const minBondsOut = adjustAmountByPercentage({
   amount: bondProceeds,
-  percentage: 1n, // <- Adjust for your tolerance
+  percentage: parseUnits("1", 18), // <- Adjust for your tolerance
   decimals: 18,
   direction: "down",
 });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongForm/CloseLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongForm/CloseLongForm.tsx
@@ -89,7 +89,7 @@ export function CloseLongForm({
     withdrawAmount &&
     adjustAmountByPercentage({
       amount: withdrawAmount,
-      percentage: 1n,
+      percentage: parseUnits("1", activeWithdrawToken.decimals),
       decimals: activeWithdrawToken.decimals,
       direction: "down",
     });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortForm/CloseShortForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortForm/CloseShortForm.tsx
@@ -18,7 +18,7 @@ import { TransactionView } from "src/ui/hyperdrive/TransactionView";
 import { useTokenBalance } from "src/ui/token/hooks/useTokenBalance";
 import { TokenInput } from "src/ui/token/TokenInput";
 import { TokenChoice, TokenPicker } from "src/ui/token/TokenPicker";
-import { formatUnits } from "viem";
+import { formatUnits, parseUnits } from "viem";
 import { useAccount } from "wagmi";
 
 interface CloseShortFormProps {
@@ -88,7 +88,7 @@ export function CloseShortForm({
     amountOut &&
     adjustAmountByPercentage({
       amount: amountOut,
-      percentage: 1n,
+      percentage: parseUnits("1", activeWithdrawToken.decimals),
       decimals: activeWithdrawToken.decimals,
       direction: "down",
     });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useOpenShort.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useOpenShort.tsx
@@ -10,7 +10,7 @@ import TransactionToast from "src/ui/base/components/Toaster/TransactionToast";
 import { SUCCESS_TOAST_DURATION } from "src/ui/base/toasts";
 import { useReadWriteHyperdrive } from "src/ui/hyperdrive/hooks/useReadWriteHyperdrive";
 import { toastWarpcast } from "src/ui/social/WarpcastToast";
-import { Address, Hash } from "viem";
+import { Address, Hash, parseUnits } from "viem";
 import { usePublicClient } from "wagmi";
 
 interface UseOpenShortOptions {
@@ -68,7 +68,7 @@ export function useOpenShort({
                 amount: ethValue,
                 decimals: 18,
                 direction: "up",
-                percentage: 1n,
+                percentage: parseUnits("1", 18),
               })
             : undefined,
         };


### PR DESCRIPTION
I had originally updated the adjustAmountByPercentage to handle floating point bigints, but there were a few points where we were not converting whole percentage numbers to their decimal alternatives. 
Co-authored-by: Danny Delott <DannyDelott@users.noreply.github.com>