### PR TITLE
Add total long value to long tab

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useTotalLongsValue.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useTotalLongsValue.ts
@@ -1,26 +1,26 @@
-import { Long, PoolInfo, ReadHyperdrive } from "@delvtech/hyperdrive-viem";
+import { Long, PoolInfo } from "@delvtech/hyperdrive-viem";
 import { HyperdriveConfig } from "@hyperdrive/appconfig";
 import { useQueries } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { parseUnits } from "src/base/parseUnits";
 import { convertSharesToBase } from "src/hyperdrive/convertSharesToBase";
+import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
 
 export function useTotalLongsValue({
   hyperdrive,
   account,
   openLongs,
-  readHyperdrive,
   poolInfo,
 }: {
   hyperdrive: HyperdriveConfig;
   account: Address | undefined;
   openLongs: Long[] | undefined;
-  readHyperdrive: ReadHyperdrive | undefined;
   poolInfo: PoolInfo | undefined;
 }): { totalLongsValue: bigint | undefined; isLoading: boolean } {
+  const readHyperdrive = useReadHyperdrive(hyperdrive.address);
+  let isLoading = true;
   let totalLongsValue = 0n;
-  let isLoading = false;
   const queryEnabled =
     !!account && !!openLongs && !!readHyperdrive && !!poolInfo;
   const previewCloseLongQueries = useQueries({
@@ -47,18 +47,27 @@ export function useTotalLongsValue({
           }),
       })) ?? [],
   });
-  previewCloseLongQueries.forEach((query) => {
-    if (query.status === "success") {
-      const amountOutInBase = convertSharesToBase({
-        decimals: hyperdrive.decimals,
-        sharesAmount: query.data,
-        vaultSharePrice: poolInfo?.vaultSharePrice,
-      });
-      totalLongsValue += amountOutInBase || 0n;
-    }
-    if (query.status === "loading") {
-      isLoading = true;
-    }
-  });
+
+  const allQueriesSucceeded = previewCloseLongQueries.every(
+    (query) => query.status === "success",
+  );
+
+  if (allQueriesSucceeded) {
+    previewCloseLongQueries.forEach((query) => {
+      if (query.data) {
+        const amountOutInBase = convertSharesToBase({
+          decimals: hyperdrive.decimals,
+          sharesAmount: query.data,
+          vaultSharePrice: poolInfo?.vaultSharePrice,
+        });
+        totalLongsValue += amountOutInBase || 0n;
+      }
+    });
+  }
+
+  isLoading = previewCloseLongQueries.some(
+    (query) => query.status === "loading",
+  );
+
   return { totalLongsValue, isLoading };
 }

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useTotalLongsValue.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useTotalLongsValue.ts
@@ -1,0 +1,64 @@
+import { Long, PoolInfo, ReadHyperdrive } from "@delvtech/hyperdrive-viem";
+import { HyperdriveConfig } from "@hyperdrive/appconfig";
+import { useQueries } from "@tanstack/react-query";
+import { makeQueryKey } from "src/base/makeQueryKey";
+import { parseUnits } from "src/base/parseUnits";
+import { convertSharesToBase } from "src/hyperdrive/convertSharesToBase";
+import { Address } from "viem";
+
+export function useTotalLongsValue({
+  hyperdrive,
+  account,
+  openLongs,
+  readHyperdrive,
+  poolInfo,
+}: {
+  hyperdrive: HyperdriveConfig;
+  account: Address;
+  openLongs: Long[] | undefined;
+  readHyperdrive: ReadHyperdrive | undefined;
+  poolInfo: PoolInfo | undefined;
+}): { totalLongsValue: bigint | undefined; isLoading: boolean } {
+  let totalLongsValue = 0n;
+  let isLoading = false;
+  const queryEnabled =
+    !!account && !!openLongs && !!readHyperdrive && !!poolInfo;
+  const previewCloseLongQueries = useQueries({
+    queries:
+      openLongs?.map((long) => ({
+        queryKey: makeQueryKey("previewCloseLong", {
+          hyperdriveAddress: hyperdrive.address,
+          bondAmountIn: long.bondAmount?.toString(),
+          minOutput: parseUnits("0", 18).toString(),
+          destination: account,
+          asBase: false,
+        }),
+        enabled: queryEnabled,
+        queryFn: async () =>
+          readHyperdrive?.previewCloseLong({
+            maturityTime: long.maturity,
+            bondAmountIn: long.bondAmount,
+            destination: account,
+            asBase: false,
+            minAmountOut: parseUnits("0", 18),
+            options: {
+              from: account,
+            },
+          }),
+      })) ?? [],
+  });
+  previewCloseLongQueries.forEach((query) => {
+    if (query.status === "success") {
+      const amountOutInBase = convertSharesToBase({
+        decimals: hyperdrive.decimals,
+        sharesAmount: query.data,
+        vaultSharePrice: poolInfo?.vaultSharePrice,
+      });
+      totalLongsValue += amountOutInBase || 0n;
+    }
+    if (query.status === "loading") {
+      isLoading = true;
+    }
+  });
+  return { totalLongsValue, isLoading };
+}

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useTotalLongsValue.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useTotalLongsValue.ts
@@ -20,7 +20,7 @@ export function useTotalLongsValue({
   const readHyperdrive = useReadHyperdrive(hyperdrive.address);
   const { poolInfo } = usePoolInfo({ hyperdriveAddress: hyperdrive.address });
   let isLoading = true;
-  let totalLongsValue = 0n;
+
   const queryEnabled =
     !!account && !!openLongs && !!readHyperdrive && !!poolInfo;
   const previewCloseLongQueries = useQueries({
@@ -34,24 +34,26 @@ export function useTotalLongsValue({
           asBase: false,
         }),
         enabled: queryEnabled,
-        queryFn: () =>
-          readHyperdrive?.previewCloseLong({
-            maturityTime: long.maturity,
-            bondAmountIn: long.bondAmount,
-            destination: account as Address,
-            asBase: false,
-            minAmountOut: parseUnits("0", 18),
-            options: {
-              from: account,
-            },
-          }),
+        queryFn: queryEnabled
+          ? () =>
+              readHyperdrive?.previewCloseLong({
+                maturityTime: long.maturity,
+                bondAmountIn: long.bondAmount,
+                destination: account,
+                asBase: false,
+                minAmountOut: parseUnits("0", 18),
+                options: {
+                  from: account,
+                },
+              })
+          : undefined,
       })) ?? [],
   });
 
   const allQueriesSucceeded = previewCloseLongQueries.every(
     (query) => query.status === "success",
   );
-
+  let totalLongsValue = 0n;
   if (allQueriesSucceeded) {
     previewCloseLongQueries.forEach((query) => {
       const amountOutInBase = convertSharesToBase({

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useTotalLongsValue.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useTotalLongsValue.ts
@@ -1,9 +1,10 @@
-import { Long, PoolInfo } from "@delvtech/hyperdrive-viem";
+import { Long } from "@delvtech/hyperdrive-viem";
 import { HyperdriveConfig } from "@hyperdrive/appconfig";
 import { useQueries } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { parseUnits } from "src/base/parseUnits";
 import { convertSharesToBase } from "src/hyperdrive/convertSharesToBase";
+import { usePoolInfo } from "src/ui/hyperdrive/hooks/usePoolInfo";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
 
@@ -11,14 +12,13 @@ export function useTotalLongsValue({
   hyperdrive,
   account,
   openLongs,
-  poolInfo,
 }: {
   hyperdrive: HyperdriveConfig;
   account: Address | undefined;
   openLongs: Long[] | undefined;
-  poolInfo: PoolInfo | undefined;
 }): { totalLongsValue: bigint | undefined; isLoading: boolean } {
   const readHyperdrive = useReadHyperdrive(hyperdrive.address);
+  const { poolInfo } = usePoolInfo({ hyperdriveAddress: hyperdrive.address });
   let isLoading = true;
   let totalLongsValue = 0n;
   const queryEnabled =

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useTotalLongsValue.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useTotalLongsValue.ts
@@ -14,7 +14,7 @@ export function useTotalLongsValue({
   poolInfo,
 }: {
   hyperdrive: HyperdriveConfig;
-  account: Address;
+  account: Address | undefined;
   openLongs: Long[] | undefined;
   readHyperdrive: ReadHyperdrive | undefined;
   poolInfo: PoolInfo | undefined;
@@ -34,11 +34,11 @@ export function useTotalLongsValue({
           asBase: false,
         }),
         enabled: queryEnabled,
-        queryFn: async () =>
+        queryFn: () =>
           readHyperdrive?.previewCloseLong({
             maturityTime: long.maturity,
             bondAmountIn: long.bondAmount,
-            destination: account,
+            destination: account as Address,
             asBase: false,
             minAmountOut: parseUnits("0", 18),
             options: {

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useTotalLongsValue.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useTotalLongsValue.ts
@@ -54,14 +54,12 @@ export function useTotalLongsValue({
 
   if (allQueriesSucceeded) {
     previewCloseLongQueries.forEach((query) => {
-      if (query.data) {
-        const amountOutInBase = convertSharesToBase({
-          decimals: hyperdrive.decimals,
-          sharesAmount: query.data,
-          vaultSharePrice: poolInfo?.vaultSharePrice,
-        });
-        totalLongsValue += amountOutInBase || 0n;
-      }
+      const amountOutInBase = convertSharesToBase({
+        decimals: hyperdrive.decimals,
+        sharesAmount: query.data,
+        vaultSharePrice: poolInfo?.vaultSharePrice,
+      });
+      totalLongsValue += amountOutInBase || 0n;
     });
   }
 

--- a/apps/hyperdrive-trading/src/ui/markets/LongsTab/LongsTab.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/LongsTab/LongsTab.tsx
@@ -1,31 +1,66 @@
-import { HyperdriveConfig } from "@hyperdrive/appconfig";
+import { Long, PoolInfo, ReadHyperdrive } from "@delvtech/hyperdrive-js-core";
+import { HyperdriveConfig, findBaseToken } from "@hyperdrive/appconfig";
+import { format as dnFormat } from "dnum";
 import { ReactElement } from "react";
+import Skeleton from "react-loading-skeleton";
+import { parseUnits } from "src/base/parseUnits";
+import { convertSharesToBase } from "src/hyperdrive/convertSharesToBase";
+import { useAppConfig } from "src/ui/appconfig/useAppConfig";
+import { usePoolInfo } from "src/ui/hyperdrive/hooks/usePoolInfo";
+import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { ClosedLongsTable } from "src/ui/hyperdrive/longs/ClosedLongsTable/ClosedLongsTable";
 import { OpenLongModalButton } from "src/ui/hyperdrive/longs/OpenLongModalButton/OpenLongModalButton";
 import { OpenLongsTable } from "src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTable";
 import { useOpenLongs } from "src/ui/hyperdrive/longs/hooks/useOpenLongs";
+import { useTotalLongsValue } from "src/ui/hyperdrive/longs/hooks/useTotalLongsValue";
 import { MarketDetailsTab } from "src/ui/markets/MarketDetailsTab/MarketDetailsTab";
 import { OpenClosedFilter } from "src/ui/markets/OpenClosedFilter/OpenClosedFilter";
 import { useOpenOrClosedSearchParam } from "src/ui/markets/hooks/useOpenOrClosedSearchParam";
+import { Address } from "viem";
 import { useAccount } from "wagmi";
-
 export function LongsTab({
   hyperdrive,
 }: {
   hyperdrive: HyperdriveConfig;
 }): ReactElement {
   const activeOpenOrClosedTab = useOpenOrClosedSearchParam();
+  const readHyperdrive = useReadHyperdrive(hyperdrive.address);
   const { address: account } = useAccount();
+  const appConfig = useAppConfig();
   const { openLongs } = useOpenLongs({
     account,
     hyperdriveAddress: hyperdrive.address,
   });
+  const { poolInfo } = usePoolInfo({ hyperdriveAddress: hyperdrive.address });
+  const { totalLongsValue, isLoading } = useTotalLongsValue({
+    hyperdrive,
+    account: account as Address,
+    openLongs,
+    readHyperdrive,
+    poolInfo,
+  });
+  const baseToken = findBaseToken({
+    baseTokenAddress: hyperdrive.baseToken,
+    tokens: appConfig.tokens,
+  });
+
   return (
     <MarketDetailsTab
       positions={
         <div className="flex flex-col">
           <div className="flex flex-wrap items-center justify-between gap-4 p-8">
-            <h5 className="font-medium">Long Positions</h5>
+            <div className="flex flex-col items-start gap-2">
+              <h5 className="font-medium">Long Positions</h5>
+              {!isLoading ? (
+                <p className="text-xs text-neutral-content">
+                  Total Value:{" "}
+                  {Number(dnFormat([totalLongsValue || 0n, 18])).toFixed(4)}{" "}
+                  {baseToken.symbol}
+                </p>
+              ) : (
+                <Skeleton width={100} />
+              )}
+            </div>
             <div className="flex items-center gap-4">
               {account && openLongs?.length ? (
                 <OpenLongModalButton
@@ -45,4 +80,50 @@ export function LongsTab({
       }
     />
   );
+}
+
+function calculateTotalLongsValue({
+  hyperdrive,
+  account,
+  openLongs,
+  readHyperdrive,
+  poolInfo,
+}: {
+  hyperdrive: HyperdriveConfig;
+  account: Address | undefined;
+  openLongs: Long[] | undefined;
+  readHyperdrive: ReadHyperdrive | undefined;
+  poolInfo: PoolInfo | undefined;
+}) {
+  return new Promise(async (resolve) => {
+    if (!readHyperdrive) {
+      resolve(0);
+    }
+    let totalValue = 0n;
+    if (openLongs && account && readHyperdrive && poolInfo) {
+      const promises = openLongs.map(async (long) => {
+        const sharesAmountOut = await readHyperdrive.previewCloseLong({
+          maturityTime: long.maturity,
+          bondAmountIn: long.bondAmount,
+          destination: account,
+          asBase: false,
+          minAmountOut: parseUnits("0", 18),
+          options: {
+            from: account,
+          },
+        });
+        const amountOutInBase = convertSharesToBase({
+          decimals: hyperdrive.decimals,
+          sharesAmount: sharesAmountOut,
+          vaultSharePrice: poolInfo?.vaultSharePrice,
+        });
+
+        return amountOutInBase;
+      });
+
+      const results = await Promise.all(promises);
+      totalValue = results.reduce((acc, val) => acc + val, 0n);
+    }
+    resolve(totalValue);
+  });
 }

--- a/apps/hyperdrive-trading/src/ui/markets/LongsTab/LongsTab.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/LongsTab/LongsTab.tsx
@@ -50,7 +50,7 @@ export function LongsTab({
                     <p className="text-xs text-neutral-content">
                       Total Value:{" "}
                       {dnFormat([totalLongsValue || 0n, baseToken.decimals], {
-                        digits: 2,
+                        digits: 4,
                       })}{" "}
                       {baseToken.symbol}
                     </p>

--- a/apps/hyperdrive-trading/src/ui/markets/LongsTab/LongsTab.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/LongsTab/LongsTab.tsx
@@ -34,7 +34,7 @@ export function LongsTab({
   const { poolInfo } = usePoolInfo({ hyperdriveAddress: hyperdrive.address });
   const { totalLongsValue, isLoading } = useTotalLongsValue({
     hyperdrive,
-    account: account as Address,
+    account,
     openLongs,
     readHyperdrive,
     poolInfo,
@@ -43,7 +43,6 @@ export function LongsTab({
     baseTokenAddress: hyperdrive.baseToken,
     tokens: appConfig.tokens,
   });
-
   return (
     <MarketDetailsTab
       positions={
@@ -54,7 +53,9 @@ export function LongsTab({
               {!isLoading ? (
                 <p className="text-xs text-neutral-content">
                   Total Value:{" "}
-                  {Number(dnFormat([totalLongsValue || 0n, 18])).toFixed(4)}{" "}
+                  {dnFormat([totalLongsValue || 0n, baseToken.decimals], {
+                    digits: 2,
+                  })}{" "}
                   {baseToken.symbol}
                 </p>
               ) : (

--- a/apps/hyperdrive-trading/src/ui/markets/LongsTab/LongsTab.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/LongsTab/LongsTab.tsx
@@ -6,7 +6,6 @@ import Skeleton from "react-loading-skeleton";
 import { parseUnits } from "src/base/parseUnits";
 import { convertSharesToBase } from "src/hyperdrive/convertSharesToBase";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
-import { usePoolInfo } from "src/ui/hyperdrive/hooks/usePoolInfo";
 import { ClosedLongsTable } from "src/ui/hyperdrive/longs/ClosedLongsTable/ClosedLongsTable";
 import { OpenLongModalButton } from "src/ui/hyperdrive/longs/OpenLongModalButton/OpenLongModalButton";
 import { OpenLongsTable } from "src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTable";
@@ -25,17 +24,14 @@ export function LongsTab({
   const activeOpenOrClosedTab = useOpenOrClosedSearchParam();
   const appConfig = useAppConfig();
   const { address: account } = useAccount();
-
   const { openLongs } = useOpenLongs({
     account,
     hyperdriveAddress: hyperdrive.address,
   });
-  const { poolInfo } = usePoolInfo({ hyperdriveAddress: hyperdrive.address });
   const { totalLongsValue, isLoading } = useTotalLongsValue({
     hyperdrive,
     account,
     openLongs,
-    poolInfo,
   });
   const baseToken = findBaseToken({
     baseTokenAddress: hyperdrive.baseToken,

--- a/apps/hyperdrive-trading/src/ui/markets/LongsTab/LongsTab.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/LongsTab/LongsTab.tsx
@@ -7,7 +7,6 @@ import { parseUnits } from "src/base/parseUnits";
 import { convertSharesToBase } from "src/hyperdrive/convertSharesToBase";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { usePoolInfo } from "src/ui/hyperdrive/hooks/usePoolInfo";
-import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { ClosedLongsTable } from "src/ui/hyperdrive/longs/ClosedLongsTable/ClosedLongsTable";
 import { OpenLongModalButton } from "src/ui/hyperdrive/longs/OpenLongModalButton/OpenLongModalButton";
 import { OpenLongsTable } from "src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTable";
@@ -24,9 +23,9 @@ export function LongsTab({
   hyperdrive: HyperdriveConfig;
 }): ReactElement {
   const activeOpenOrClosedTab = useOpenOrClosedSearchParam();
-  const readHyperdrive = useReadHyperdrive(hyperdrive.address);
-  const { address: account } = useAccount();
   const appConfig = useAppConfig();
+  const { address: account } = useAccount();
+
   const { openLongs } = useOpenLongs({
     account,
     hyperdriveAddress: hyperdrive.address,
@@ -36,7 +35,6 @@ export function LongsTab({
     hyperdrive,
     account,
     openLongs,
-    readHyperdrive,
     poolInfo,
   });
   const baseToken = findBaseToken({
@@ -51,13 +49,17 @@ export function LongsTab({
             <div className="flex flex-col items-start gap-2">
               <h5 className="font-medium">Long Positions</h5>
               {!isLoading ? (
-                <p className="text-xs text-neutral-content">
-                  Total Value:{" "}
-                  {dnFormat([totalLongsValue || 0n, baseToken.decimals], {
-                    digits: 2,
-                  })}{" "}
-                  {baseToken.symbol}
-                </p>
+                <>
+                  {openLongs?.length ? (
+                    <p className="text-xs text-neutral-content">
+                      Total Value:{" "}
+                      {dnFormat([totalLongsValue || 0n, baseToken.decimals], {
+                        digits: 2,
+                      })}{" "}
+                      {baseToken.symbol}
+                    </p>
+                  ) : undefined}
+                </>
               ) : (
                 <Skeleton width={100} />
               )}


### PR DESCRIPTION
This PR adds a "Total Value" field to the top of the longs table. I created a new hook called useTotalLongsValue in order to make use of the `useQueries` hook. This way the queries get fetched in parallel, and they are saved to the cache so when the CurrentValueCell component calls it again in the table, it will already have access to the value. 

![image](https://github.com/delvtech/hyperdrive-frontend/assets/22210106/19660038-bacd-41ff-b7eb-3a97ef4521d0)