### PR TITLE
Adds market paused button

### DIFF
--- a/apps/hyperdrive-trading/src/ui/base/components/WarningButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/WarningButton.tsx
@@ -14,7 +14,7 @@ export function WarningButton({
     >
       <button
         disabled
-        className="disabled daisy-btn daisy-btn-circle daisy-btn-warning flex w-auto px-4 disabled:bg-warning disabled:text-base-100 disabled:opacity-30"
+        className="disabled daisy-btn daisy-btn-circle daisy-btn-warning flex w-auto min-w-40 px-4 disabled:bg-warning disabled:text-base-100 disabled:opacity-30"
       >
         {icon}
         {label}

--- a/apps/hyperdrive-trading/src/ui/base/components/WarningButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/WarningButton.tsx
@@ -14,7 +14,7 @@ export function WarningButton({
     >
       <button
         disabled
-        className="disabled daisy-btn daisy-btn-circle daisy-btn-warning  flex w-auto px-4 disabled:bg-warning disabled:text-base-100 disabled:opacity-30"
+        className="disabled daisy-btn daisy-btn-circle daisy-btn-warning flex w-auto px-4 disabled:bg-warning disabled:text-base-100 disabled:opacity-30"
       >
         {icon}
         {label}

--- a/apps/hyperdrive-trading/src/ui/base/components/WarningButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/WarningButton.tsx
@@ -1,0 +1,24 @@
+export function WarningButton({
+  label,
+  icon,
+  tooltip,
+}: {
+  label: string;
+  icon: React.ReactNode;
+  tooltip?: string;
+}): JSX.Element {
+  return (
+    <div
+      className="daisy-tooltip daisy-tooltip-left before:z-10"
+      data-tip={tooltip}
+    >
+      <button
+        disabled
+        className="disabled daisy-btn daisy-btn-circle daisy-btn-warning  flex w-auto px-4 disabled:bg-warning disabled:text-base-100 disabled:opacity-30"
+      >
+        {icon}
+        {label}
+      </button>
+    </div>
+  );
+}

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongModalButton/OpenLongModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongModalButton/OpenLongModalButton.tsx
@@ -1,7 +1,9 @@
-import { XMarkIcon } from "@heroicons/react/24/solid";
+import { PauseCircleIcon, XMarkIcon } from "@heroicons/react/24/solid";
 import { HyperdriveConfig } from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
 import { Modal } from "src/ui/base/components/Modal/Modal";
+import { WarningButton } from "src/ui/base/components/WarningButton";
+import { useMarketState } from "src/ui/hyperdrive/hooks/useMarketState";
 import { OpenLongForm } from "src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm";
 
 export interface OpenLongModalButtonProps {
@@ -12,10 +14,20 @@ export function OpenLongModalButton({
   modalId,
   hyperdrive,
 }: OpenLongModalButtonProps): ReactElement {
+  const { marketState } = useMarketState(hyperdrive.address);
   function closeModal() {
     (window as any)[modalId].close();
   }
 
+  if (marketState?.isPaused) {
+    return (
+      <WarningButton
+        label="Market Paused"
+        icon={<PauseCircleIcon width={16} />}
+        tooltip="This market is currently paused. You cannot open new positions but you may close existing ones."
+      />
+    );
+  }
   return (
     <Modal
       modalId={modalId}

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
@@ -1,4 +1,4 @@
-import { Long } from "@delvtech/hyperdrive-js-core";
+import { Long } from "@delvtech/hyperdrive-viem";
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/outline";
 import {
   AppConfig,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
@@ -25,6 +25,7 @@ import { NonIdealState } from "src/ui/base/components/NonIdealState";
 import { Pagination } from "src/ui/base/components/Pagination";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { MaturesOnCell } from "src/ui/hyperdrive/MaturesOnCell/MaturesOnCell";
+import { useMarketState } from "src/ui/hyperdrive/hooks/useMarketState";
 import { CloseLongModalButton } from "src/ui/hyperdrive/longs/CloseLongModalButton/CloseLongModalButton";
 import { OpenLongModalButton } from "src/ui/hyperdrive/longs/OpenLongModalButton/OpenLongModalButton";
 import { CurrentValueCell } from "src/ui/hyperdrive/longs/OpenLongsTable/CurrentValueCell";
@@ -39,6 +40,7 @@ export function OpenLongsTableDesktop({
 }): ReactElement {
   const { address: account } = useAccount();
   const appConfig = useAppConfig();
+  const { marketState } = useMarketState(hyperdrive.address);
   const { openLongs, openLongsStatus } = useOpenLongs({
     account,
     hyperdriveAddress: hyperdrive.address,
@@ -76,6 +78,16 @@ export function OpenLongsTableDesktop({
         heading="Loading your Longs..."
         text="Searching for Long events, calculating current value and PnL..."
       />
+    );
+  }
+  if (marketState?.isPaused) {
+    return (
+      <div className="my-28">
+        <NonIdealState
+          heading="Market Paused"
+          text="This market is currently paused. You cannot open new positions but you may close existing ones."
+        />
+      </div>
     );
   }
   if (!openLongs?.length && openLongsStatus === "success") {

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
@@ -1,4 +1,4 @@
-import { Long } from "@delvtech/hyperdrive-viem";
+import { Long } from "@delvtech/hyperdrive-js-core";
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/outline";
 import {
   AppConfig,
@@ -80,17 +80,18 @@ export function OpenLongsTableDesktop({
       />
     );
   }
-  if (marketState?.isPaused) {
-    return (
-      <div className="my-28">
-        <NonIdealState
-          heading="Market Paused"
-          text="This market is currently paused. You cannot open new positions but you may close existing ones."
-        />
-      </div>
-    );
-  }
+
   if (!openLongs?.length && openLongsStatus === "success") {
+    if (marketState?.isPaused) {
+      return (
+        <div className="my-28">
+          <NonIdealState
+            heading="Market Paused"
+            text="This market is currently paused. You cannot open new positions but you may close existing ones."
+          />
+        </div>
+      );
+    }
     return (
       <div className="my-28">
         <NonIdealState

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableMobile.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableMobile.tsx
@@ -24,6 +24,7 @@ import { NonIdealState } from "src/ui/base/components/NonIdealState";
 import { Pagination } from "src/ui/base/components/Pagination";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { MaturesOnCell } from "src/ui/hyperdrive/MaturesOnCell/MaturesOnCell";
+import { useMarketState } from "src/ui/hyperdrive/hooks/useMarketState";
 import { CloseLongModalButton } from "src/ui/hyperdrive/longs/CloseLongModalButton/CloseLongModalButton";
 import { OpenLongModalButton } from "src/ui/hyperdrive/longs/OpenLongModalButton/OpenLongModalButton";
 import { CurrentValueCell } from "src/ui/hyperdrive/longs/OpenLongsTable/CurrentValueCell";
@@ -37,6 +38,7 @@ export function OpenLongsTableMobile({
   hyperdrive: HyperdriveConfig;
 }): ReactElement {
   const { address: account } = useAccount();
+  const { marketState } = useMarketState(hyperdrive.address);
   const appConfig = useAppConfig();
   const { openLongs, openLongsStatus } = useOpenLongs({
     account,
@@ -78,6 +80,16 @@ export function OpenLongsTableMobile({
     );
   }
   if (!openLongs?.length && openLongsStatus === "success") {
+    if (marketState?.isPaused) {
+      return (
+        <div className="my-28">
+          <NonIdealState
+            heading="Market Paused"
+            text="This market is currently paused. You cannot open new positions but you may close existing ones."
+          />
+        </div>
+      );
+    }
     return (
       <div className="my-28">
         <NonIdealState

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityModalButton/AddLiquidityModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityModalButton/AddLiquidityModalButton.tsx
@@ -1,7 +1,10 @@
+import { PauseCircleIcon } from "@heroicons/react/16/solid";
 import { XMarkIcon } from "@heroicons/react/24/solid";
 import { HyperdriveConfig } from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
 import { Modal } from "src/ui/base/components/Modal/Modal";
+import { WarningButton } from "src/ui/base/components/WarningButton";
+import { useMarketState } from "src/ui/hyperdrive/hooks/useMarketState";
 import { AddLiquidityForm } from "src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm";
 
 export function AddLiquidityModalButton({
@@ -11,8 +14,19 @@ export function AddLiquidityModalButton({
   modalId: string;
   hyperdrive: HyperdriveConfig;
 }): ReactElement {
+  const { marketState } = useMarketState(hyperdrive.address);
   function closeModal() {
     (window as any)[modalId].close();
+  }
+
+  if (marketState?.isPaused) {
+    return (
+      <WarningButton
+        label="Market Paused"
+        icon={<PauseCircleIcon width={16} />}
+        tooltip="This market is currently paused. You cannot open new positions but you may close existing ones."
+      />
+    );
   }
 
   return (

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortModalButton/OpenShortModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortModalButton/OpenShortModalButton.tsx
@@ -1,7 +1,9 @@
-import { XMarkIcon } from "@heroicons/react/24/solid";
+import { PauseCircleIcon, XMarkIcon } from "@heroicons/react/24/solid";
 import { HyperdriveConfig } from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
 import { Modal } from "src/ui/base/components/Modal/Modal";
+import { WarningButton } from "src/ui/base/components/WarningButton";
+import { useMarketState } from "src/ui/hyperdrive/hooks/useMarketState";
 import { OpenShortForm } from "src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm";
 
 export interface OpenShortModalButtonProps {
@@ -12,8 +14,19 @@ export function OpenShortModalButton({
   modalId,
   hyperdrive,
 }: OpenShortModalButtonProps): ReactElement {
+  const { marketState } = useMarketState(hyperdrive.address);
   function closeModal() {
     (window as any)[modalId].close();
+  }
+
+  if (marketState?.isPaused) {
+    return (
+      <WarningButton
+        label="Market Paused"
+        icon={<PauseCircleIcon width={16} />}
+        tooltip="This market is currently paused. You cannot open new positions but you may close existing ones."
+      />
+    );
   }
 
   return (

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTable.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-key */
-import { OpenShort } from "@delvtech/hyperdrive-js-core";
+import { OpenShort } from "@delvtech/hyperdrive-viem";
 import { HyperdriveConfig } from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
 import { ConnectWalletButton } from "src/ui/base/components/ConnectWallet";

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTable.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-key */
-import { OpenShort } from "@delvtech/hyperdrive-viem";
+import { OpenShort } from "@delvtech/hyperdrive-js-core";
 import { HyperdriveConfig } from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
 import { ConnectWalletButton } from "src/ui/base/components/ConnectWallet";
@@ -46,18 +46,17 @@ export function OpenShortsTable({
     );
   }
 
-  if (marketState?.isPaused) {
-    return (
-      <div className="my-28">
-        <NonIdealState
-          heading="Market Paused"
-          text="This market is currently paused. You cannot open new positions but you may close existing ones."
-        />
-      </div>
-    );
-  }
-
   if (!openShorts?.length && openShortsStatus === "success") {
+    if (marketState?.isPaused) {
+      return (
+        <div className="my-28">
+          <NonIdealState
+            heading="Market Paused"
+            text="This market is currently paused. You cannot open new positions but you may close existing ones."
+          />
+        </div>
+      );
+    }
     return (
       <div className="my-28">
         <NonIdealState

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTable.tsx
@@ -6,6 +6,7 @@ import { ConnectWalletButton } from "src/ui/base/components/ConnectWallet";
 import LoadingState from "src/ui/base/components/LoadingState";
 import { NonIdealState } from "src/ui/base/components/NonIdealState";
 import { useIsTailwindSmallScreen } from "src/ui/base/mediaBreakpoints";
+import { useMarketState } from "src/ui/hyperdrive/hooks/useMarketState";
 import { OpenShortModalButton } from "src/ui/hyperdrive/shorts/OpenShortModalButton/OpenShortModalButton";
 import { OpenShortsTableDesktop } from "src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktop";
 import { OpenShortsTableMobile } from "src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableMobile";
@@ -18,7 +19,7 @@ export function OpenShortsTable({
   hyperdrive: HyperdriveConfig;
 }): ReactElement {
   const { address: account } = useAccount();
-
+  const { marketState } = useMarketState(hyperdrive.address);
   const isTailwindSmallScreen = useIsTailwindSmallScreen();
   const { openShorts, openShortsStatus } = useOpenShorts({
     account,
@@ -42,6 +43,17 @@ export function OpenShortsTable({
         heading="Loading your Shorts..."
         text="Searching for Short events, calculating current value and PnL..."
       />
+    );
+  }
+
+  if (marketState?.isPaused) {
+    return (
+      <div className="my-28">
+        <NonIdealState
+          heading="Market Paused"
+          text="This market is currently paused. You cannot open new positions but you may close existing ones."
+        />
+      </div>
     );
   }
 

--- a/apps/hyperdrive-trading/src/ui/markets/LongsTab/LongsTab.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/LongsTab/LongsTab.tsx
@@ -1,11 +1,8 @@
-import { PauseCircleIcon } from "@heroicons/react/24/solid";
 import { HyperdriveConfig, findBaseToken } from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
 import Skeleton from "react-loading-skeleton";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
-import { WarningButton } from "src/ui/base/components/WarningButton";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
-import { useMarketState } from "src/ui/hyperdrive/hooks/useMarketState";
 import { ClosedLongsTable } from "src/ui/hyperdrive/longs/ClosedLongsTable/ClosedLongsTable";
 import { OpenLongModalButton } from "src/ui/hyperdrive/longs/OpenLongModalButton/OpenLongModalButton";
 import { OpenLongsTable } from "src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTable";
@@ -21,7 +18,6 @@ export function LongsTab({
   hyperdrive: HyperdriveConfig;
 }): ReactElement {
   const activeOpenOrClosedTab = useOpenOrClosedSearchParam();
-  const { marketState } = useMarketState(hyperdrive.address);
   const appConfig = useAppConfig();
   const { address: account } = useAccount();
   const { openLongs } = useOpenLongs({
@@ -63,17 +59,10 @@ export function LongsTab({
               )}
             </div>
             <div className="flex items-center gap-4">
-              {account && openLongs?.length && !marketState?.isPaused ? (
+              {account && openLongs?.length ? (
                 <OpenLongModalButton
                   modalId="open-long"
                   hyperdrive={hyperdrive}
-                />
-              ) : null}
-              {marketState?.isPaused ? (
-                <WarningButton
-                  label="Market Paused"
-                  icon={<PauseCircleIcon width={16} />}
-                  tooltip="This market is currently paused. You cannot open new positions but you may close existing ones."
                 />
               ) : null}
               <OpenClosedFilter />

--- a/apps/hyperdrive-trading/src/ui/markets/LongsTab/LongsTab.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/LongsTab/LongsTab.tsx
@@ -1,8 +1,11 @@
+import { PauseCircleIcon } from "@heroicons/react/24/solid";
 import { HyperdriveConfig, findBaseToken } from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
 import Skeleton from "react-loading-skeleton";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
+import { WarningButton } from "src/ui/base/components/WarningButton";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
+import { useMarketState } from "src/ui/hyperdrive/hooks/useMarketState";
 import { ClosedLongsTable } from "src/ui/hyperdrive/longs/ClosedLongsTable/ClosedLongsTable";
 import { OpenLongModalButton } from "src/ui/hyperdrive/longs/OpenLongModalButton/OpenLongModalButton";
 import { OpenLongsTable } from "src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTable";
@@ -18,6 +21,7 @@ export function LongsTab({
   hyperdrive: HyperdriveConfig;
 }): ReactElement {
   const activeOpenOrClosedTab = useOpenOrClosedSearchParam();
+  const { marketState } = useMarketState(hyperdrive.address);
   const appConfig = useAppConfig();
   const { address: account } = useAccount();
   const { openLongs } = useOpenLongs({
@@ -59,10 +63,17 @@ export function LongsTab({
               )}
             </div>
             <div className="flex items-center gap-4">
-              {account && openLongs?.length ? (
+              {account && openLongs?.length && !marketState?.isPaused ? (
                 <OpenLongModalButton
                   modalId="open-long"
                   hyperdrive={hyperdrive}
+                />
+              ) : null}
+              {marketState?.isPaused ? (
+                <WarningButton
+                  label="Market Paused"
+                  icon={<PauseCircleIcon width={16} />}
+                  tooltip="This market is currently paused. You cannot open new positions but you may close existing ones."
                 />
               ) : null}
               <OpenClosedFilter />

--- a/apps/hyperdrive-trading/src/ui/markets/LpTab/LpTab.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/LpTab/LpTab.tsx
@@ -41,7 +41,7 @@ export function LpTab({
     <MarketDetailsTab
       positions={
         <div className="flex flex-col items-center">
-          <div className="flex w-full items-center justify-between p-8">
+          <div className="flex w-full flex-col justify-between gap-8 p-8 lg:flex-row lg:items-center lg:gap-0">
             <h5 className="font-medium">LP Position</h5>
             <div className="flex items-center gap-4">
               {(lpShares && lpSharesStatus === "success") ||

--- a/apps/hyperdrive-trading/src/ui/markets/LpTab/LpTab.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/LpTab/LpTab.tsx
@@ -1,8 +1,11 @@
+import { PauseCircleIcon } from "@heroicons/react/16/solid";
 import { HyperdriveConfig } from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
 import { ConnectWalletButton } from "src/ui/base/components/ConnectWallet";
 import LoadingState from "src/ui/base/components/LoadingState";
 import { NonIdealState } from "src/ui/base/components/NonIdealState";
+import { WarningButton } from "src/ui/base/components/WarningButton";
+import { useMarketState } from "src/ui/hyperdrive/hooks/useMarketState";
 import { AddLiquidityModalButton } from "src/ui/hyperdrive/lp/AddLiquidityModalButton/AddLiquidityModalButton";
 import { ClosedLpTable } from "src/ui/hyperdrive/lp/ClosedLpTable/ClosedLpTable";
 import { OpenLpSharesCard } from "src/ui/hyperdrive/lp/OpenLpSharesCard/OpenLpSharesCard";
@@ -21,6 +24,7 @@ export function LpTab({
 }): ReactElement {
   const { address: account } = useAccount();
 
+  const { marketState } = useMarketState(hyperdrive.address);
   const activeOpenOrClosedTab = useOpenOrClosedSearchParam();
 
   const { lpShares, lpSharesStatus } = useLpShares({
@@ -42,9 +46,18 @@ export function LpTab({
             <div className="flex items-center gap-4">
               {(lpShares && lpSharesStatus === "success") ||
               (withdrawalShares && withdrawalSharesStatus === "success") ? (
-                <AddLiquidityModalButton
-                  modalId="add-lp"
-                  hyperdrive={hyperdrive}
+                !marketState?.isPaused ? (
+                  <AddLiquidityModalButton
+                    modalId="add-lp"
+                    hyperdrive={hyperdrive}
+                  />
+                ) : null
+              ) : null}
+              {marketState?.isPaused ? (
+                <WarningButton
+                  label="Market Paused"
+                  icon={<PauseCircleIcon width={16} />}
+                  tooltip="This market is currently paused. You cannot open new positions but you may close existing ones."
                 />
               ) : null}
               <OpenClosedFilter />
@@ -84,6 +97,16 @@ export function LpTab({
                   lpSharesStatus === "success" &&
                   withdrawalSharesStatus === "success"
                 ) {
+                  if (marketState?.isPaused) {
+                    return (
+                      <div className="my-28">
+                        <NonIdealState
+                          heading="Market Paused"
+                          text="This market is currently paused. You cannot open new positions but you may close existing ones."
+                        />
+                      </div>
+                    );
+                  }
                   return (
                     <div className="my-20">
                       <NonIdealState

--- a/apps/hyperdrive-trading/src/ui/markets/LpTab/LpTab.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/LpTab/LpTab.tsx
@@ -1,10 +1,8 @@
-import { PauseCircleIcon } from "@heroicons/react/16/solid";
 import { HyperdriveConfig } from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
 import { ConnectWalletButton } from "src/ui/base/components/ConnectWallet";
 import LoadingState from "src/ui/base/components/LoadingState";
 import { NonIdealState } from "src/ui/base/components/NonIdealState";
-import { WarningButton } from "src/ui/base/components/WarningButton";
 import { useMarketState } from "src/ui/hyperdrive/hooks/useMarketState";
 import { AddLiquidityModalButton } from "src/ui/hyperdrive/lp/AddLiquidityModalButton/AddLiquidityModalButton";
 import { ClosedLpTable } from "src/ui/hyperdrive/lp/ClosedLpTable/ClosedLpTable";
@@ -46,18 +44,9 @@ export function LpTab({
             <div className="flex items-center gap-4">
               {(lpShares && lpSharesStatus === "success") ||
               (withdrawalShares && withdrawalSharesStatus === "success") ? (
-                !marketState?.isPaused ? (
-                  <AddLiquidityModalButton
-                    modalId="add-lp"
-                    hyperdrive={hyperdrive}
-                  />
-                ) : null
-              ) : null}
-              {marketState?.isPaused ? (
-                <WarningButton
-                  label="Market Paused"
-                  icon={<PauseCircleIcon width={16} />}
-                  tooltip="This market is currently paused. You cannot open new positions but you may close existing ones."
+                <AddLiquidityModalButton
+                  modalId="add-lp"
+                  hyperdrive={hyperdrive}
                 />
               ) : null}
               <OpenClosedFilter />

--- a/apps/hyperdrive-trading/src/ui/markets/ShortsTab/ShortsTab.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/ShortsTab/ShortsTab.tsx
@@ -1,8 +1,11 @@
+import { PauseCircleIcon } from "@heroicons/react/16/solid";
 import { findBaseToken, HyperdriveConfig } from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
 import Skeleton from "react-loading-skeleton";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
+import { WarningButton } from "src/ui/base/components/WarningButton";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
+import { useMarketState } from "src/ui/hyperdrive/hooks/useMarketState";
 import { ClosedShortsTable } from "src/ui/hyperdrive/shorts/ClosedShortsTable/ClosedShortsTable";
 import { useOpenShorts } from "src/ui/hyperdrive/shorts/hooks/useOpenShorts";
 import { useTotalShortsValue } from "src/ui/hyperdrive/shorts/hooks/useTotalShortsValue";
@@ -20,6 +23,7 @@ export function ShortsTab({
   const activeOpenOrClosedTab = useOpenOrClosedSearchParam();
   const { address: account } = useAccount();
   const appConfig = useAppConfig();
+  const { marketState } = useMarketState(hyperdrive.address);
   const { openShorts } = useOpenShorts({
     account,
     hyperdriveAddress: hyperdrive.address,
@@ -60,10 +64,18 @@ export function ShortsTab({
               )}
             </div>
             <div className="flex items-center gap-4">
-              {account && openShorts?.length ? (
+              {account && openShorts?.length && !marketState?.isPaused ? (
                 <OpenShortModalButton
                   modalId="open-short"
                   hyperdrive={hyperdrive}
+                />
+              ) : null}
+
+              {marketState?.isPaused ? (
+                <WarningButton
+                  label="Market Paused"
+                  icon={<PauseCircleIcon width={16} />}
+                  tooltip="This market is currently paused. You cannot open new positions but you may close existing ones."
                 />
               ) : null}
               <OpenClosedFilter />

--- a/apps/hyperdrive-trading/src/ui/markets/ShortsTab/ShortsTab.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/ShortsTab/ShortsTab.tsx
@@ -1,11 +1,8 @@
-import { PauseCircleIcon } from "@heroicons/react/16/solid";
 import { findBaseToken, HyperdriveConfig } from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
 import Skeleton from "react-loading-skeleton";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
-import { WarningButton } from "src/ui/base/components/WarningButton";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
-import { useMarketState } from "src/ui/hyperdrive/hooks/useMarketState";
 import { ClosedShortsTable } from "src/ui/hyperdrive/shorts/ClosedShortsTable/ClosedShortsTable";
 import { useOpenShorts } from "src/ui/hyperdrive/shorts/hooks/useOpenShorts";
 import { useTotalShortsValue } from "src/ui/hyperdrive/shorts/hooks/useTotalShortsValue";
@@ -23,7 +20,6 @@ export function ShortsTab({
   const activeOpenOrClosedTab = useOpenOrClosedSearchParam();
   const { address: account } = useAccount();
   const appConfig = useAppConfig();
-  const { marketState } = useMarketState(hyperdrive.address);
   const { openShorts } = useOpenShorts({
     account,
     hyperdriveAddress: hyperdrive.address,
@@ -64,20 +60,13 @@ export function ShortsTab({
               )}
             </div>
             <div className="flex items-center gap-4">
-              {account && openShorts?.length && !marketState?.isPaused ? (
+              {account && openShorts?.length ? (
                 <OpenShortModalButton
                   modalId="open-short"
                   hyperdrive={hyperdrive}
                 />
               ) : null}
 
-              {marketState?.isPaused ? (
-                <WarningButton
-                  label="Market Paused"
-                  icon={<PauseCircleIcon width={16} />}
-                  tooltip="This market is currently paused. You cannot open new positions but you may close existing ones."
-                />
-              ) : null}
               <OpenClosedFilter />
             </div>
           </div>


### PR DESCRIPTION
This PR adds a warning label to the market tabs and nonideal state if the marketstate is currently paused. If the user currently has positions open, a warning label is presented in the tab bar and the open position button is removed. The user will still be able to remove any open positions. If the user has no positions open the buttons are removed all together and the market paused info is presented in the non-ideal state.
![Screenshot 2024-05-14 at 3 57 27 PM](https://github.com/delvtech/hyperdrive-frontend/assets/22210106/ecec40e7-488f-4e38-a050-09e51806e85d)
I'm trying to decide if I should add the warning button to the non-ideal state or if the text is sufficient. Thoughts @DannyDelott?
![Screenshot 2024-05-14 at 3 56 06 PM](https://github.com/delvtech/hyperdrive-frontend/assets/22210106/9dd65f0e-395d-4d3c-af12-ed71c1db436e)
![Screenshot 2024-05-14 at 4 23 06 PM](https://github.com/delvtech/hyperdrive-frontend/assets/22210106/e01cc602-bbd2-49eb-8d27-725de2230e03)

