### PR TITLE
Mobile layout for new market cards

### DIFF
--- a/apps/hyperdrive-trading/src/ui/base/mediaBreakpoints.ts
+++ b/apps/hyperdrive-trading/src/ui/base/mediaBreakpoints.ts
@@ -30,6 +30,11 @@ export function useIsTailwindLargeScreen(): boolean {
   return isXl;
 }
 
+export function useIsTailwindLessThanSm(): boolean {
+  const isLessThanSm = useMedia(`(max-width: ${SMALL_BREAKPOINT}px)`);
+  return isLessThanSm;
+}
+
 function useIsTailwindSm(): boolean {
   const isLessThanMd = useMedia(`(max-width: ${MEDIUM_BREAKPOINT}px)`);
   return isLessThanMd;

--- a/apps/hyperdrive-trading/src/ui/markets/YieldSourceCard/YieldSourceCard.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/YieldSourceCard/YieldSourceCard.tsx
@@ -9,7 +9,9 @@ import Skeleton from "react-loading-skeleton";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { Badge } from "src/ui/base/components/Badge";
 import { Well } from "src/ui/base/components/Well/Well";
-import { YieldSourceMarketsTable } from "src/ui/markets/YieldSourceMarketsTable/YieldSourceMarketsTable";
+import { useIsTailwindLessThanSm } from "src/ui/base/mediaBreakpoints";
+import { YieldSourceMarketsTableDesktop } from "src/ui/markets/YieldSourceMarketsTable/YieldSourceMarketsTableDesktop";
+import { YieldSourceMarketsTableMobile } from "src/ui/markets/YieldSourceMarketsTable/YieldSourceMarketsTableMobile";
 import { useYieldSourceRate } from "src/ui/vaults/useYieldSourceRate";
 
 export function YieldSourceCard({
@@ -18,6 +20,8 @@ export function YieldSourceCard({
   yieldSourceProtocol: Protocol;
 }): ReactElement | null {
   const appConfig = useAppConfig();
+
+  const isSmallScreen = useIsTailwindLessThanSm();
 
   // Extract the list of pools that have this yield source
   const pools = findYieldSourceHyperdrives({
@@ -51,17 +55,18 @@ export function YieldSourceCard({
   });
 
   return (
-    <Well transparent interactive>
-      <div className="flex w-full flex-col gap-2 md:w-[700px]">
-        {/* Card header */}
-        <div className="flex flex-col justify-between gap-4 sm:flex-row md:p-4 ">
-          {/* Yield source name, icon, and rate */}
-          <div className="flex gap-2 sm:gap-5">
-            <img
-              src={yieldSourceProtocol.iconUrl}
-              className="h-20 scale-75 sm:scale-100"
-            />
+    <Well transparent interactive block={isSmallScreen}>
+      <div className="flex flex-col gap-12 md:w-[700px] md:gap-2">
+        <div className="flex flex-col justify-between gap-8 sm:flex-row md:p-4 ">
+          {/* Card header */}
+          <div className="flex flex-col items-center gap-2 sm:flex-row sm:gap-5">
             <div>
+              <img
+                src={yieldSourceProtocol.iconUrl}
+                className="h-20 scale-75 sm:scale-100 "
+              />
+            </div>
+            <div className="text-center md:text-left">
               <h3 className="mb-1">{sharesToken.extensions.shortName}</h3>
               {vaultRateStatus === "loading" && !vaultRate ? (
                 <Skeleton className="w-42 h-8" />
@@ -79,8 +84,8 @@ export function YieldSourceCard({
           </div>
 
           {/* Deposit assets */}
-          <div className="flex items-center justify-center gap-2 text-neutral-content sm:flex-col">
-            <span className="mb-2 flex">Deposit assets</span>
+          <div className="flex flex-col items-center justify-center gap-2 text-neutral-content ">
+            <span>Deposit assets</span>
             <div className="daisy-avatar-group inline-flex justify-center -space-x-6 rtl:space-x-reverse">
               {isBaseTokenDepositEnabled ? (
                 <div className="daisy-avatar w-12 scale-75 sm:scale-100">
@@ -95,9 +100,15 @@ export function YieldSourceCard({
             </div>
           </div>
         </div>
-
         {/* Pools Table */}
-        <YieldSourceMarketsTable protocol={yieldSourceProtocol} />
+        {isSmallScreen ? (
+          <div className="flex flex-col items-center justify-center text-neutral-content">
+            <span>Markets</span>
+            <YieldSourceMarketsTableMobile protocol={yieldSourceProtocol} />
+          </div>
+        ) : (
+          <YieldSourceMarketsTableDesktop protocol={yieldSourceProtocol} />
+        )}{" "}
       </div>
     </Well>
   );

--- a/apps/hyperdrive-trading/src/ui/markets/YieldSourceCard/YieldSourceCard.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/YieldSourceCard/YieldSourceCard.tsx
@@ -57,7 +57,7 @@ export function YieldSourceCard({
   return (
     <Well transparent interactive block={isSmallScreen}>
       <div className="flex flex-col gap-12 md:w-[700px] md:gap-2">
-        <div className="flex flex-col justify-between gap-8 sm:flex-row md:p-4 ">
+        <div className="flex flex-col justify-between gap-2 sm:flex-row sm:gap-8 md:p-4">
           {/* Card header */}
           <div className="flex flex-col items-center gap-2 sm:flex-row sm:gap-5">
             <div>
@@ -84,7 +84,7 @@ export function YieldSourceCard({
           </div>
 
           {/* Deposit assets */}
-          <div className="flex flex-col items-center justify-center gap-2 text-neutral-content ">
+          <div className="flex items-center justify-center gap-2 text-neutral-content sm:flex-col">
             <span>Deposit assets</span>
             <div className="daisy-avatar-group inline-flex justify-center -space-x-6 rtl:space-x-reverse">
               {isBaseTokenDepositEnabled ? (

--- a/apps/hyperdrive-trading/src/ui/markets/YieldSourceCard/YieldSourceCard.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/YieldSourceCard/YieldSourceCard.tsx
@@ -52,11 +52,15 @@ export function YieldSourceCard({
 
   return (
     <Well transparent interactive>
-      <div className="flex w-[700px] flex-col gap-2">
+      <div className="flex w-full flex-col gap-2 md:w-[700px]">
         {/* Card header */}
-        <div className="flex justify-between gap-4 p-4">
-          <div className="flex gap-5">
-            <img src={yieldSourceProtocol.iconUrl} className="h-20" />
+        <div className="flex flex-col justify-between gap-4 sm:flex-row md:p-4 ">
+          {/* Yield source name, icon, and rate */}
+          <div className="flex gap-2 sm:gap-5">
+            <img
+              src={yieldSourceProtocol.iconUrl}
+              className="h-20 scale-75 sm:scale-100"
+            />
             <div>
               <h3 className="mb-1">{sharesToken.extensions.shortName}</h3>
               {vaultRateStatus === "loading" && !vaultRate ? (
@@ -74,21 +78,18 @@ export function YieldSourceCard({
             </div>
           </div>
 
-          <div className="flex flex-col text-neutral-content ">
+          {/* Deposit assets */}
+          <div className="flex items-center justify-center gap-2 text-neutral-content sm:flex-col">
             <span className="mb-2 flex">Deposit assets</span>
             <div className="daisy-avatar-group inline-flex justify-center -space-x-6 rtl:space-x-reverse">
               {isBaseTokenDepositEnabled ? (
-                <div className="daisy-avatar">
-                  <div className="w-12">
-                    <img src={baseToken.iconUrl} />
-                  </div>
+                <div className="daisy-avatar w-12 scale-75 sm:scale-100">
+                  <img src={baseToken.iconUrl} />
                 </div>
               ) : null}
               {isShareTokenDepositsEnabled ? (
-                <div className="daisy-avatar">
-                  <div className="w-12">
-                    <img src={sharesToken.iconUrl} />
-                  </div>
+                <div className="daisy-avatar w-12 scale-75 sm:scale-100">
+                  <img src={sharesToken.iconUrl} />
                 </div>
               ) : null}
             </div>

--- a/apps/hyperdrive-trading/src/ui/markets/YieldSourceMarketsTable/YieldSourceMarketsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/YieldSourceMarketsTable/YieldSourceMarketsTableDesktop.tsx
@@ -25,7 +25,7 @@ import { Address } from "viem";
 
 const columnHelper = createColumnHelper<YieldSourceMarketsTableRowData>();
 
-export function YieldSourceMarketsTable({
+export function YieldSourceMarketsTableDesktop({
   protocol,
 }: {
   protocol: Protocol;

--- a/apps/hyperdrive-trading/src/ui/markets/YieldSourceMarketsTable/YieldSourceMarketsTableMobile.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/YieldSourceMarketsTable/YieldSourceMarketsTableMobile.tsx
@@ -1,0 +1,179 @@
+import { ChevronRightIcon } from "@heroicons/react/20/solid";
+import { AppConfig, Protocol, findBaseToken } from "@hyperdrive/appconfig";
+import { Link, useNavigate } from "@tanstack/react-router";
+import {
+  createColumnHelper,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { ReactElement } from "react";
+import { convertMillisecondsToDays } from "src/base/convertMillisecondsToDays";
+import { formatRate } from "src/base/formatRate";
+import { useAppConfig } from "src/ui/appconfig/useAppConfig";
+import LoadingState from "src/ui/base/components/LoadingState";
+import { formatCompact } from "src/ui/base/formatting/formatCompact";
+import { LpApyCell } from "src/ui/markets/AllMarketsTable/LpApyCell";
+import {
+  YieldSourceMarketsTableRowData,
+  useRowData,
+} from "src/ui/markets/YieldSourceMarketsTable/useRowData";
+import { MARKET_DETAILS_ROUTE } from "src/ui/markets/routes";
+import { Address } from "viem";
+
+const columnHelper = createColumnHelper<YieldSourceMarketsTableRowData>();
+
+export function YieldSourceMarketsTableMobile({
+  protocol,
+}: {
+  protocol: Protocol;
+}): ReactElement {
+  const navigate = useNavigate();
+  const { data: rowData, status } = useRowData(protocol);
+  const appConfig = useAppConfig();
+
+  const tableInstance = useReactTable({
+    columns: getMobileColumns(appConfig),
+    data: rowData || [],
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  if (status === "loading") {
+    return <LoadingState />;
+  }
+
+  return (
+    <table className="daisy-table daisy-table-zebra daisy-table-lg">
+      <tbody>
+        {tableInstance.getRowModel().rows.map((row) => {
+          return (
+            <tr
+              key={row.id}
+              className="daisy-hover h-16 cursor-pointer border-b-0 text-gray-50"
+              onClick={() => {
+                navigate({
+                  params: { address: row.original.market.address },
+                  search: {
+                    openOrClosed: "Open",
+                    position: "Longs",
+                  },
+                  to: MARKET_DETAILS_ROUTE,
+                });
+              }}
+            >
+              <>
+                {row.getVisibleCells().map((cell) => {
+                  return (
+                    <td key={cell.id} className="py-10 last:w-5 ">
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext(),
+                      )}
+                    </td>
+                  );
+                })}
+              </>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}
+
+function GoToMarketButton({
+  hyperdriveAddress,
+}: {
+  hyperdriveAddress: Address;
+}): ReactElement {
+  return (
+    <Link
+      from={MARKET_DETAILS_ROUTE}
+      resetScroll
+      search={() => ({
+        position: "Longs" as const,
+        openOrClosed: "Open" as const,
+      })}
+      params={{ address: hyperdriveAddress }}
+      className="daisy-btn-circle daisy-btn-xs flex items-center justify-center bg-gray-600 hover:bg-gray-700"
+    >
+      <ChevronRightIcon className="h-3" />
+    </Link>
+  );
+}
+
+function formatMobileColumnData(
+  row: YieldSourceMarketsTableRowData,
+  appConfig: AppConfig,
+) {
+  const baseToken = findBaseToken({
+    baseTokenAddress: row.market.baseToken,
+    tokens: appConfig.tokens,
+  });
+  return [
+    {
+      name: "Term",
+      value: (
+        <span className="flex flex-row items-center justify-start">
+          {convertMillisecondsToDays(
+            Number(row.market.poolConfig.positionDuration * 1000n),
+          )}{" "}
+          days
+        </span>
+      ),
+    },
+    { name: "Fixed APR", value: `${formatRate(row.fixedApr)}%` },
+    { name: "Short APY", value: `${formatRate(row.shortApy)}%` },
+    {
+      name: "LP APY",
+      value: <LpApyCell hyperdriveAddress={row.market.address} />,
+    },
+    {
+      name: "Liquidity",
+      value: (
+        <span
+          key="liquidity"
+          className="flex flex-row items-center justify-start"
+        >
+          {formatCompact({
+            value: row.liquidity,
+            decimals: row.market.decimals,
+          })}{" "}
+          {baseToken.symbol}
+        </span>
+      ),
+    },
+  ];
+}
+
+function getMobileColumns(appConfig: AppConfig) {
+  return [
+    columnHelper.display({
+      id: "ColumnPairs",
+      cell: ({ row }) => {
+        const data = formatMobileColumnData(row.original, appConfig);
+        return (
+          <div className="flex flex-col gap-2">
+            {data.map((column, i) => (
+              <div
+                key={i}
+                className="flex w-full justify-between gap-4 text-left md:justify-evenly"
+              >
+                <p className="text-neutral-content md:w-40">{column.name}</p>
+                <p className="md:w-40" key={column.name}>
+                  {column.value}
+                </p>
+              </div>
+            ))}
+          </div>
+        );
+      },
+    }),
+    columnHelper.display({
+      id: "go-to-market",
+      cell: ({ row }) => (
+        <GoToMarketButton hyperdriveAddress={row.original.market.address} />
+      ),
+    }),
+  ];
+}


### PR DESCRIPTION
Related to #1038 

This renders a mobile table for any breakpoint that's < tailwind `sm` breakpoint.
<img width="321" alt="image" src="https://github.com/delvtech/hyperdrive-frontend/assets/4524175/44104592-0eb5-48ee-b030-867920937121">
