### PR TITLE
Replace add liquidity simulate with hyperwasm 

### DIFF
--- a/.changeset/great-apes-hug.md
+++ b/.changeset/great-apes-hug.md
@@ -1,0 +1,5 @@
+---
+"@delvtech/hyperdrive-js-core": minor
+---
+
+Replace simulate call in previewAdddLiquidity with hyperwasm method

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/usePreviewAddLiquidity.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/usePreviewAddLiquidity.ts
@@ -66,7 +66,6 @@ export function usePreviewAddLiquidity({
             minLpSharePrice,
             maxAPR,
             asBase,
-            options: { value: ethValue, from: destination },
           });
         }
       : undefined,

--- a/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
@@ -1607,18 +1607,22 @@ export class ReadHyperdrive extends ReadModel {
     destination: `0x${string}`;
     asBase: boolean;
     extraData?: `0x${string}`;
-    options?: ContractWriteOptions;
+    options?: ContractReadOptions;
   }): Promise<{ lpSharesOut: bigint; slippagePaid: bigint }> {
-    const lpSharesOut = await this.contract.simulateWrite(
-      "addLiquidity",
-      {
-        _contribution: contribution,
-        _minLpSharePrice: minLpSharePrice,
-        _minApr: minAPR,
-        _maxApr: maxAPR,
-        _options: { destination, asBase, extraData },
-      },
-      options,
+    const poolConfig = await this.getPoolConfig(options);
+    const poolInfo = await this.getPoolInfo(options);
+    const currentTime = BigInt(Math.floor(Date.now() / 1000));
+    const lpSharesOut = BigInt(
+      hyperwasm.calcAddLiquidity(
+        convertBigIntsToStrings(poolInfo),
+        convertBigIntsToStrings(poolConfig),
+        currentTime.toString(),
+        contribution.toString(),
+        asBase,
+        minLpSharePrice.toString(),
+        minAPR.toString(),
+        maxAPR.toString(),
+      ),
     );
     const { vaultSharePrice, lpSharePrice } = await this.getPoolInfo();
     const decimals = await this.getDecimals();


### PR DESCRIPTION
Closes #935 
New hyperwasm function call:
![Screenshot 2024-05-20 at 7 21 28 PM](https://github.com/delvtech/hyperdrive-frontend/assets/22210106/f9c63812-a030-45ab-804f-13884666cc5f)
Current simulate call on testnet:
![Screenshot 2024-05-20 at 7 22 05 PM](https://github.com/delvtech/hyperdrive-frontend/assets/22210106/c3c02182-76e9-4bc1-8aa7-989638924139)
