### PR TITLE
Compute the yield source rate from Hyperdrive state

### DIFF
--- a/.changeset/blue-plants-play.md
+++ b/.changeset/blue-plants-play.md
@@ -1,0 +1,5 @@
+---
+"@delvtech/hyperdrive-js-core": patch
+---
+
+Refactor getYieldSourceRate to use internal calc based on vaultSharePrice

--- a/apps/hyperdrive-trading/src/ui/markets/YieldSourceMarketsTable/useRowData.ts
+++ b/apps/hyperdrive-trading/src/ui/markets/YieldSourceMarketsTable/useRowData.ts
@@ -50,7 +50,9 @@ export function useRowData(
                 });
                 const liquidity = await readHyperdrive.getPresentValue();
 
-                const vaultRate = await readHyperdrive.getYieldSourceRate({});
+                const vaultRate = await readHyperdrive.getYieldSourceRate({
+                  timeRange: 604_800n, // 1 week in seconds
+                });
                 const fixedApr = await readHyperdrive.getSpotRate();
                 const shortApy = await readHyperdrive.getImpliedRate({
                   bondAmount: parseUnits("1", hyperdrive.decimals),

--- a/apps/hyperdrive-trading/src/ui/markets/YieldSourceMarketsTable/useRowData.ts
+++ b/apps/hyperdrive-trading/src/ui/markets/YieldSourceMarketsTable/useRowData.ts
@@ -50,9 +50,15 @@ export function useRowData(
                 });
                 const liquidity = await readHyperdrive.getPresentValue();
 
-                const vaultRate = await readHyperdrive.getYieldSourceRate({
-                  timeRange: 604_800n, // 1 week in seconds
-                });
+                let vaultRate = 0n;
+                try {
+                  vaultRate = await readHyperdrive.getYieldSourceRate({
+                    timeRange: 604_800n, // 1 week in seconds
+                  });
+                } catch (e) {
+                  vaultRate = 0n;
+                }
+
                 const fixedApr = await readHyperdrive.getSpotRate();
                 const shortApy = await readHyperdrive.getImpliedRate({
                   bondAmount: parseUnits("1", hyperdrive.decimals),

--- a/apps/hyperdrive-trading/src/ui/vaults/useYieldSourceRate.ts
+++ b/apps/hyperdrive-trading/src/ui/vaults/useYieldSourceRate.ts
@@ -26,7 +26,9 @@ export function useYieldSourceRate({
     }),
     queryFn: queryEnabled
       ? async () => {
-          const rate = await readHyperdrive.getYieldSourceRate({});
+          const rate = await readHyperdrive.getYieldSourceRate({
+            timeRange: 604_800n, // 1 week in seconds
+          });
           return {
             vaultRate: rate,
             formatted: formatRate(rate),

--- a/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
@@ -130,9 +130,8 @@ export class ReadHyperdrive extends ReadModel {
     timeRange: bigint;
   }): Promise<bigint> {
     // Get the vault share price of the checkpoint in the past `timeRange`
-    const { timestamp: currentBlockTime } = (await this.network.getBlock({
-      blockTag: "latest",
-    })) as Block; // safe to cast because there's always a "latest" block
+    const { timestamp: currentBlockTime } =
+      (await this.network.getBlock()) as Block; // safe to cast because there's always a latest block
     const { checkpointDuration } = await this.getPoolConfig();
     const startCheckpointId = getCheckpointId(
       currentBlockTime - timeRange,

--- a/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
@@ -1,4 +1,5 @@
 import {
+  Block,
   BlockTag,
   CachedReadContract,
   ContractGetEventsOptions,
@@ -33,7 +34,6 @@ import { getCheckpointId } from "src/pool/getCheckpointId";
 import { calculateShortAccruedYield } from "src/shorts/calculateShortAccruedYield";
 import { ClosedShort, OpenShort } from "src/shorts/types";
 import { ReadErc20 } from "src/token/erc20/ReadErc20";
-import { ReadMockErc4626 } from "src/token/erc4626/ReadMockErc4626";
 import { ReadEth } from "src/token/eth/ReadEth";
 import { RedeemedWithdrawalShares } from "src/withdrawalShares/RedeemedWithdrawalShares";
 import { WITHDRAW_SHARES_ASSET_ID } from "src/withdrawalShares/assetId";
@@ -111,19 +111,76 @@ export class ReadHyperdrive extends ReadModel {
     return this.contract.read("decimals");
   }
 
+  /**
+   * Get a standardized variable rate using vault share prices from checkpoints in
+   * the last `timeRange` seconds.
+   *
+   * Note: This function will throw an error if the pool was deployed within the
+   * last `timeRange` seconds.
+   *
+   * See Agent0 for calculation:
+   * https://github.com/delvtech/agent0/blob/854e9392e09898e65aeed0040c5e648c8d3d1380/src/agent0/ethpy/hyperdrive/interface/read_interface.py#L421
+   *
+   * @param timeRange The time range (in seconds) to use to calculate the variable
+   * rate to look for checkpoints.
+   */
   async getYieldSourceRate({
+    timeRange,
     options,
   }: {
+    timeRange: bigint;
     options?: ContractReadOptions;
   }): Promise<bigint> {
-    const { vaultSharesToken } = await this.getPoolConfig(options);
-    const vault = new ReadMockErc4626({
-      address: vaultSharesToken,
-      contractFactory: this.contractFactory,
-      namespace: this.contract.namespace,
-      network: this.network,
+    // Get the vault share price of the checkpoint in the past `timeRange`
+    const { timestamp: currentBlockTime } = (await this.network.getBlock({
+      blockTag: "latest",
+    })) as Block; // safe to cast because there's always a "latest" block
+    const { checkpointDuration } = await this.getPoolConfig();
+    const startCheckpointId = getCheckpointId(
+      currentBlockTime - timeRange,
+      checkpointDuration,
+    );
+    const { vaultSharePrice: startVaultSharePrice } = await this.getCheckpoint({
+      checkpointId: startCheckpointId,
     });
-    return vault.getRate(options);
+
+    // Vault share price is 0 if checkpoint doesn't exist
+    // This happens if the pool was deployed within the past `timeRange`
+    if (!startVaultSharePrice) {
+      throw new Error("Checkpoint doesn't exist for the given time range.");
+    }
+
+    // We can also get the current vault share price instead of getting it from
+    // the latest checkpoint
+    const currentCheckpointId = getCheckpointId(
+      currentBlockTime,
+      checkpointDuration,
+    );
+
+    let { vaultSharePrice: currentVaultSharePrice } = await this.getCheckpoint({
+      checkpointId: currentCheckpointId,
+    });
+    // If the current checkpoint doesn't exist (due to checkpoint not being made
+    // yet), we use the current vault share price
+    if (!currentVaultSharePrice) {
+      currentVaultSharePrice = await (await this.getPoolInfo()).vaultSharePrice;
+    }
+    const rateOfReturn =
+      (currentVaultSharePrice - startVaultSharePrice) / startVaultSharePrice;
+    // Annualized the rate of return
+    const annualizedRateOfReturn =
+      (rateOfReturn * BigInt(60 * 60 * 24 * 365)) / timeRange;
+
+    return annualizedRateOfReturn;
+
+    // const { vaultSharesToken } = await this.getPoolConfig(options);
+    // const vault = new ReadMockErc4626({
+    //   address: vaultSharesToken,
+    //   contractFactory: this.contractFactory,
+    //   namespace: this.contract.namespace,
+    //   network: this.network,
+    // });
+    // return vault.getRate(options);
   }
 
   getCheckpoint({

--- a/packages/hyperdrive-js-core/src/hyperdrive/metamorpho/ReadMetaMorphoHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/metamorpho/ReadMetaMorphoHyperdrive.ts
@@ -1,4 +1,4 @@
-import { ContractReadOptions, ReadContract } from "@delvtech/evm-client";
+import { ReadContract } from "@delvtech/evm-client";
 import { Constructor } from "src/base/types";
 import {
   ReadHyperdrive,
@@ -16,11 +16,7 @@ export class ReadMetaMorphoHyperdrive extends readMetaMorphoHyperdriveMixin(
 /**
  * @internal
  */
-export interface ReadMetaMorphoHyperdriveMixin {
-  getYieldSourceRate(options?: {
-    options?: ContractReadOptions;
-  }): Promise<bigint>;
-}
+export interface ReadMetaMorphoHyperdriveMixin {}
 
 /**
  * @internal
@@ -49,19 +45,6 @@ export function readMetaMorphoHyperdriveMixin<
         cache,
         namespace,
       });
-    }
-    async getYieldSourceRate({
-      options,
-    }: {
-      options?: ContractReadOptions | undefined;
-    }): Promise<bigint> {
-      const sharesToken = await this.getSharesToken();
-      const rate = await this.metaMorphoContract.read(
-        "supplyAPYVault",
-        { vault: sharesToken.address },
-        options,
-      );
-      return rate;
     }
   };
 }

--- a/packages/hyperdrive-js-core/src/hyperdrive/steth/ReadStEthHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/steth/ReadStEthHyperdrive.ts
@@ -1,6 +1,4 @@
 import { ContractReadOptions } from "@delvtech/evm-client";
-import { fetchJson } from "src/base/fetchJson";
-import { MAINNET, SEPOLIA } from "src/base/knownChainIds";
 import { Constructor } from "src/base/types";
 import {
   ReadHyperdrive,
@@ -94,27 +92,6 @@ export function readStEthHyperdriveMixin<T extends Constructor<ReadHyperdrive>>(
       this.contract.clearCache();
     }
 
-    async getYieldSourceRate({
-      options,
-    }: {
-      options?: ContractReadOptions | undefined;
-    }): Promise<bigint> {
-      const chainId = await this.network.getChainId();
-      switch (chainId) {
-        // Mainnet: Use the official lido api for the yield source rate
-        // See: https://docs.lido.fi/integrations/api/#lido-apr
-        case MAINNET:
-          const lidoSevenDayMovingAverage = await fetchJson<{
-            data: { smaApr: number };
-          }>("https://eth-api.lido.fi/v1/protocol/steth/apr/sma");
-          return BigInt(lidoSevenDayMovingAverage.data.smaApr);
-
-        // Testnet: Use getRate from the default yield source contract
-        case SEPOLIA:
-        default:
-          return super.getYieldSourceRate({ options });
-      }
-    }
     async getBaseToken(): Promise<ReadEth> {
       return new ReadEth({
         contractFactory: this.contractFactory,


### PR DESCRIPTION
Fixes #1074.

This PR updates `getYieldSourceRate` to stop using `getRate()` on the mock contract, which only works on testnet. Instead, it switches to a calculation based on hyperdrive state, making it chain-agnostic and compatible with any yield source.

Additionally, I eliminated the specific logic for fetching the Lido Steth rate from their official web API, introduced in #1071. Similarly, I removed the method for retrieving the Morpho Dai rate from a fabricated snippets contract deployed to Sepolia.