### PR TITLE
adds maturity date sorting

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
@@ -46,6 +46,14 @@ export function OpenLongsTableDesktop({
   const tableInstance = useReactTable({
     columns: getColumns({ hyperdrive, appConfig }),
     data: openLongs || [],
+    initialState: {
+      sorting: [
+        {
+          id: "maturationDate",
+          desc: true,
+        },
+      ],
+    },
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableMobile.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableMobile.tsx
@@ -45,6 +45,14 @@ export function OpenLongsTableMobile({
   const tableInstance = useReactTable({
     columns: getMobileColumns({ hyperdrive, appConfig }),
     data: openLongs || [],
+    initialState: {
+      sorting: [
+        {
+          id: "maturationDate",
+          desc: true,
+        },
+      ],
+    },
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktop.tsx
@@ -43,6 +43,14 @@ export function OpenShortsTableDesktop({
   const tableInstance = useReactTable({
     columns: getColumns(hyperdrive, baseToken),
     data: openShorts || [],
+    initialState: {
+      sorting: [
+        {
+          id: "maturationDate",
+          desc: true,
+        },
+      ],
+    },
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableMobile.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableMobile.tsx
@@ -37,6 +37,14 @@ export function OpenShortsTableMobile({
   const tableInstance = useReactTable({
     columns: getMobileColumns(hyperdrive, appConfig),
     data: openShorts || [],
+    initialState: {
+      sorting: [
+        {
+          id: "maturationDate",
+          desc: true,
+        },
+      ],
+    },
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getPaginationRowModel: getPaginationRowModel(),


### PR DESCRIPTION
![Screenshot 2024-05-10 at 3 01 26 PM](https://github.com/delvtech/hyperdrive-frontend/assets/22210106/192a336f-b7cb-4796-8aa1-699fa2e1ef81)
This is a PR that adds initial sorting to Long/Short tables to ensure your positions that are nearest to maturity show up at the top. There is still an existing issue where fully mature positions are showing up at the bottom. I think the best UX is to show these at the top so i'll investigate a custom sorting function on Monday.

I'll also add this sorting to the closed tables in a separate PR. Where recently matured positions will show up at the top.