### PR TITLE
Show max trades in available liquidity stat, improve Insufficient Liquidity error message

### DIFF
--- a/apps/hyperdrive-trading/src/ui/base/components/Stat.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/Stat.tsx
@@ -22,7 +22,7 @@ export function Stat({
         <p
           data-tip={description}
           className={classNames(
-            `group daisy-tooltip cursor-help text-sm text-neutral-content before:max-w-48 before:p-2 before:text-start`,
+            `group daisy-tooltip cursor-help text-sm text-neutral-content before:max-w-56 before:p-2 before:text-start`,
             {
               "daisy-tooltip-top": tooltipPosition === "top",
               "daisy-tooltip-bottom": tooltipPosition === "bottom",

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
@@ -122,7 +122,7 @@ export function OpenLongForm({
     amount: depositAmountAsBigInt,
   });
 
-  const { maxBaseIn, maxSharesIn } = useMaxLong({
+  const { maxBaseIn, maxSharesIn, maxBondsOut } = useMaxLong({
     hyperdriveAddress: hyperdrive.address,
   });
   const activeTokenMaxTradeSize =
@@ -269,7 +269,12 @@ export function OpenLongForm({
         if (!!depositAmountAsBigInt && !hasEnoughLiquidity) {
           return (
             <p className="text-center text-sm text-error">
-              Insufficient liquidity
+              Pool limit exceeded. Max long size is{" "}
+              {formatBalance({
+                balance: maxBondsOut || 0n,
+                decimals: baseToken.decimals,
+              })}{" "}
+              hy{baseToken.symbol}
             </p>
           );
         }

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
@@ -288,7 +288,12 @@ export function OpenShortForm({
         if (!!amountOfBondsToShortAsBigInt && !hasEnoughLiquidity) {
           return (
             <p className="text-center text-sm text-error">
-              Insufficient liquidity
+              Pool limit exceeded. Max short size is{" "}
+              {formatBalance({
+                balance: maxBondsOut || 0n,
+                decimals: hyperdrive.decimals,
+              })}{" "}
+              hy{baseToken.symbol}
             </p>
           );
         }

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/LiquidityStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/LiquidityStats.tsx
@@ -9,6 +9,8 @@ import { formatCompact } from "src/ui/base/formatting/formatCompact";
 import { useIdleLiquidity } from "src/ui/hyperdrive/hooks/useIdleLiquidity";
 import { usePresentValue } from "src/ui/hyperdrive/hooks/usePresentValue";
 import { useTradingVolume } from "src/ui/hyperdrive/hooks/useTradingVolume";
+import { useMaxLong } from "src/ui/hyperdrive/longs/hooks/useMaxLong";
+import { useMaxShort } from "src/ui/hyperdrive/shorts/hooks/useMaxShort";
 import { useBlockNumber } from "wagmi";
 export function LiquidityStats({
   hyperdrive,
@@ -26,6 +28,12 @@ export function LiquidityStats({
     useTradingVolume(hyperdrive.address, currentBlockNumber);
 
   const { presentValue, presentValueStatus } = usePresentValue({
+    hyperdriveAddress: hyperdrive.address,
+  });
+  const { maxBondsOut: maxLong } = useMaxLong({
+    hyperdriveAddress: hyperdrive.address,
+  });
+  const { maxBondsOut: maxShort } = useMaxShort({
     hyperdriveAddress: hyperdrive.address,
   });
 
@@ -57,8 +65,8 @@ export function LiquidityStats({
             description={`The present value in the pool`}
           />
           <Stat
-            label={`Available (${baseToken.symbol})`}
-            description={`The idle liquidity available for opening Longs and Shorts, and exiting LP positions`}
+            label={`Idle (${baseToken.symbol})`}
+            description={`The idle liquidity available for opening Longs and Shorts, and exiting LP positions\n\nMax Long: ${formatBalance({ balance: maxLong || 0n, decimals: baseToken.decimals })} hy${baseToken.symbol}\nMax Short: ${formatBalance({ balance: maxShort || 0n, decimals: baseToken.decimals })} hy${baseToken.symbol}`}
             value={
               idleLiquidityStatus === "loading" &&
               idleLiquidity === undefined ? (

--- a/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
@@ -988,6 +988,7 @@ export class ReadHyperdrive extends ReadModel {
   }> {
     const poolInfo = await this.getPoolInfo(options);
     const poolConfig = await this.getPoolConfig(options);
+    const decimals = await this.getDecimals();
 
     const { timestamp: blockTimestamp } = await getBlockOrThrow(
       this.network,
@@ -1022,8 +1023,8 @@ export class ReadHyperdrive extends ReadModel {
       openSharePrice.toString(),
     );
     const maxSharesIn = dnum.divide(
-      [BigInt(maxBaseIn), 18],
-      [poolInfo?.vaultSharePrice, 18],
+      [BigInt(maxBaseIn), decimals],
+      [poolInfo?.vaultSharePrice, decimals],
     )[0];
 
     return {


### PR DESCRIPTION
Showing the max trades in the stat and relabeling it to "idle liquidity" to be more descriptive.