### PR TITLE
Fix pools not showing for ezeth

### DIFF
--- a/apps/hyperdrive-trading/src/ui/markets/YieldSourceMarketsTable/ShortRateCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/YieldSourceMarketsTable/ShortRateCell.tsx
@@ -1,0 +1,28 @@
+import { HyperdriveConfig } from "@hyperdrive/appconfig";
+import { ReactElement } from "react";
+import { formatRate } from "src/base/formatRate";
+import { useImpliedRate } from "src/ui/hyperdrive/shorts/hooks/useImpliedRate";
+import { useYieldSourceRate } from "src/ui/vaults/useYieldSourceRate";
+import { parseUnits } from "viem";
+
+export function ShortRateCell({
+  hyperdrive,
+}: {
+  hyperdrive: HyperdriveConfig;
+}): ReactElement {
+  const { vaultRate } = useYieldSourceRate({
+    hyperdriveAddress: hyperdrive.address,
+  });
+  const { impliedRate } = useImpliedRate({
+    hyperdriveAddress: hyperdrive.address,
+    bondAmount: parseUnits("100", hyperdrive.decimals),
+    variableApy: vaultRate?.vaultRate,
+    timestamp: BigInt(Math.floor(Date.now() / 1000)),
+  });
+  const shortApy = impliedRate ? impliedRate : 0n;
+  return (
+    <span key="short-apy" className="lg:flex lg:w-20 lg:justify-end">
+      {shortApy ? `${formatRate(shortApy)}%` : "-"}
+    </span>
+  );
+}

--- a/apps/hyperdrive-trading/src/ui/markets/YieldSourceMarketsTable/YieldSourceMarketsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/YieldSourceMarketsTable/YieldSourceMarketsTableDesktop.tsx
@@ -18,6 +18,7 @@ import { NonIdealState } from "src/ui/base/components/NonIdealState";
 import { TextWithTooltip } from "src/ui/base/components/Tooltip/TextWithTooltip";
 import { formatCompact } from "src/ui/base/formatting/formatCompact";
 import { LpApyCell } from "src/ui/markets/AllMarketsTable/LpApyCell";
+import { ShortRateCell } from "src/ui/markets/YieldSourceMarketsTable/ShortRateCell";
 import {
   YieldSourceMarketsTableRowData,
   useRowData,
@@ -187,20 +188,17 @@ function getColumns(appConfig: AppConfig) {
         );
       },
     }),
-    columnHelper.accessor("shortApy", {
-      id: "short-apy",
+    columnHelper.display({
+      id: "short-rate",
       header: () => (
         <TextWithTooltip
           label="Short ROI"
           tooltip="Holding period return on shorts assuming the current variable rate stays the same until maturity."
         />
       ),
-      cell: ({ getValue }) => {
-        const shortApy = getValue();
+      cell: ({ row }) => {
         return (
-          <span key="short-apy" className="lg:flex lg:w-20 lg:justify-end">
-            {shortApy ? `${formatRate(shortApy)}%` : "-"}
-          </span>
+          <ShortRateCell key="short-apy" hyperdrive={row.original.market} />
         );
       },
     }),

--- a/apps/hyperdrive-trading/src/ui/markets/YieldSourceMarketsTable/YieldSourceMarketsTableMobile.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/YieldSourceMarketsTable/YieldSourceMarketsTableMobile.tsx
@@ -14,6 +14,7 @@ import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import LoadingState from "src/ui/base/components/LoadingState";
 import { formatCompact } from "src/ui/base/formatting/formatCompact";
 import { LpApyCell } from "src/ui/markets/AllMarketsTable/LpApyCell";
+import { ShortRateCell } from "src/ui/markets/YieldSourceMarketsTable/ShortRateCell";
 import {
   YieldSourceMarketsTableRowData,
   useRowData,
@@ -128,7 +129,7 @@ function formatMobileColumnData(
     { name: "Fixed APR", value: `${formatRate(row.fixedApr)}%` },
     {
       name: "Short ROI",
-      value: row.shortApy ? `${formatRate(row.shortApy)}%` : "-",
+      value: <ShortRateCell hyperdrive={row.market} />,
     },
     {
       name: "LP APY",

--- a/apps/hyperdrive-trading/src/ui/markets/YieldSourceMarketsTable/useRowData.ts
+++ b/apps/hyperdrive-trading/src/ui/markets/YieldSourceMarketsTable/useRowData.ts
@@ -8,16 +8,13 @@ import { UseQueryResult, useQuery } from "@tanstack/react-query";
 import sortBy from "lodash.sortby";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { getReadHyperdrive } from "src/hyperdrive/getReadHyperdrive";
-import { getYieldSourceRate } from "src/hyperdrive/getYieldSourceRate";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
-import { parseUnits } from "viem";
 import { usePublicClient } from "wagmi";
 
 export interface YieldSourceMarketsTableRowData {
   market: HyperdriveConfig;
   liquidity: bigint;
   fixedApr: bigint;
-  shortApy: bigint;
 }
 
 export function useRowData(
@@ -52,23 +49,12 @@ export function useRowData(
                 });
                 const liquidity = await readHyperdrive.getPresentValue();
 
-                const vaultRate = await getYieldSourceRate(readHyperdrive);
-
                 const fixedApr = await readHyperdrive.getSpotRate();
 
-                let shortApy = 0n;
-                if (vaultRate) {
-                  shortApy = await readHyperdrive.getImpliedRate({
-                    bondAmount: parseUnits("1", hyperdrive.decimals),
-                    variableApy: vaultRate,
-                    timestamp: BigInt(Math.floor(Date.now() / 1000)),
-                  });
-                }
                 return {
                   market: hyperdrive,
                   liquidity,
                   fixedApr,
-                  shortApy,
                 };
               },
             ),


### PR DESCRIPTION
Moving the Short Rate into its own component lets us still show the pools, while we figure out why short rate isn't calculated correctly:

<img width="954" alt="image" src="https://github.com/delvtech/hyperdrive-frontend/assets/4524175/ce0a3567-c5a3-469d-a8e0-2bf012dcfbbe">
