### PR TITLE
Adds custom error toasts on viem errors

### DIFF
--- a/apps/hyperdrive-trading/src/network/parseError.ts
+++ b/apps/hyperdrive-trading/src/network/parseError.ts
@@ -1,0 +1,33 @@
+import { BaseError as BaseViemError, DecodeErrorResultReturnType } from "viem";
+
+/**
+ * Parses an viem/wagmi error to get a displayable string
+ * @param error - error object
+ * @returns parsed error string
+ */
+export function parseError({ error }: { error: any }): string {
+  let message: string = error.message ?? "An unknown error occurred";
+  if (error instanceof BaseViemError) {
+    if (error.details) {
+      message = error.details;
+    } else if (error.shortMessage) {
+      message = error.shortMessage;
+      const cause = error.cause as
+        | { data?: DecodeErrorResultReturnType }
+        | undefined;
+      // if its not generic error, append custom error name and its args to message
+      if (cause?.data && cause.data?.errorName !== "Error") {
+        const customErrorArgs = cause.data.args?.toString() ?? "";
+        message = `${message.replace(/reverted\.$/, "reverted with following reason:")}\n${
+          cause.data.errorName
+        }(${customErrorArgs})`;
+      }
+    } else if (error.message) {
+      message = error.message;
+    } else if (error.name) {
+      message = error.name;
+    }
+  }
+
+  return message;
+}

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useCloseLong.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useCloseLong.tsx
@@ -5,6 +5,7 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import toast from "react-hot-toast";
+import { parseError } from "src/network/parseError";
 import TransactionToast from "src/ui/base/components/Toaster/TransactionToast";
 import { SUCCESS_TOAST_DURATION } from "src/ui/base/toasts";
 import { useReadWriteHyperdrive } from "src/ui/hyperdrive/hooks/useReadWriteHyperdrive";
@@ -87,6 +88,12 @@ export function useCloseLong({
           description: "Close Long",
         });
       }
+    },
+    onError(error) {
+      const message = parseError({
+        error,
+      });
+      toast.error(message);
     },
   });
 

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useOpenLong.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useOpenLong.tsx
@@ -3,6 +3,7 @@ import { useAddRecentTransaction } from "@rainbow-me/rainbowkit";
 import { MutationStatus } from "@tanstack/query-core";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import toast from "react-hot-toast";
+import { parseError } from "src/network/parseError";
 import TransactionToast from "src/ui/base/components/Toaster/TransactionToast";
 import { SUCCESS_TOAST_DURATION } from "src/ui/base/toasts";
 import { useReadWriteHyperdrive } from "src/ui/hyperdrive/hooks/useReadWriteHyperdrive";
@@ -98,6 +99,12 @@ export function useOpenLong({
         hash,
         description: "Open Long",
       });
+    },
+    onError(error) {
+      const message = parseError({
+        error,
+      });
+      toast.error(message);
     },
   });
   return {

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useAddLiquidity.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useAddLiquidity.tsx
@@ -5,6 +5,7 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import toast from "react-hot-toast";
+import { parseError } from "src/network/parseError";
 import TransactionToast from "src/ui/base/components/Toaster/TransactionToast";
 import { SUCCESS_TOAST_DURATION } from "src/ui/base/toasts";
 import { useReadWriteHyperdrive } from "src/ui/hyperdrive/hooks/useReadWriteHyperdrive";
@@ -96,6 +97,12 @@ export function useAddLiquidity({
           description: "Add Liquidity",
         });
       }
+    },
+    onError(error) {
+      const message = parseError({
+        error,
+      });
+      toast.error(message);
     },
   });
 

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useRedeemWithdrawalShares.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useRedeemWithdrawalShares.ts
@@ -6,6 +6,8 @@ import {
   useMutation,
   useQueryClient,
 } from "@tanstack/react-query";
+import toast from "react-hot-toast";
+import { parseError } from "src/network/parseError";
 import { Address } from "viem";
 import { usePublicClient } from "wagmi";
 
@@ -62,6 +64,12 @@ export function useRedeemWithdrawalShares({
           description: "Redeem Withdrawal Shares",
         });
       }
+    },
+    onError(error) {
+      const message = parseError({
+        error,
+      });
+      toast.error(message);
     },
   });
 

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useRemoveLiquidity.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useRemoveLiquidity.tsx
@@ -5,6 +5,7 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import toast from "react-hot-toast";
+import { parseError } from "src/network/parseError";
 import TransactionToast from "src/ui/base/components/Toaster/TransactionToast";
 import { SUCCESS_TOAST_DURATION } from "src/ui/base/toasts";
 import { useReadWriteHyperdrive } from "src/ui/hyperdrive/hooks/useReadWriteHyperdrive";
@@ -82,6 +83,12 @@ export function useRemoveLiquidity({
           description: "Remove Liquidity",
         });
       }
+    },
+    onError(error) {
+      const message = parseError({
+        error,
+      });
+      toast.error(message);
     },
   });
   return {

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useCloseShort.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useCloseShort.tsx
@@ -5,6 +5,7 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import toast from "react-hot-toast";
+import { parseError } from "src/network/parseError";
 import TransactionToast from "src/ui/base/components/Toaster/TransactionToast";
 import { SUCCESS_TOAST_DURATION } from "src/ui/base/toasts";
 import { useReadWriteHyperdrive } from "src/ui/hyperdrive/hooks/useReadWriteHyperdrive";
@@ -86,6 +87,12 @@ export function useCloseShort({
           description: "Close Short",
         });
       }
+    },
+    onError(error) {
+      const message = parseError({
+        error,
+      });
+      toast.error(message);
     },
   });
 

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useOpenShort.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useOpenShort.tsx
@@ -6,6 +6,7 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import toast from "react-hot-toast";
+import { parseError } from "src/network/parseError";
 import TransactionToast from "src/ui/base/components/Toaster/TransactionToast";
 import { SUCCESS_TOAST_DURATION } from "src/ui/base/toasts";
 import { useReadWriteHyperdrive } from "src/ui/hyperdrive/hooks/useReadWriteHyperdrive";
@@ -104,6 +105,12 @@ export function useOpenShort({
           description: "Open Short",
         });
       }
+    },
+    onError(error) {
+      const message = parseError({
+        error,
+      });
+      toast.error(message);
     },
   });
 


### PR DESCRIPTION
This PR adds error handling for errors that are returned by Viem. In a subsequent PR i'll address errors that get beyond this initial round of error checking, such as out of gas errors.

![Screenshot 2024-05-09 at 4 06 48 PM](https://github.com/delvtech/hyperdrive-frontend/assets/22210106/a410786a-3b74-473e-970b-f9072816a46a)

Question: @DannyDelott do we want to use that gradient branding text. It looks a little weird with the generic error. 
![Screenshot 2024-05-09 at 4 16 56 PM](https://github.com/delvtech/hyperdrive-frontend/assets/22210106/05155e90-363a-4034-9ea9-28441d632832)
Also using toast.error is a bit strange because there are two x marks. I'm tempted to create a custom TransactionErrorToast component that removes the x mark on the left. Wdyt?