### PR TITLE
Tile layout for All Markets page

### DIFF
--- a/apps/hyperdrive-trading/src/ui/app/Navbar/FeatureFlagPicker.tsx
+++ b/apps/hyperdrive-trading/src/ui/app/Navbar/FeatureFlagPicker.tsx
@@ -13,9 +13,8 @@ export function FeatureFlagPicker(): ReactElement {
       >
         <li className="daisy-menu-title">Feature flags</li>
         {/* Place your feature flag menu items here */}
-        {/* TODO: Remove implied-yield once calculation is fixed in rust sdk */}
-        <FeatureFlagMenuItem flagName={"implied-yield"}>
-          Show Implied Yield
+        <FeatureFlagMenuItem flagName={"card-view"}>
+          Card layout
         </FeatureFlagMenuItem>
       </ul>
     </div>

--- a/apps/hyperdrive-trading/src/ui/base/components/Well/Well.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/Well/Well.tsx
@@ -5,7 +5,6 @@ interface WellProps {
   interactive?: boolean;
   elevation?: "flat" | "elevated";
   transparent?: boolean;
-  outlined?: boolean;
   block?: boolean;
   disabled?: boolean;
   onClick?: () => void;
@@ -16,25 +15,24 @@ export function Well({
   interactive,
   elevation = "elevated",
   transparent,
-  outlined,
   children,
   block,
   onClick,
 }: PropsWithChildren<WellProps>): ReactElement {
   const isInteractive = !disabled && (interactive || onClick);
   const className = classNames(
-    "daisy-card p-7 border",
-    outlined ? "border-1 border-lime" : "border-1 border-neutral-content/20",
+    "daisy-card p-7 border border-1 border-neutral-content/20",
     {
       "shadow-md": elevation === "elevated",
       "bg-base-200": !transparent,
       "w-full": block,
-      "hover:cursor-pointer hover:-translate-y-1 transition duration-300 hover:shadow-xl ease-in-out":
+      "hover:-translate-y-0.5 hover:scale-[1.01] transition duration-300 hover:shadow-xl ease-in-out hover:shadow-primary/5":
         isInteractive,
+      "hover:cursor-pointer": onClick,
     },
   );
 
-  if (onClick || interactive) {
+  if (onClick) {
     return (
       <button className={className} onClick={onClick} disabled={disabled}>
         {children}

--- a/apps/hyperdrive-trading/src/ui/landing/Landing.tsx
+++ b/apps/hyperdrive-trading/src/ui/landing/Landing.tsx
@@ -1,22 +1,52 @@
 import { ReactElement } from "react";
 import { CommonHeadTags } from "src/ui/app/Head/CommonHeadTags";
+import { useAppConfig } from "src/ui/appconfig/useAppConfig";
+import { useFeatureFlag } from "src/ui/base/featureFlags/featureFlags";
 import { useIsTailwindSmallScreen } from "src/ui/base/mediaBreakpoints";
 import { Hero } from "src/ui/landing/Hero/Hero";
 import { AllMarketsTable } from "src/ui/markets/AllMarketsTable/AllMarketsTable";
+import { YieldSourceCard } from "src/ui/markets/YieldSourceCard/YieldSourceCard";
 import { FAQ } from "src/ui/onboarding/FAQ/FAQ";
 import { MobileFaq } from "src/ui/onboarding/FAQ/MobileFaq";
 import { PositionCards } from "./PositionCards/PositionCards";
 
 export function Landing(): ReactElement | null {
   const isSmallScreenView = useIsTailwindSmallScreen();
+  const { isFlagEnabled: showCardView } = useFeatureFlag("card-view");
 
   return (
     <div className="flex flex-col items-center gap-14 px-4 py-8">
       <CommonHeadTags />
       <Hero />
-      <AllMarketsTable />
+      <div className="flex w-full flex-col items-center">
+        {!showCardView ? (
+          <>
+            <h3 className="gradient-text mb-8 text-center">
+              Available Markets
+            </h3>
+            <div className="daisy-card daisy-card-bordered flex w-full md:w-auto md:p-6">
+              <AllMarketsTable />
+            </div>
+          </>
+        ) : (
+          <YieldSourceCards />
+        )}
+      </div>
+
       <PositionCards />
       {isSmallScreenView ? <MobileFaq /> : <FAQ />}
+    </div>
+  );
+}
+
+function YieldSourceCards() {
+  const appConfig = useAppConfig();
+
+  return (
+    <div className="flex flex-wrap justify-center gap-16">
+      {Object.entries(appConfig.protocols).map(([key, protocol]) => (
+        <YieldSourceCard key={key} protocol={protocol} />
+      ))}
     </div>
   );
 }

--- a/apps/hyperdrive-trading/src/ui/landing/PositionCards/PositionCard.tsx
+++ b/apps/hyperdrive-trading/src/ui/landing/PositionCards/PositionCard.tsx
@@ -7,7 +7,6 @@ interface Props {
   subtitle: string;
   icon: ReactNode;
   checklist: string[];
-  emphasized?: boolean;
 }
 
 export function PositionCard({
@@ -15,10 +14,9 @@ export function PositionCard({
   subtitle,
   icon,
   checklist,
-  emphasized,
 }: Props): ReactElement {
   return (
-    <Well outlined={emphasized}>
+    <Well>
       <div className="flex w-[290px] flex-col p-3 md:w-[325px]">
         <div className="mb-8 flex w-12 justify-center rounded-lg bg-gray-600 p-4">
           {icon}

--- a/apps/hyperdrive-trading/src/ui/markets/AllMarketsTable/AllMarketsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/AllMarketsTable/AllMarketsTable.tsx
@@ -5,16 +5,10 @@ import { AllMarketsTableMobile } from "src/ui/markets/AllMarketsTable/AllMarkets
 
 export function AllMarketsTable(): ReactElement {
   const isTailwindSmallScreen = useIsTailwindSmallScreen();
-  return (
-    <div className="flex w-full flex-col items-center">
-      <h3 className="gradient-text mb-8 text-center">Available Markets</h3>
-      <div className="daisy-card daisy-card-bordered flex w-full md:w-auto md:p-6">
-        {isTailwindSmallScreen ? (
-          <AllMarketsTableMobile />
-        ) : (
-          <AllMarketsTableDesktop />
-        )}
-      </div>
-    </div>
+
+  return isTailwindSmallScreen ? (
+    <AllMarketsTableMobile />
+  ) : (
+    <AllMarketsTableDesktop />
   );
 }

--- a/apps/hyperdrive-trading/src/ui/markets/Markets.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/Markets.tsx
@@ -1,9 +1,12 @@
 import { ReactElement } from "react";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
+import { useFeatureFlag } from "src/ui/base/featureFlags/featureFlags";
 import { AllMarketsTable } from "src/ui/markets/AllMarketsTable/AllMarketsTable";
 
 export function Markets(): ReactElement {
   const appConfig = useAppConfig();
+
+  const { isFlagEnabled: showCardView } = useFeatureFlag("card-view");
 
   if (!appConfig?.hyperdrives.length) {
     return <div>No markets found</div>;
@@ -24,7 +27,7 @@ export function Markets(): ReactElement {
           </div>
         </div>
       </div>
-      <AllMarketsTable />
+      {!showCardView ? <AllMarketsTable /> : null}
     </div>
   );
 }

--- a/apps/hyperdrive-trading/src/ui/markets/YieldSourceCard/YieldSourceCard.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/YieldSourceCard/YieldSourceCard.tsx
@@ -1,0 +1,124 @@
+import { ArrowRightCircleIcon } from "@heroicons/react/16/solid";
+import {
+  Protocol,
+  findBaseToken,
+  findYieldSourceToken,
+} from "@hyperdrive/appconfig";
+import { ReactElement } from "react";
+import { useAppConfig } from "src/ui/appconfig/useAppConfig";
+import { Badge } from "src/ui/base/components/Badge";
+import { Well } from "src/ui/base/components/Well/Well";
+
+export function YieldSourceCard({
+  protocol,
+}: {
+  protocol: Protocol;
+}): ReactElement {
+  const appConfig = useAppConfig();
+
+  const pools = appConfig.hyperdrives.filter((hyperdrive) => {
+    const sharesToken = findYieldSourceToken({
+      tokens: appConfig.tokens,
+      yieldSourceTokenAddress: hyperdrive.sharesToken,
+    });
+    return sharesToken.extensions.protocol === protocol.id;
+  });
+
+  const {
+    depositOptions: { isBaseTokenDepositEnabled, isShareTokenDepositsEnabled },
+  } = pools[0];
+  const baseToken = findBaseToken({
+    baseTokenAddress: pools[0].baseToken,
+    tokens: appConfig.tokens,
+  });
+  const sharesToken = findYieldSourceToken({
+    yieldSourceTokenAddress: pools[0].sharesToken,
+    tokens: appConfig.tokens,
+  });
+
+  // TODO: Implement the values and markets table, most of the data is stubbed
+  // for now
+
+  return (
+    <Well transparent interactive>
+      <div className="flex flex-col gap-2">
+        {/* Card header */}
+        <div className="flex justify-between gap-4 p-4">
+          <div className="flex gap-5">
+            <img src={protocol.iconUrl} className="h-20" />
+            <div>
+              <h3 className="mb-1">{sharesToken.extensions.shortName}</h3>
+              <Badge>
+                <span className="font-dmMono text-neutral-content">
+                  Current APY @ <span className="text-primary">23.17%</span>
+                </span>
+              </Badge>
+            </div>
+          </div>
+
+          <div className="flex flex-col text-neutral-content ">
+            <span className="mb-2 flex">Deposit assets</span>
+            <div className="daisy-avatar-group inline-flex justify-center -space-x-6 rtl:space-x-reverse">
+              {isBaseTokenDepositEnabled ? (
+                <div className="daisy-avatar">
+                  <div className="w-12">
+                    <img src={baseToken.iconUrl} />
+                  </div>
+                </div>
+              ) : null}
+              {isShareTokenDepositsEnabled ? (
+                <div className="daisy-avatar">
+                  <div className="w-12">
+                    <img src={sharesToken.iconUrl} />
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </div>
+
+        {/* Pools Table */}
+        <table className="daisy-table daisy-table-zebra daisy-table-lg mt-8">
+          <thead>
+            <tr className="text-sm">
+              {["Term", "Fixed APR", "Short APY", "LP APY", "Liquidity"].map(
+                (header) => (
+                  <th className="font-normal text-gray-400" key={header}>
+                    {header}{" "}
+                  </th>
+                ),
+              )}
+            </tr>
+          </thead>
+
+          <tbody>
+            <tr className="daisy-hover h-20 cursor-pointer border-b-0 text-gray-50">
+              <td>14 days</td>
+              <td>5.27%</td>
+              <td>4.15%</td>
+              <td>1.65%</td>
+              <td>1.62M {baseToken.symbol}</td>
+              <td>
+                <button className="daisy-btn-circle daisy-btn-xs flex items-center justify-center rounded-full">
+                  <ArrowRightCircleIcon className="h-8" />
+                </button>
+              </td>
+            </tr>
+            <tr className="daisy-hover h-20 cursor-pointer border-b-0 text-gray-50">
+              <td>30 days</td>
+              <td>5.01%</td>
+              <td>3.27%</td>
+              <td>6.91%</td>
+              <td>762K {baseToken.symbol}</td>
+              <td>
+                <button className="daisy-btn-circle daisy-btn-xs flex items-center justify-center rounded-full">
+                  <ArrowRightCircleIcon className="h-8" />
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </Well>
+  );
+}

--- a/apps/hyperdrive-trading/src/ui/onboarding/FAQ/FAQ.tsx
+++ b/apps/hyperdrive-trading/src/ui/onboarding/FAQ/FAQ.tsx
@@ -59,9 +59,7 @@ export function FAQEntries(): JSX.Element {
 
         {/* answers */}
         <div className="col-span-2 flex flex-col">
-          <h4 className="mb-4 font-medium text-neutral-content">
-            {selectedFAQ?.question}
-          </h4>
+          <h4 className="mb-4 text-neutral-content">{selectedFAQ?.question}</h4>
           <div className="text-base-content">{selectedFAQ?.answer}</div>
         </div>
       </div>

--- a/packages/hyperdrive-appconfig/src/generated/11155111.appconfig.ts
+++ b/packages/hyperdrive-appconfig/src/generated/11155111.appconfig.ts
@@ -79,6 +79,54 @@ export const sepoliaAppConfig: AppConfig = {
       extensions: {},
     },
     {
+      address: "0xECa45b0391E81c311F1b390808a3BA3214d35eAA",
+      decimals: 18,
+      places: 2,
+      name: "sDAI",
+      symbol: "SDAI",
+      iconUrl: "https://etherscan.io/token/images/Badgedai_32.svg",
+      tags: ["yieldSource", "erc4626"],
+      extensions: {
+        shortName: "Maker DSR",
+        protocol: "maker",
+      },
+    },
+    {
+      address: "0x552ceaDf3B47609897279F42D3B3309B604896f3",
+      decimals: 18,
+      places: 2,
+      name: "DAI",
+      symbol: "DAI",
+      iconUrl:
+        "https://cryptologos.cc/logos/multi-collateral-dai-dai-logo.png?v=029",
+      tags: [],
+      extensions: {},
+    },
+    {
+      address: "0xECa45b0391E81c311F1b390808a3BA3214d35eAA",
+      decimals: 18,
+      places: 2,
+      name: "sDAI",
+      symbol: "SDAI",
+      iconUrl: "https://etherscan.io/token/images/Badgedai_32.svg",
+      tags: ["yieldSource", "erc4626"],
+      extensions: {
+        shortName: "Maker DSR",
+        protocol: "maker",
+      },
+    },
+    {
+      address: "0x552ceaDf3B47609897279F42D3B3309B604896f3",
+      decimals: 18,
+      places: 2,
+      name: "DAI",
+      symbol: "DAI",
+      iconUrl:
+        "https://cryptologos.cc/logos/multi-collateral-dai-dai-logo.png?v=029",
+      tags: [],
+      extensions: {},
+    },
+    {
       address: "0x3A2031f3FAb5AA2b5c47c02fcD9f26072977834c",
       decimals: 18,
       places: 2,
@@ -90,54 +138,6 @@ export const sepoliaAppConfig: AppConfig = {
       extensions: {
         shortName: "MetaMorpho",
         protocol: "morpho",
-      },
-    },
-    {
-      address: "0x552ceaDf3B47609897279F42D3B3309B604896f3",
-      decimals: 18,
-      places: 2,
-      name: "DAI",
-      symbol: "DAI",
-      iconUrl:
-        "https://cryptologos.cc/logos/multi-collateral-dai-dai-logo.png?v=029",
-      tags: [],
-      extensions: {},
-    },
-    {
-      address: "0xECa45b0391E81c311F1b390808a3BA3214d35eAA",
-      decimals: 18,
-      places: 2,
-      name: "sDAI",
-      symbol: "SDAI",
-      iconUrl: "https://etherscan.io/token/images/Badgedai_32.svg",
-      tags: ["yieldSource", "erc4626"],
-      extensions: {
-        shortName: "Maker DSR",
-        protocol: "maker",
-      },
-    },
-    {
-      address: "0x552ceaDf3B47609897279F42D3B3309B604896f3",
-      decimals: 18,
-      places: 2,
-      name: "DAI",
-      symbol: "DAI",
-      iconUrl:
-        "https://cryptologos.cc/logos/multi-collateral-dai-dai-logo.png?v=029",
-      tags: [],
-      extensions: {},
-    },
-    {
-      address: "0xECa45b0391E81c311F1b390808a3BA3214d35eAA",
-      decimals: 18,
-      places: 2,
-      name: "sDAI",
-      symbol: "SDAI",
-      iconUrl: "https://etherscan.io/token/images/Badgedai_32.svg",
-      tags: ["yieldSource", "erc4626"],
-      extensions: {
-        shortName: "Maker DSR",
-        protocol: "maker",
       },
     },
     {
@@ -378,19 +378,23 @@ export const sepoliaAppConfig: AppConfig = {
   ],
   protocols: {
     maker: {
+      id: "maker",
       name: "Maker",
       iconUrl: "https://cryptologos.cc/logos/maker-mkr-logo.png?v=024",
     },
     lido: {
+      id: "lido",
       name: "Lido",
       iconUrl: "https://cryptologos.cc/logos/lido-dao-ldo-logo.png?v=029",
     },
     morpho: {
+      id: "morpho",
       name: "Morpho",
       iconUrl:
         "https://assets.coingecko.com/coins/images/29837/large/2022-official-morpho-token.png?1696528764",
     },
     rocketPool: {
+      id: "rocketPool",
       name: "Rocket Pool",
       iconUrl:
         "https://assets.coingecko.com/coins/images/2090/large/rocket_pool_%28RPL%29.png?1696503058",

--- a/packages/hyperdrive-appconfig/src/generated/31337.appconfig.ts
+++ b/packages/hyperdrive-appconfig/src/generated/31337.appconfig.ts
@@ -139,10 +139,12 @@ export const localChainAppConfig: AppConfig = {
   ],
   protocols: {
     maker: {
+      id: "maker",
       name: "Maker",
       iconUrl: "https://cryptologos.cc/logos/maker-mkr-logo.png?v=024",
     },
     lido: {
+      id: "lido",
       name: "Lido",
       iconUrl: "https://cryptologos.cc/logos/lido-dao-ldo-logo.png?v=029",
     },

--- a/packages/hyperdrive-appconfig/src/generated/42069.appconfig.ts
+++ b/packages/hyperdrive-appconfig/src/generated/42069.appconfig.ts
@@ -140,10 +140,12 @@ export const cloudChainAppConfig: AppConfig = {
   protocols: {
     maker: {
       name: "Maker",
+      id: "maker",
       iconUrl: "https://cryptologos.cc/logos/maker-mkr-logo.png?v=024",
     },
     lido: {
       name: "Lido",
+      id: "lido",
       iconUrl: "https://cryptologos.cc/logos/lido-dao-ldo-logo.png?v=029",
     },
   },

--- a/packages/hyperdrive-appconfig/src/protocols/protocols.ts
+++ b/packages/hyperdrive-appconfig/src/protocols/protocols.ts
@@ -1,25 +1,30 @@
 export interface Protocol {
+  id: string;
   name: string;
   iconUrl: string;
 }
 
 const lido: Protocol = {
+  id: "lido",
   name: "Lido",
   iconUrl: "https://cryptologos.cc/logos/lido-dao-ldo-logo.png?v=029",
 };
 
 const maker: Protocol = {
+  id: "maker",
   name: "Maker",
   iconUrl: "https://cryptologos.cc/logos/maker-mkr-logo.png?v=024",
 };
 
 const morpho: Protocol = {
+  id: "morpho",
   name: "Morpho",
   iconUrl:
     "https://assets.coingecko.com/coins/images/29837/large/2022-official-morpho-token.png?1696528764",
 };
 
 const rocketPool: Protocol = {
+  id: "rocketPool",
   name: "Rocket Pool",
   iconUrl:
     "https://assets.coingecko.com/coins/images/2090/large/rocket_pool_%28RPL%29.png?1696503058",


### PR DESCRIPTION
Quick wireframe of the Tile layout for the All Markets page.

### Problem: Short APY doesn't fit in current All Markets table
- We don't have room for another column
- Combining the Short APY into an existing column is weird too
- All Markets table contains a lot of duplicate information, creating visual noise the more pools we add
	- (base asset + icon, yield source info, and Variable Rate... basically half of the table info).

### Solution: Tile layout
- Grouping by yield source allows us to quickly find markets and choose a term.
- Duplicate info is "lifted up" into a single place on the tile
- Table on each tile only contains dynamic values a trader cares about

https://github.com/delvtech/hyperdrive-frontend/assets/4524175/e2111608-46e1-4df9-8ae9-cb5ddd4f0bc9

