### PR TITLE
Add missing stETH conversions, temp patches for `MockLido` & `MockRocketPool` shares accounting

### DIFF
--- a/apps/hyperdrive-trading/src/ui/token/hooks/useTokenBalance.ts
+++ b/apps/hyperdrive-trading/src/ui/token/hooks/useTokenBalance.ts
@@ -1,6 +1,5 @@
 import { ETH_MAGIC_NUMBER } from "src/token/ETH_MAGIC_NUMBER";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
-import { getIsReth } from "src/vaults/isReth";
 import { getIsSteth } from "src/vaults/isSteth";
 import { Address, erc20Abi, formatUnits } from "viem";
 import { useBalance, useChainId, useReadContract } from "wagmi";
@@ -61,20 +60,19 @@ export function useTokenBalance({
   }
 
   /**
-   * FIXME: The steth and reth hyperdrive contracts and much of the hyperdrive
-   * math operate on shares (as recommended by the protocols), but the MockLido
-   * and MockRocketPool contracts store account balances in base and calculate
-   * share price based on the current timestamp. This means an account's
-   * stETH/rETH balance remains constant while the amount of shares it
+   * FIXME: The StETHHyperdrive contract and much of hyperdrive math operates on
+   * shares, but the MockLido contract stores account balances in base and
+   * calculates share price based on the current timestamp. This means an
+   * account's stETH balance remains constant while the amount of shares it
    * represents decreases every second. This is different from how the real Lido
-   * and Rocket Token contracts work, where stETH/rETH balances update every
-   * rebase and the amount of shares they represent remains constant.
+   * contract works, where stETH balances update every rebase and the amount of
+   * shares they represent remains constant.
    *
-   * Because of this accounting difference in the mocks, the accuracy of any
-   * calculations based on share balance/price will slowly drift every second,
-   * and transactions prepared with an account's full share balance are likely
-   * to revert once submitted since the price will have changed. To accommodate
-   * this, the balance is truncated to the nearest .0001 base.
+   * Because of this accounting difference, the accuracy of any calculations
+   * based on share balance/price will slowly drift over time, and transactions
+   * prepared with an account's full share balance are likely to revert once
+   * submitted since the price will have changed. To accommodate this, the
+   * balance is truncated to the nearest .0001 base.
    */
   const tokenConfig = config.tokens.find(
     ({ address }) => address === tokenAddress,
@@ -83,7 +81,7 @@ export function useTokenBalance({
     tokenConfig &&
     tokenBalance &&
     (chainId === 42069 || chainId === 11155111) &&
-    (getIsSteth(tokenConfig) || getIsReth(tokenConfig))
+    getIsSteth(tokenConfig)
   ) {
     const truncatedBalance = tokenBalance - (tokenBalance % BigInt(1e14));
     return {

--- a/apps/hyperdrive-trading/src/ui/token/hooks/useTokenBalance.ts
+++ b/apps/hyperdrive-trading/src/ui/token/hooks/useTokenBalance.ts
@@ -1,6 +1,9 @@
 import { ETH_MAGIC_NUMBER } from "src/token/ETH_MAGIC_NUMBER";
+import { useAppConfig } from "src/ui/appconfig/useAppConfig";
+import { getIsReth } from "src/vaults/isReth";
+import { getIsSteth } from "src/vaults/isSteth";
 import { Address, erc20Abi, formatUnits } from "viem";
-import { useBalance, useReadContract } from "wagmi";
+import { useBalance, useChainId, useReadContract } from "wagmi";
 
 /**
  * Hook to get the token balance for an account. Supports the eth magic number
@@ -24,6 +27,8 @@ export function useTokenBalance({
   status: "error" | "success" | "loading";
 } {
   const isEth = tokenAddress === ETH_MAGIC_NUMBER;
+  const config = useAppConfig();
+  const chainId = useChainId();
 
   const { data: ethBalance, status: ethBalanceStatus } = useBalance({
     address: account,
@@ -52,6 +57,41 @@ export function useTokenBalance({
             }
           : undefined,
       status: ethBalanceStatus,
+    };
+  }
+
+  /**
+   * FIXME: The steth and reth hyperdrive contracts and much of the hyperdrive
+   * math operate on shares (as recommended by the protocols), but the MockLido
+   * and MockRocketPool contracts store account balances in base and calculate
+   * share price based on the current timestamp. This means an account's
+   * stETH/rETH balance remains constant while the amount of shares it
+   * represents decreases every second. This is different from how the real Lido
+   * and Rocket Token contracts work, where stETH/rETH balances update every
+   * rebase and the amount of shares they represent remains constant.
+   *
+   * Because of this accounting difference in the mocks, the accuracy of any
+   * calculations based on share balance/price will slowly drift every second,
+   * and transactions prepared with an account's full share balance are likely
+   * to revert once submitted since the price will have changed. To accommodate
+   * this, the balance is truncated to the nearest .0001 base.
+   */
+  const tokenConfig = config.tokens.find(
+    ({ address }) => address === tokenAddress,
+  );
+  if (
+    tokenConfig &&
+    tokenBalance &&
+    (chainId === 42069 || chainId === 11155111) &&
+    (getIsSteth(tokenConfig) || getIsReth(tokenConfig))
+  ) {
+    const truncatedBalance = tokenBalance - (tokenBalance % BigInt(1e14));
+    return {
+      balance: {
+        formatted: formatUnits(truncatedBalance, decimals),
+        value: truncatedBalance,
+      },
+      status: tokenBalanceStatus,
     };
   }
 

--- a/apps/hyperdrive-trading/src/vaults/isReth.ts
+++ b/apps/hyperdrive-trading/src/vaults/isReth.ts
@@ -1,0 +1,5 @@
+import { TokenConfig } from "@hyperdrive/appconfig";
+
+export function getIsReth(token: TokenConfig<any>): boolean {
+  return token.tags.includes("reth");
+}

--- a/apps/hyperdrive-trading/src/vaults/isReth.ts
+++ b/apps/hyperdrive-trading/src/vaults/isReth.ts
@@ -1,5 +1,0 @@
-import { TokenConfig } from "@hyperdrive/appconfig";
-
-export function getIsReth(token: TokenConfig<any>): boolean {
-  return token.tags.includes("reth");
-}

--- a/crates/hyperdrive-wasm/src/long/close.rs
+++ b/crates/hyperdrive-wasm/src/long/close.rs
@@ -8,8 +8,8 @@ use crate::{
     utils::set_panic_hook,
 };
 
-/// Calculates the amount of shares or base the trader will receive after fees
-/// for closing a long
+/// Calculates the amount of shares the trader will receive after fees for
+/// closing a long
 ///
 /// @param poolInfo - The current state of the pool
 ///

--- a/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
@@ -141,6 +141,17 @@ export class ReadHyperdrive extends ReadModel {
     return (baseAmount * 10n ** BigInt(decimals)) / vaultSharePrice;
   }
 
+  async getInitializationBlock(): Promise<Block> {
+    const events = await this.contract.getEvents("Initialize");
+
+    if (!events.length || events[0].blockNumber === undefined) {
+      throw new Error("Pool has not been initialized, no block found.");
+    }
+    const blockNumber = events[0].blockNumber;
+
+    return getBlockOrThrow(this.network, { blockNumber });
+  }
+
   /**
    * Get a standardized variable rate using vault share prices from checkpoints in
    * the last `timeRange` seconds.
@@ -154,18 +165,6 @@ export class ReadHyperdrive extends ReadModel {
    * @param timeRange The time range (in seconds) to use to calculate the variable
    * rate to look for checkpoints.
    */
-
-  async getInitializationBlock(): Promise<Block> {
-    const events = await this.contract.getEvents("Initialize");
-
-    if (!events.length || events[0].blockNumber === undefined) {
-      throw new Error("Pool has not been initialized, no block found.");
-    }
-    const blockNumber = events[0].blockNumber;
-
-    return getBlockOrThrow(this.network, { blockNumber });
-  }
-
   async getYieldSourceRate({
     blockRange,
   }: {

--- a/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
@@ -1507,10 +1507,10 @@ export class ReadHyperdrive extends ReadModel {
   }
 
   /**
-   * Predicts the amount of base asset it will cost to open a short.
+   * Calculates the cost to open a short given the current pool state and the
+   * amount of bonds the user wants to short.
    * @param amountOfBondsToShort The number of bonds to short
    * @param asBase If true, the traderDeposit will be in base. If false, the traderDeposit will be in shares
-   * @param asBase The decimal precision of the traderDeposit value
    */
   async previewOpenShort({
     amountOfBondsToShort,

--- a/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
@@ -112,6 +112,36 @@ export class ReadHyperdrive extends ReadModel {
   }
 
   /**
+   * Convert an amount of shares to base tokens using the current vault share price.
+   */
+  async convertToBase({
+    sharesAmount,
+    options,
+  }: {
+    sharesAmount: bigint;
+    options?: ContractReadOptions;
+  }): Promise<bigint> {
+    const { vaultSharePrice } = await this.getPoolInfo(options);
+    const decimals = await this.getDecimals();
+    return (sharesAmount * vaultSharePrice) / 10n ** BigInt(decimals);
+  }
+
+  /**
+   * Convert an amount of base tokens to shares using the current vault share price.
+   */
+  async convertToShares({
+    baseAmount,
+    options,
+  }: {
+    baseAmount: bigint;
+    options?: ContractReadOptions;
+  }): Promise<bigint> {
+    const { vaultSharePrice } = await this.getPoolInfo(options);
+    const decimals = await this.getDecimals();
+    return (baseAmount * 10n ** BigInt(decimals)) / vaultSharePrice;
+  }
+
+  /**
    * Get a standardized variable rate using vault share prices from checkpoints in
    * the last `timeRange` seconds.
    *

--- a/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
@@ -114,7 +114,7 @@ export class ReadHyperdrive extends ReadModel {
   /**
    * Convert an amount of shares to base tokens using the current vault share price.
    */
-  async convertToBase({
+  protected async convertToBase({
     sharesAmount,
     options,
   }: {
@@ -123,13 +123,16 @@ export class ReadHyperdrive extends ReadModel {
   }): Promise<bigint> {
     const { vaultSharePrice } = await this.getPoolInfo(options);
     const decimals = await this.getDecimals();
-    return (sharesAmount * vaultSharePrice) / 10n ** BigInt(decimals);
+    return dnum.multiply(
+      [sharesAmount, decimals],
+      [vaultSharePrice, decimals],
+    )[0];
   }
 
   /**
    * Convert an amount of base tokens to shares using the current vault share price.
    */
-  async convertToShares({
+  protected async convertToShares({
     baseAmount,
     options,
   }: {
@@ -138,7 +141,7 @@ export class ReadHyperdrive extends ReadModel {
   }): Promise<bigint> {
     const { vaultSharePrice } = await this.getPoolInfo(options);
     const decimals = await this.getDecimals();
-    return (baseAmount * 10n ** BigInt(decimals)) / vaultSharePrice;
+    return dnum.divide([baseAmount, decimals], [vaultSharePrice, decimals])[0];
   }
 
   async getInitializationBlock(): Promise<Block> {

--- a/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
@@ -1886,26 +1886,6 @@ export class ReadHyperdrive extends ReadModel {
   }
 }
 
-function calculateBaseAmount({
-  vaultShareAmount,
-  asBase,
-  baseAmount,
-}: {
-  vaultShareAmount: bigint;
-  asBase: boolean;
-  baseAmount: bigint;
-}): bigint {
-  // If you paid in base, no need to convert anything
-  if (asBase) {
-    return baseAmount;
-  }
-
-  // Get the vault share price at the time you opened the position
-  // so we can convert your shares paid into their base value
-  const vaultSharePrice = dnum.div([baseAmount, 18], [vaultShareAmount, 18])[0];
-  return dnum.multiply([vaultSharePrice, 18], [vaultShareAmount, 18])[0];
-}
-
 /*
  * This  returns the LP APY using the following formula for continuous compounding:
 

--- a/packages/hyperdrive-js-core/src/hyperdrive/steth/ReadStEthHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/steth/ReadStEthHyperdrive.ts
@@ -116,7 +116,7 @@ export function readStEthHyperdriveMixin<T extends Constructor<ReadHyperdrive>>(
     ): ReturnType<ReadHyperdrive["getMaxShort"]> {
       const result = await super.getMaxShort(options);
 
-      if (!this.setUseSharesAccounting) {
+      if (!this.isUsingSharesAccounting) {
         return {
           ...result,
           maxSharesIn: result.maxBaseIn,
@@ -131,7 +131,7 @@ export function readStEthHyperdriveMixin<T extends Constructor<ReadHyperdrive>>(
     ): ReturnType<ReadHyperdrive["getMaxLong"]> {
       const result = await super.getMaxLong(options);
 
-      if (!this.setUseSharesAccounting) {
+      if (!this.isUsingSharesAccounting) {
         return {
           ...result,
           maxSharesIn: result.maxBaseIn,

--- a/packages/hyperdrive-js-core/src/hyperdrive/steth/ReadStEthHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/steth/ReadStEthHyperdrive.ts
@@ -109,6 +109,25 @@ export function readStEthHyperdriveMixin<T extends Constructor<ReadHyperdrive>>(
       });
     }
 
+    // Calculations
+
+    async getMaxLong(
+      options?: Parameters<ReadHyperdrive["getMaxLong"]>[0],
+    ): ReturnType<ReadHyperdrive["getMaxLong"]> {
+      const result = await super.getMaxLong(options);
+
+      if (!this.setUseSharesAccounting) {
+        return {
+          ...result,
+          maxSharesIn: result.maxBaseIn,
+        };
+      }
+
+      return result;
+    }
+
+    // Previews
+
     async previewOpenLong({
       amountIn: _amountIn,
       asBase,

--- a/packages/hyperdrive-js-core/src/hyperdrive/steth/ReadStEthHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/steth/ReadStEthHyperdrive.ts
@@ -111,6 +111,21 @@ export function readStEthHyperdriveMixin<T extends Constructor<ReadHyperdrive>>(
 
     // Calculations
 
+    async getMaxShort(
+      options?: Parameters<ReadHyperdrive["getMaxShort"]>[0],
+    ): ReturnType<ReadHyperdrive["getMaxShort"]> {
+      const result = await super.getMaxShort(options);
+
+      if (!this.setUseSharesAccounting) {
+        return {
+          ...result,
+          maxSharesIn: result.maxBaseIn,
+        };
+      }
+
+      return result;
+    }
+
     async getMaxLong(
       options?: Parameters<ReadHyperdrive["getMaxLong"]>[0],
     ): ReturnType<ReadHyperdrive["getMaxLong"]> {

--- a/packages/hyperdrive-js-core/src/hyperdrive/steth/ReadStEthHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/steth/ReadStEthHyperdrive.ts
@@ -118,22 +118,21 @@ export function readStEthHyperdriveMixin<T extends Constructor<ReadHyperdrive>>(
       const result = await super.getMaxShort(options);
 
       if (!this.isUsingSharesAccounting) {
-        const decimals = await this.getDecimals();
-        return {
-          ...result,
-          // TODO: MockLido updates its price based on the current timestamp, so
-          // the accuracy of max calculations will slowly drift every second.
-          // This pads the max shares to avoid errors trying to open the max,
-          // but may not be needed for mainnet.
-          maxSharesIn: dnum.multiply(
-            [result.maxBaseIn, decimals],
-            [BigInt(1e18) - BigInt(1e12), decimals],
-          )[0],
-          // maxSharesIn: result.maxBaseIn,
-        };
+        result.maxSharesIn = result.maxBaseIn;
       }
 
-      return result;
+      const decimals = await this.getDecimals();
+      return {
+        ...result,
+        // FIXME: MockLido updates its price based on the current timestamp, so
+        // the accuracy of max calculations will slowly drift every second.
+        // This pads the max shares to avoid errors trying to open the max,
+        // but may not be needed for mainnet.
+        maxSharesIn: dnum.multiply(
+          [result.maxSharesIn, decimals],
+          [BigInt(1e18) - BigInt(1e12), decimals],
+        )[0],
+      };
     }
 
     async getMaxLong(
@@ -142,22 +141,21 @@ export function readStEthHyperdriveMixin<T extends Constructor<ReadHyperdrive>>(
       const result = await super.getMaxLong(options);
 
       if (!this.isUsingSharesAccounting) {
-        const decimals = await this.getDecimals();
-        return {
-          ...result,
-          // TODO: MockLido updates its price based on the current timestamp, so
-          // the accuracy of max calculations will slowly drift every second.
-          // This pads the max shares to avoid errors trying to open the max,
-          // but may not be needed for mainnet.
-          maxSharesIn: dnum.multiply(
-            [result.maxBaseIn, decimals],
-            [BigInt(1e18) - BigInt(1e12), decimals],
-          )[0],
-          // maxSharesIn: result.maxBaseIn,
-        };
+        result.maxSharesIn = result.maxBaseIn;
       }
 
-      return result;
+      const decimals = await this.getDecimals();
+      return {
+        ...result,
+        // FIXME: MockLido updates its price based on the current timestamp, so
+        // the accuracy of max calculations will slowly drift every second.
+        // This pads the max shares to avoid errors trying to open the max,
+        // but may not be needed for mainnet.
+        maxSharesIn: dnum.multiply(
+          [result.maxSharesIn, decimals],
+          [BigInt(1e18) - BigInt(1e12), decimals],
+        )[0],
+      };
     }
 
     // Previews

--- a/packages/hyperdrive-js-core/src/hyperdrive/steth/ReadStEthHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/steth/ReadStEthHyperdrive.ts
@@ -144,16 +144,17 @@ export function readStEthHyperdriveMixin<T extends Constructor<ReadHyperdrive>>(
     // Previews
 
     async previewOpenLong({
-      amountIn: _amountIn,
+      amountIn,
       asBase,
       options,
     }: Parameters<ReadHyperdrive["previewOpenLong"]>[0]): ReturnType<
       ReadHyperdrive["previewOpenLong"]
     > {
-      let amountIn = _amountIn;
-
       if (!asBase && !this.isUsingSharesAccounting) {
-        amountIn = await this.convertToShares(amountIn, options);
+        amountIn = await this.convertToShares({
+          baseAmount: amountIn,
+          options,
+        });
       }
 
       return super.previewOpenLong({
@@ -171,8 +172,6 @@ export function readStEthHyperdriveMixin<T extends Constructor<ReadHyperdrive>>(
     }: Parameters<ReadHyperdrive["previewCloseLong"]>[0]): ReturnType<
       ReadHyperdrive["previewCloseLong"]
     > {
-      const requiresConversion = !asBase && !this.isUsingSharesAccounting;
-
       const { flatPlusCurveFee, amountOut } = await super.previewCloseLong({
         maturityTime,
         bondAmountIn,
@@ -180,14 +179,17 @@ export function readStEthHyperdriveMixin<T extends Constructor<ReadHyperdrive>>(
         options,
       });
 
-      if (requiresConversion) {
-        const convertedStEthAmount = await this.convertToStEth(amountOut, {
-          blockTag: "latest",
-        });
-        return { amountOut: convertedStEthAmount, flatPlusCurveFee };
+      if (!asBase && !this.isUsingSharesAccounting) {
+        return {
+          flatPlusCurveFee,
+          amountOut: await this.convertToBase({
+            sharesAmount: amountOut,
+            options,
+          }),
+        };
       }
 
-      return { amountOut, flatPlusCurveFee };
+      return { flatPlusCurveFee, amountOut };
     }
 
     async previewOpenShort({
@@ -206,10 +208,10 @@ export function readStEthHyperdriveMixin<T extends Constructor<ReadHyperdrive>>(
       if (!asBase && !this.isUsingSharesAccounting) {
         return {
           ...result,
-          traderDeposit: await this.convertToStEth(
-            result.traderDeposit,
+          traderDeposit: await this.convertToBase({
+            sharesAmount: result.traderDeposit,
             options,
-          ),
+          }),
         };
       }
 
@@ -225,8 +227,6 @@ export function readStEthHyperdriveMixin<T extends Constructor<ReadHyperdrive>>(
     }: Parameters<ReadHyperdrive["previewCloseShort"]>[0]): ReturnType<
       ReadHyperdrive["previewCloseShort"]
     > {
-      const requiresConversion = !asBase && !this.isUsingSharesAccounting;
-
       const { amountOut, flatPlusCurveFee } = await super.previewCloseShort({
         asBase,
         maturityTime,
@@ -235,35 +235,36 @@ export function readStEthHyperdriveMixin<T extends Constructor<ReadHyperdrive>>(
         options,
       });
 
-      if (requiresConversion) {
-        const convertedStEthAmount = await this.convertToStEth(amountOut, {
-          blockTag: "latest",
-        });
-        return { amountOut: convertedStEthAmount, flatPlusCurveFee };
+      if (!asBase && !this.isUsingSharesAccounting) {
+        return {
+          amountOut: await this.convertToBase({
+            sharesAmount: amountOut,
+            options,
+          }),
+          flatPlusCurveFee,
+        };
       }
 
       return { amountOut, flatPlusCurveFee };
     }
 
     async previewAddLiquidity({
-      contribution: _contribution,
+      contribution,
       minAPR,
       minLpSharePrice,
       maxAPR,
-      destination,
       asBase,
-      extraData,
       options,
+      // TODO: Remove unused fields
+      destination,
+      extraData,
     }: Parameters<ReadHyperdrive["previewAddLiquidity"]>[0]): ReturnType<
       ReadHyperdrive["previewAddLiquidity"]
     > {
-      let contribution = _contribution;
-
       if (!asBase && !this.isUsingSharesAccounting) {
-        // Using the latest block since the preview will simulate the transaction
-        // using the latest state of the contract.
-        contribution = await this.convertToShares(contribution, {
-          blockTag: "latest",
+        contribution = await this.convertToShares({
+          baseAmount: contribution,
+          options,
         });
       }
 
@@ -272,16 +273,16 @@ export function readStEthHyperdriveMixin<T extends Constructor<ReadHyperdrive>>(
         minAPR,
         minLpSharePrice,
         maxAPR,
-        destination,
         asBase,
-        extraData,
         options,
+        destination,
+        extraData,
       });
     }
 
     async previewRemoveLiquidity({
       lpSharesIn,
-      minOutputPerShare: _minOutputPerShare,
+      minOutputPerShare,
       destination,
       asBase,
       extraData,
@@ -290,13 +291,15 @@ export function readStEthHyperdriveMixin<T extends Constructor<ReadHyperdrive>>(
       ReadHyperdrive["previewRemoveLiquidity"]
     > {
       const requiresConversion = !asBase && !this.isUsingSharesAccounting;
-      let minOutputPerShare = _minOutputPerShare;
 
       if (requiresConversion) {
         // Using the latest block since the preview will simulate the transaction
         // using the latest state of the contract.
-        minOutputPerShare = await this.convertToShares(minOutputPerShare, {
-          blockTag: "latest",
+        minOutputPerShare = await this.convertToShares({
+          baseAmount: minOutputPerShare,
+          options: {
+            blockTag: "latest",
+          },
         });
       }
 
@@ -312,41 +315,63 @@ export function readStEthHyperdriveMixin<T extends Constructor<ReadHyperdrive>>(
       if (requiresConversion) {
         return {
           ...result,
-          proceeds: await this.convertToStEth(result.proceeds),
+          proceeds: await this.convertToBase({
+            sharesAmount: result.proceeds,
+            options: {
+              blockTag: "latest",
+            },
+          }),
         };
       }
 
       return result;
     }
 
-    /**
-     * Convert a stETH amount to shares.
-     */
-    private async convertToShares(
-      stEthAmount: bigint,
-      options?: ContractReadOptions,
-    ): Promise<bigint> {
-      const stEth = await this.getSharesToken();
-      const sharesAmount = await stEth.getSharesByPooledEth({
-        ethAmount: stEthAmount,
+    async previewRedeemWithdrawalShares({
+      withdrawalSharesIn,
+      minOutputPerShare,
+      destination,
+      asBase,
+      extraData,
+      options,
+    }: Parameters<
+      ReadHyperdrive["previewRedeemWithdrawalShares"]
+    >[0]): ReturnType<ReadHyperdrive["previewRedeemWithdrawalShares"]> {
+      const requiresConversion = !asBase && !this.isUsingSharesAccounting;
+
+      if (requiresConversion) {
+        // Using the latest block since the preview will simulate the transaction
+        // using the latest state of the contract.
+        minOutputPerShare = await this.convertToShares({
+          baseAmount: minOutputPerShare,
+          options: {
+            blockTag: "latest",
+          },
+        });
+      }
+
+      const result = await super.previewRedeemWithdrawalShares({
+        withdrawalSharesIn,
+        minOutputPerShare,
+        destination,
+        asBase,
+        extraData,
         options,
       });
-      // FIXME: Remove and find solution for mainnet
-      // This is needed because the conversion done before submitting the
-      // transaction to open a position and by the time the position TX is
-      // submitted, the share price could have changed.
-      return sharesAmount - (sharesAmount % BigInt(1e16));
-    }
 
-    /**
-     * Convert a share amount to stETH.
-     */
-    private async convertToStEth(
-      sharesAmount: bigint,
-      options?: ContractReadOptions,
-    ): Promise<bigint> {
-      const stEth = await this.getSharesToken();
-      return stEth.getPooledEthByShares({ sharesAmount, options });
+      if (requiresConversion) {
+        return {
+          ...result,
+          sharesProceeds: await this.convertToBase({
+            sharesAmount: result.sharesProceeds,
+            options: {
+              blockTag: "latest",
+            },
+          }),
+        };
+      }
+
+      return result;
     }
   };
 }

--- a/packages/hyperdrive-js-core/src/hyperdrive/steth/ReadStEthHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/steth/ReadStEthHyperdrive.ts
@@ -1,4 +1,5 @@
 import { ContractReadOptions } from "@delvtech/evm-client";
+import * as dnum from "dnum";
 import { Constructor } from "src/base/types";
 import {
   ReadHyperdrive,
@@ -117,9 +118,18 @@ export function readStEthHyperdriveMixin<T extends Constructor<ReadHyperdrive>>(
       const result = await super.getMaxShort(options);
 
       if (!this.isUsingSharesAccounting) {
+        const decimals = await this.getDecimals();
         return {
           ...result,
-          maxSharesIn: result.maxBaseIn,
+          // TODO: MockLido updates its price based on the current timestamp, so
+          // the accuracy of max calculations will slowly drift every second.
+          // This pads the max shares to avoid errors trying to open the max,
+          // but may not be needed for mainnet.
+          maxSharesIn: dnum.multiply(
+            [result.maxBaseIn, decimals],
+            [BigInt(1e18) - BigInt(1e12), decimals],
+          )[0],
+          // maxSharesIn: result.maxBaseIn,
         };
       }
 
@@ -132,9 +142,18 @@ export function readStEthHyperdriveMixin<T extends Constructor<ReadHyperdrive>>(
       const result = await super.getMaxLong(options);
 
       if (!this.isUsingSharesAccounting) {
+        const decimals = await this.getDecimals();
         return {
           ...result,
-          maxSharesIn: result.maxBaseIn,
+          // TODO: MockLido updates its price based on the current timestamp, so
+          // the accuracy of max calculations will slowly drift every second.
+          // This pads the max shares to avoid errors trying to open the max,
+          // but may not be needed for mainnet.
+          maxSharesIn: dnum.multiply(
+            [result.maxBaseIn, decimals],
+            [BigInt(1e18) - BigInt(1e12), decimals],
+          )[0],
+          // maxSharesIn: result.maxBaseIn,
         };
       }
 

--- a/packages/hyperdrive-js-core/src/hyperdrive/steth/ReadWriteStEthHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/steth/ReadWriteStEthHyperdrive.ts
@@ -194,7 +194,7 @@ export class ReadWriteStEthHyperdrive extends readStEthHyperdriveMixin(
       });
     }
 
-    return super.closeLong({
+    return super.closeShort({
       args: {
         maturityTime,
         bondAmountIn,

--- a/packages/hyperdrive-js-core/src/hyperdrive/steth/ReadWriteStEthHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/steth/ReadWriteStEthHyperdrive.ts
@@ -36,4 +36,256 @@ export class ReadWriteStEthHyperdrive extends readStEthHyperdriveMixin(
       network: this.network,
     });
   }
+
+  async initialize({
+    args: { contribution, apr, destination, asBase, extraData },
+    options,
+  }: Parameters<ReadWriteHyperdrive["initialize"]>[0]): ReturnType<
+    ReadWriteHyperdrive["initialize"]
+  > {
+    if (!asBase && !this.isUsingSharesAccounting) {
+      contribution = await this.convertToShares({
+        baseAmount: contribution,
+        options: {
+          blockTag: "latest",
+        },
+      });
+    }
+
+    return super.initialize({
+      args: { contribution, apr, destination, asBase, extraData },
+      options,
+    });
+  }
+
+  async openLong({
+    args: {
+      destination,
+      amount,
+      minBondsOut,
+      minVaultSharePrice,
+      asBase,
+      extraData,
+    },
+    options,
+  }: Parameters<ReadWriteHyperdrive["openLong"]>[0]): ReturnType<
+    ReadWriteHyperdrive["openLong"]
+  > {
+    if (!asBase && !this.isUsingSharesAccounting) {
+      amount = await this.convertToShares({
+        baseAmount: amount,
+        options: {
+          blockTag: "latest",
+        },
+      });
+    }
+
+    return super.openLong({
+      args: {
+        destination,
+        amount,
+        minBondsOut,
+        minVaultSharePrice,
+        asBase,
+        extraData,
+      },
+      options,
+    });
+  }
+
+  async closeLong({
+    args: {
+      maturityTime,
+      bondAmountIn,
+      minAmountOut,
+      destination,
+      asBase,
+      extraData,
+    },
+    options,
+  }: Parameters<ReadWriteHyperdrive["closeLong"]>[0]): ReturnType<
+    ReadWriteHyperdrive["closeLong"]
+  > {
+    if (!asBase && !this.isUsingSharesAccounting) {
+      minAmountOut = await this.convertToShares({
+        baseAmount: minAmountOut,
+        options: {
+          blockTag: "latest",
+        },
+      });
+    }
+
+    return super.closeLong({
+      args: {
+        maturityTime,
+        bondAmountIn,
+        minAmountOut,
+        destination,
+        asBase,
+        extraData,
+      },
+      options,
+    });
+  }
+
+  async openShort({
+    args: {
+      destination,
+      bondAmount,
+      minVaultSharePrice,
+      maxDeposit,
+      asBase,
+      extraData,
+    },
+    options,
+  }: Parameters<ReadWriteHyperdrive["openShort"]>[0]): ReturnType<
+    ReadWriteHyperdrive["openShort"]
+  > {
+    if (!asBase && !this.isUsingSharesAccounting) {
+      maxDeposit = await this.convertToShares({
+        baseAmount: maxDeposit,
+        options: {
+          blockTag: "latest",
+        },
+      });
+    }
+
+    return super.openShort({
+      args: {
+        destination,
+        bondAmount,
+        minVaultSharePrice,
+        maxDeposit,
+        asBase,
+        extraData,
+      },
+      options,
+    });
+  }
+
+  async closeShort({
+    args: {
+      maturityTime,
+      bondAmountIn,
+      minAmountOut,
+      destination,
+      asBase,
+      extraData,
+    },
+    options,
+  }: Parameters<ReadWriteHyperdrive["closeShort"]>[0]): ReturnType<
+    ReadWriteHyperdrive["closeShort"]
+  > {
+    if (!asBase && !this.isUsingSharesAccounting) {
+      minAmountOut = await this.convertToShares({
+        baseAmount: minAmountOut,
+        options: {
+          blockTag: "latest",
+        },
+      });
+    }
+
+    return super.closeLong({
+      args: {
+        maturityTime,
+        bondAmountIn,
+        minAmountOut,
+        destination,
+        asBase,
+        extraData,
+      },
+      options,
+    });
+  }
+
+  async addLiquidity({
+    args: {
+      destination,
+      contribution,
+      minAPR,
+      minLpSharePrice,
+      maxAPR,
+      asBase,
+      extraData,
+    },
+    options,
+  }: Parameters<ReadWriteHyperdrive["addLiquidity"]>[0]): ReturnType<
+    ReadWriteHyperdrive["addLiquidity"]
+  > {
+    if (!asBase && !this.isUsingSharesAccounting) {
+      contribution = await this.convertToShares({
+        baseAmount: contribution,
+        options: {
+          blockTag: "latest",
+        },
+      });
+    }
+
+    return super.addLiquidity({
+      args: {
+        destination,
+        contribution,
+        minAPR,
+        minLpSharePrice,
+        maxAPR,
+        asBase,
+        extraData,
+      },
+      options,
+    });
+  }
+
+  async removeLiquidity({
+    args: { destination, lpSharesIn, minOutputPerShare, asBase, extraData },
+    options,
+  }: Parameters<ReadWriteHyperdrive["removeLiquidity"]>[0]): ReturnType<
+    ReadWriteHyperdrive["removeLiquidity"]
+  > {
+    if (!asBase && !this.isUsingSharesAccounting) {
+      minOutputPerShare = await this.convertToShares({
+        baseAmount: minOutputPerShare,
+        options: {
+          blockTag: "latest",
+        },
+      });
+    }
+
+    return super.removeLiquidity({
+      args: { destination, lpSharesIn, minOutputPerShare, asBase, extraData },
+      options,
+    });
+  }
+
+  async redeemWithdrawalShares({
+    args: {
+      withdrawalSharesIn,
+      minOutputPerShare,
+      destination,
+      asBase,
+      extraData,
+    },
+    options,
+  }: Parameters<ReadWriteHyperdrive["redeemWithdrawalShares"]>[0]): ReturnType<
+    ReadWriteHyperdrive["redeemWithdrawalShares"]
+  > {
+    if (!asBase && !this.isUsingSharesAccounting) {
+      minOutputPerShare = await this.convertToShares({
+        baseAmount: minOutputPerShare,
+        options: {
+          blockTag: "latest",
+        },
+      });
+    }
+
+    return super.redeemWithdrawalShares({
+      args: {
+        withdrawalSharesIn,
+        minOutputPerShare,
+        destination,
+        asBase,
+        extraData,
+      },
+      options,
+    });
+  }
 }

--- a/packages/hyperdrive-js-core/src/hyperdrive/steth/ReadWriteStEthHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/steth/ReadWriteStEthHyperdrive.ts
@@ -40,6 +40,7 @@ export class ReadWriteStEthHyperdrive extends readStEthHyperdriveMixin(
   async initialize({
     args: { contribution, apr, destination, asBase, extraData },
     options,
+    onTransactionCompleted,
   }: Parameters<ReadWriteHyperdrive["initialize"]>[0]): ReturnType<
     ReadWriteHyperdrive["initialize"]
   > {
@@ -55,6 +56,7 @@ export class ReadWriteStEthHyperdrive extends readStEthHyperdriveMixin(
     return super.initialize({
       args: { contribution, apr, destination, asBase, extraData },
       options,
+      onTransactionCompleted,
     });
   }
 
@@ -68,6 +70,7 @@ export class ReadWriteStEthHyperdrive extends readStEthHyperdriveMixin(
       extraData,
     },
     options,
+    onTransactionCompleted,
   }: Parameters<ReadWriteHyperdrive["openLong"]>[0]): ReturnType<
     ReadWriteHyperdrive["openLong"]
   > {
@@ -90,6 +93,7 @@ export class ReadWriteStEthHyperdrive extends readStEthHyperdriveMixin(
         extraData,
       },
       options,
+      onTransactionCompleted,
     });
   }
 
@@ -103,6 +107,7 @@ export class ReadWriteStEthHyperdrive extends readStEthHyperdriveMixin(
       extraData,
     },
     options,
+    onTransactionCompleted,
   }: Parameters<ReadWriteHyperdrive["closeLong"]>[0]): ReturnType<
     ReadWriteHyperdrive["closeLong"]
   > {
@@ -125,6 +130,7 @@ export class ReadWriteStEthHyperdrive extends readStEthHyperdriveMixin(
         extraData,
       },
       options,
+      onTransactionCompleted,
     });
   }
 
@@ -138,6 +144,7 @@ export class ReadWriteStEthHyperdrive extends readStEthHyperdriveMixin(
       extraData,
     },
     options,
+    onTransactionCompleted,
   }: Parameters<ReadWriteHyperdrive["openShort"]>[0]): ReturnType<
     ReadWriteHyperdrive["openShort"]
   > {
@@ -160,6 +167,7 @@ export class ReadWriteStEthHyperdrive extends readStEthHyperdriveMixin(
         extraData,
       },
       options,
+      onTransactionCompleted,
     });
   }
 
@@ -173,6 +181,7 @@ export class ReadWriteStEthHyperdrive extends readStEthHyperdriveMixin(
       extraData,
     },
     options,
+    onTransactionCompleted,
   }: Parameters<ReadWriteHyperdrive["closeShort"]>[0]): ReturnType<
     ReadWriteHyperdrive["closeShort"]
   > {
@@ -195,6 +204,7 @@ export class ReadWriteStEthHyperdrive extends readStEthHyperdriveMixin(
         extraData,
       },
       options,
+      onTransactionCompleted,
     });
   }
 
@@ -209,6 +219,7 @@ export class ReadWriteStEthHyperdrive extends readStEthHyperdriveMixin(
       extraData,
     },
     options,
+    onTransactionCompleted,
   }: Parameters<ReadWriteHyperdrive["addLiquidity"]>[0]): ReturnType<
     ReadWriteHyperdrive["addLiquidity"]
   > {
@@ -232,12 +243,14 @@ export class ReadWriteStEthHyperdrive extends readStEthHyperdriveMixin(
         extraData,
       },
       options,
+      onTransactionCompleted,
     });
   }
 
   async removeLiquidity({
     args: { destination, lpSharesIn, minOutputPerShare, asBase, extraData },
     options,
+    onTransactionCompleted,
   }: Parameters<ReadWriteHyperdrive["removeLiquidity"]>[0]): ReturnType<
     ReadWriteHyperdrive["removeLiquidity"]
   > {
@@ -253,6 +266,7 @@ export class ReadWriteStEthHyperdrive extends readStEthHyperdriveMixin(
     return super.removeLiquidity({
       args: { destination, lpSharesIn, minOutputPerShare, asBase, extraData },
       options,
+      onTransactionCompleted,
     });
   }
 
@@ -265,6 +279,7 @@ export class ReadWriteStEthHyperdrive extends readStEthHyperdriveMixin(
       extraData,
     },
     options,
+    onTransactionCompleted,
   }: Parameters<ReadWriteHyperdrive["redeemWithdrawalShares"]>[0]): ReturnType<
     ReadWriteHyperdrive["redeemWithdrawalShares"]
   > {
@@ -286,6 +301,7 @@ export class ReadWriteStEthHyperdrive extends readStEthHyperdriveMixin(
         extraData,
       },
       options,
+      onTransactionCompleted,
     });
   }
 }


### PR DESCRIPTION
Related to #1066.

## Missing conversions

- The `ReadStEthHyperdrive` model, which is responsible for converting amounts from Lido shares to stETH, was missing `getMaxLong` and `getMaxShort` overrides to convert the `maxSharesIn`.
- The `ReadWriteStEthHyperdrive` model wasn't converting any of the stETH amounts to Lido shares, so transactions were being submitted with higher share amounts than what the UI showed.

All missing conversions were added.

## Constant share price increase in `MockLido`

- The `MockLido` and `MockRocketPool` contracts [calculate share price based on the current timestamp](https://github.com/delvtech/hyperdrive/blob/main/contracts/test/MockLido.sol#L171) which means that the accuracy of any calculations based on share price will slowly drift as time passes. This was causing errors when trying to open the max long/short since the max shares amount is already over the max the second after it's calculated.
- An account's stETH balance remains constant in the `MockLido` contract while the amount of shares it represents decreases as the share price increases. This is different from how the real Lido contract works, where stETH balances update every rebase and the amount of shares they represent remains constant. This was causing errors when trying to open trades using your full stETH balance since the converted shares balance was higher when prepared than when submitted.

To reduce the chance of hitting these errors, the `maxSharesIn` was padded  in `ReadStEthHyperdrive` and `ReadREthHyperdrive`, and the stETH balances were truncated to 1e14 on Sepolia with `FIXME:` comments.

Excalidraw of max long error: https://app.excalidraw.com/s/6Cpa5unvDjf/AYHlDBfPJak