### PR TITLE
Remove dependency on hyperdrive artifacts in trading ui

### DIFF
--- a/apps/hyperdrive-trading/README.md
+++ b/apps/hyperdrive-trading/README.md
@@ -17,7 +17,6 @@ This project uses many tools like:
 #### Monorepo dependencies:
 
 - [@delvtech/hyperdrive-viem](../../packages/hyperdrive-viem/)
-- [@delvtech/hyperdrive-artifacts](../../packages/hyperdrive-artifacts/)
 - [@hyperdrive/appconfig](../../packages/hyperdrive-appconfig/)
 
 ### Environment variables

--- a/apps/hyperdrive-trading/package.json
+++ b/apps/hyperdrive-trading/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "@heroicons/react": "^2.0.16",
     "@hyperdrive/appconfig": "*",
-    "@delvtech/hyperdrive-artifacts": "^0.2.0",
     "@delvtech/hyperdrive-viem": "^0.0.5",
     "@rainbow-me/rainbowkit": "^2.0.0",
     "@tanstack/react-query": "^4.29.12",

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useMarketState.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useMarketState.ts
@@ -1,15 +1,11 @@
-import { IHyperdrive } from "@delvtech/hyperdrive-artifacts/IHyperdrive";
+import { ReadHyperdrive } from "@delvtech/hyperdrive-js-core";
 import { QueryStatus, useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
-import { Address, ContractFunctionReturnType } from "viem";
+import { Address } from "viem";
 export function useMarketState(hyperdrive: Address): {
   marketState:
-    | ContractFunctionReturnType<
-        typeof IHyperdrive.abi,
-        "view",
-        "getMarketState"
-      >
+    | Awaited<ReturnType<ReadHyperdrive["getMarketState"]>>
     | undefined;
   marketStateStatus: QueryStatus;
 } {

--- a/apps/hyperdrive-trading/src/ui/markets/YourBalanceWell/YourBalanceWell.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/YourBalanceWell/YourBalanceWell.tsx
@@ -1,4 +1,3 @@
-import { ERC20 } from "@delvtech/hyperdrive-artifacts/ERC20";
 import { EllipsisVerticalIcon } from "@heroicons/react/24/outline";
 import {
   HyperdriveConfig,
@@ -18,7 +17,7 @@ import { RevokeAllowanceModalButton } from "src/ui/token/RevokeAllowanceModalBut
 import { useMintToken } from "src/ui/token/hooks/useMintToken";
 import { useTokenAllowance } from "src/ui/token/hooks/useTokenAllowance";
 import { useTokenBalance } from "src/ui/token/hooks/useTokenBalance";
-import { Address, parseUnits } from "viem";
+import { Address, erc20Abi, parseUnits } from "viem";
 import { foundry, sepolia } from "viem/chains";
 import { useAccount, useChainId, useReadContract } from "wagmi";
 
@@ -82,7 +81,7 @@ function AvailableAsset({
     enabled: !isEth,
   });
   const { data: totalSupply } = useReadContract({
-    abi: ERC20.abi,
+    abi: erc20Abi,
     functionName: "totalSupply",
     address: token.address,
     query: { enabled: !isEth },

--- a/apps/hyperdrive-trading/src/ui/token/RevokeAllowanceModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/token/RevokeAllowanceModalButton.tsx
@@ -1,4 +1,3 @@
-import { ERC20 } from "@delvtech/hyperdrive-artifacts/ERC20";
 import { XMarkIcon } from "@heroicons/react/24/outline";
 import { TokenConfig } from "@hyperdrive/appconfig";
 import { useState } from "react";
@@ -8,6 +7,7 @@ import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { useNumericInput } from "src/ui/base/hooks/useNumericInput";
 import { TokenInput } from "src/ui/token/TokenInput";
 import { useApproveToken } from "src/ui/token/hooks/useApproveToken";
+import { erc20Abi } from "viem";
 import { useAccount, useBalance, useReadContract } from "wagmi";
 
 export function RevokeAllowanceModalButton({
@@ -48,7 +48,7 @@ export function RevokeAllowanceModalButton({
   // effectively an infinite approval. See revoke.cash:
   // https://github.com/RevokeCash/revoke.cash/blob/823a1d2541bf1177f43511bf8983f49c8fc7811d/lib/utils/allowances.ts#L244
   const { data: totalSupply } = useReadContract({
-    abi: ERC20.abi,
+    abi: erc20Abi,
     functionName: "totalSupply",
     address: token.address,
     query: { enabled: !isEth },

--- a/apps/hyperdrive-trading/src/ui/token/hooks/useMintToken.tsx
+++ b/apps/hyperdrive-trading/src/ui/token/hooks/useMintToken.tsx
@@ -1,4 +1,3 @@
-import { ERC20Mintable } from "@delvtech/hyperdrive-artifacts/ERC20Mintable";
 import { TokenConfig } from "@hyperdrive/appconfig";
 import { useAddRecentTransaction } from "@rainbow-me/rainbowkit";
 import toast from "react-hot-toast";
@@ -8,7 +7,7 @@ import { waitForTransactionAndInvalidateCache } from "src/network/waitForTransac
 import { ETH_MAGIC_NUMBER } from "src/token/ETH_MAGIC_NUMBER";
 import TransactionToast from "src/ui/base/components/Toaster/TransactionToast";
 import { SUCCESS_TOAST_DURATION } from "src/ui/base/toasts";
-import { Address, formatUnits } from "viem";
+import { Address, formatUnits, parseAbi } from "viem";
 import { sepolia } from "viem/chains";
 import {
   useChainId,
@@ -66,7 +65,9 @@ export function useMintToken({
         return writeContract(
           {
             address: token.address,
-            abi: ERC20Mintable.abi,
+            abi: parseAbi([
+              "function mint(address destination, uint256 mintAmount)",
+            ]),
             functionName: "mint",
             args: [destination, mintAmount],
           },


### PR DESCRIPTION
We shouldn't need to depend on the abis for anything, that's what the sdk and appconfig are for.