### PR TITLE
Fix tooltips and mobile layout

### DIFF
--- a/apps/hyperdrive-trading/src/ui/base/components/Stat.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/Stat.tsx
@@ -24,7 +24,7 @@ export function Stat({
         <p
           data-tip={description}
           className={classNames(
-            `group daisy-tooltip flex w-full cursor-help justify-center text-center text-sm text-neutral-content before:z-50 before:max-w-56 before:p-2 before:text-start lg:text-center`,
+            `group daisy-tooltip flex w-full cursor-help justify-center text-sm text-neutral-content before:z-40 before:max-w-56 before:p-2 before:text-start`,
             {
               "daisy-tooltip-top": tooltipPosition === "top",
               "daisy-tooltip-bottom": tooltipPosition === "bottom",

--- a/apps/hyperdrive-trading/src/ui/base/components/Stat.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/Stat.tsx
@@ -24,7 +24,7 @@ export function Stat({
         <p
           data-tip={description}
           className={classNames(
-            `group daisy-tooltip flex w-full cursor-help justify-center text-sm text-neutral-content before:z-40 before:max-w-56 before:p-2 before:text-start`,
+            `group daisy-tooltip cursor-help text-sm text-neutral-content before:z-40 before:max-w-56 before:p-2 before:text-start`,
             {
               "daisy-tooltip-top": tooltipPosition === "top",
               "daisy-tooltip-bottom": tooltipPosition === "bottom",

--- a/apps/hyperdrive-trading/src/ui/base/components/Stat.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/Stat.tsx
@@ -17,7 +17,9 @@ export function Stat({
 }: StatProps): ReactElement {
   return (
     <div className="flex w-full flex-col items-center whitespace-pre-wrap ease-in-out">
-      <div className="mb-1 whitespace-nowrap text-h4 font-bold">{value}</div>
+      <div className="mb-1 whitespace-nowrap text-h5 font-bold lg:text-h4">
+        {value}
+      </div>
       {description ? (
         <p
           data-tip={description}

--- a/apps/hyperdrive-trading/src/ui/base/components/Stat.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/Stat.tsx
@@ -16,13 +16,13 @@ export function Stat({
   tooltipPosition = "bottom",
 }: StatProps): ReactElement {
   return (
-    <div className="flex flex-col items-start whitespace-pre-wrap ease-in-out">
+    <div className="flex w-full flex-col items-center whitespace-pre-wrap ease-in-out">
       <div className="mb-1 whitespace-nowrap text-h4 font-bold">{value}</div>
       {description ? (
         <p
           data-tip={description}
           className={classNames(
-            `group daisy-tooltip cursor-help text-sm text-neutral-content before:max-w-56 before:p-2 before:text-start`,
+            `group daisy-tooltip flex w-full cursor-help justify-center text-center text-sm text-neutral-content before:z-50 before:max-w-56 before:p-2 before:text-start lg:text-center`,
             {
               "daisy-tooltip-top": tooltipPosition === "top",
               "daisy-tooltip-bottom": tooltipPosition === "bottom",
@@ -32,7 +32,7 @@ export function Stat({
           )}
         >
           {label}
-          <InformationCircleIcon className="group-hover:text-gray-500 ml-1 inline-block w-4 text-neutral-content opacity-0 transition duration-150 ease-in-out group-hover:opacity-100" />
+          <InformationCircleIcon className="group-hover:text-gray-500 ml-1 hidden w-4 text-neutral-content opacity-0 transition duration-150 ease-in-out group-hover:opacity-100 lg:inline-block" />
         </p>
       ) : (
         <p className="text-sm text-neutral-content">{label}</p>

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/LiquidityStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/LiquidityStats.tsx
@@ -47,9 +47,9 @@ export function LiquidityStats({
     <Well transparent>
       <div className="space-y-8">
         <h5 className="flex text-neutral-content">Liquidity</h5>
-        <div className="flex w-full gap-6 lg:gap-16">
+        <div className="flex gap-6 lg:gap-16">
           <Stat
-            label={`Total ${baseToken.symbol}`}
+            label={`Total (${baseToken.symbol})`}
             value={
               presentValueStatus === "loading" && presentValue === undefined ? (
                 <Skeleton className="w-20" />

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/LiquidityStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/LiquidityStats.tsx
@@ -6,6 +6,7 @@ import { Stat } from "src/ui/base/components/Stat";
 import { Well } from "src/ui/base/components/Well/Well";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { formatCompact } from "src/ui/base/formatting/formatCompact";
+import { useIsTailwindSmallScreen } from "src/ui/base/mediaBreakpoints";
 import { useIdleLiquidity } from "src/ui/hyperdrive/hooks/useIdleLiquidity";
 import { usePresentValue } from "src/ui/hyperdrive/hooks/usePresentValue";
 import { useTradingVolume } from "src/ui/hyperdrive/hooks/useTradingVolume";
@@ -17,6 +18,7 @@ export function LiquidityStats({
 }: {
   hyperdrive: HyperdriveConfig;
 }): ReactElement {
+  const isTailwindSmallScreen = useIsTailwindSmallScreen();
   const { data: currentBlockNumber } = useBlockNumber();
   const appConfig = useAppConfig();
   const baseToken = findBaseToken({
@@ -45,9 +47,9 @@ export function LiquidityStats({
     <Well transparent>
       <div className="space-y-8">
         <h5 className="flex text-neutral-content">Liquidity</h5>
-        <div className="flex gap-16">
+        <div className="flex w-full gap-6 lg:gap-16">
           <Stat
-            label={`Total (${baseToken.symbol})`}
+            label={`Total ${baseToken.symbol}`}
             value={
               presentValueStatus === "loading" && presentValue === undefined ? (
                 <Skeleton className="w-20" />
@@ -63,6 +65,7 @@ export function LiquidityStats({
               )
             }
             description={`The present value in the pool`}
+            tooltipPosition={isTailwindSmallScreen ? "right" : "bottom"}
           />
           <Stat
             label={`Idle (${baseToken.symbol})`}
@@ -109,6 +112,7 @@ export function LiquidityStats({
                 />
               )
             }
+            tooltipPosition={isTailwindSmallScreen ? "left" : "bottom"}
           />
         </div>
       </div>

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/YieldStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/YieldStats.tsx
@@ -48,7 +48,7 @@ export function YieldStats({
   return (
     <Well transparent>
       <div className="space-y-8">
-        <div className="flex justify-between gap-20">
+        <div className="flex justify-between">
           <h5 className="flex text-neutral-content">Yield</h5>
           <div className="font-dmMono text-neutral-content">
             <YieldSourceRateBadge
@@ -59,7 +59,7 @@ export function YieldStats({
             />
           </div>
         </div>
-        <div className="flex flex-wrap gap-16">
+        <div className="flex flex-wrap gap-4 lg:gap-16">
           <Animated isActive={position === "Longs"}>
             <Stat
               label="Fixed APR"
@@ -75,6 +75,7 @@ export function YieldStats({
                 )
               }
               description="Fixed rate earned from opening longs, before fees and slippage are applied."
+              tooltipPosition={isTailwindSmallScreen ? "right" : "bottom"}
             />
           </Animated>
           <Animated isActive={position === "Shorts"}>
@@ -92,7 +93,7 @@ export function YieldStats({
                 )
               }
               description="Holding period return on shorts assuming the current variable rate stays the same until maturity."
-              tooltipPosition={"right"}
+              tooltipPosition={"bottom"}
             />
           </Animated>
           <Animated isActive={position === "LP"}>
@@ -110,7 +111,7 @@ export function YieldStats({
                 )
               }
               description={`The LP's annual return projection assuming the past 7-day performance rate continues for a year.`}
-              tooltipPosition={isTailwindSmallScreen ? "right" : "bottom"}
+              tooltipPosition={isTailwindSmallScreen ? "left" : "bottom"}
             />
           </Animated>
         </div>
@@ -126,7 +127,7 @@ function Animated({
   return (
     <div
       className={classNames("transition-all duration-200 ease-in-out", {
-        "gradient-text z-20 -translate-y-1 scale-105": isActive,
+        "gradient-text z-20 scale-105": isActive,
       })}
     >
       {children}

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/YieldStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/YieldStats.tsx
@@ -59,7 +59,7 @@ export function YieldStats({
             />
           </div>
         </div>
-        <div className="flex flex-wrap gap-4 lg:gap-16">
+        <div className="flex flex-wrap gap-8 lg:gap-16">
           <Animated isActive={position === "Longs"}>
             <Stat
               label="Fixed APR"

--- a/apps/hyperdrive-trading/src/ui/vaults/YieldSourceRateBadge.tsx
+++ b/apps/hyperdrive-trading/src/ui/vaults/YieldSourceRateBadge.tsx
@@ -34,7 +34,7 @@ export function YieldSourceRateBadge({
 
   return (
     <Badge>
-      <span className="font-dmMono text-neutral-content">
+      <span className="font-dmMono text-sm text-neutral-content lg:text-md">
         {labelRenderer ? (
           labelRenderer(vaultRate)
         ) : (


### PR DESCRIPTION
This PR fixes the tooltips on market stats and cleans up the mobile layout. @DannyDelott one thing we should keep in mind going forward is if we update the layout on a component that has a tooltip, it might impact the mobile layout. Since the daisy ui tooltip isn't screen-size aware, it can add a bunch of padding where the tooltip is supposed to appear. 

Before:
![mobile-before](https://github.com/delvtech/hyperdrive-frontend/assets/22210106/8438a9a5-8fff-4d75-b5b9-449212a7699e)
After:
![Mobile -after](https://github.com/delvtech/hyperdrive-frontend/assets/22210106/725479b8-3382-4e66-b1a3-4469a4c4dfad)
