### PR TITLE
fix steth conversion bug on OpenLongPreview

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongPreview.tsx
@@ -16,7 +16,6 @@ import { LabelValue } from "src/ui/base/components/LabelValue";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { formatDate } from "src/ui/base/formatting/formatDate";
 import { useCurrentFixedAPR } from "src/ui/hyperdrive/hooks/useCurrentFixedAPR";
-import { getIsSteth } from "src/vaults/isSteth";
 
 interface OpenLongPreviewProps {
   hyperdrive: HyperdriveConfig;
@@ -47,7 +46,7 @@ export function OpenLongPreview({
     tokens: appConfig.tokens,
   });
   const { fixedAPR } = useCurrentFixedAPR(hyperdrive.address);
-  const isSteth = getIsSteth(sharesToken);
+
   const termLengthMS = Number(hyperdrive.poolConfig.positionDuration * 1000n);
   const numDays = convertMillisecondsToDays(termLengthMS);
   return (
@@ -106,7 +105,7 @@ export function OpenLongPreview({
                       positionDuration:
                         hyperdrive.poolConfig.positionDuration || 0n,
                       baseAmount:
-                        asBase || isSteth
+                        asBase || sharesToken.extensions.isSharesPeggedToBase
                           ? long.baseAmountPaid
                           : // TODO: move sharesAmountPaid into the sdk's Long interface
                             // instead of converting here

--- a/packages/hyperdrive-appconfig/src/generated/11155111.appconfig.ts
+++ b/packages/hyperdrive-appconfig/src/generated/11155111.appconfig.ts
@@ -19,6 +19,7 @@ export const sepoliaAppConfig: AppConfig = {
       extensions: {
         shortName: "Lido stETH",
         protocol: "lido",
+        isSharesPeggedToBase: true,
       },
     },
     {
@@ -32,20 +33,6 @@ export const sepoliaAppConfig: AppConfig = {
       iconUrl: "https://cryptologos.cc/logos/ethereum-eth-logo.png?v=029",
     },
     {
-      address: "0x3B57E3b2531a376Ee5B248943Bb6DE99E333BB5D",
-      decimals: 18,
-      places: 4,
-      name: "Renzo ezETH",
-      symbol: "ezETH",
-      iconUrl:
-        "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjIwMiIgdmlld0JveD0iMCAwIDIwMCAyMDIiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxyZWN0IHdpZHRoPSIyMDAiIGhlaWdodD0iMTk4LjM2NCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMCAyKSIgZmlsbD0iIzA4MEIxQiIvPgo8ZyBmaWx0ZXI9InVybCgjZmlsdGVyMF9kZF83N180MykiPgo8cGF0aCBkPSJNMTAwLjExMSA0NC4xMjA0TDk5LjM0ODMgNDYuNzEzMUw5OS4zNDgzIDEyMS45NDFMMTAwLjExMSAxMjIuNzAyTDEzNC45NzggMTAyLjA2MUwxMDAuMTExIDQ0LjEyMDRaIiBmaWxsPSIjNkI2QjZCIi8+CjxwYXRoIGQ9Ik0xMDAuMTExIDQ0LjEyMDRMNjUuMjQxNyAxMDIuMDYxTDEwMC4xMTEgMTIyLjcwMkwxMDAuMTExIDg2LjE4ODlMMTAwLjExMSA0NC4xMjA0WiIgZmlsbD0iI0EyQTJBMiIvPgo8cGF0aCBkPSJNMTAwLjExMSAxMjkuMzE0TDk5LjY4MDkgMTI5LjgzOEw5OS42ODA5IDE1Ni42MzZMMTAwLjExMSAxNTcuODkyTDEzNSAxMDguNjgzTDEwMC4xMTEgMTI5LjMxNFoiIGZpbGw9IiM0RjRFNEUiLz4KPHBhdGggZD0iTTEwMC4xMTEgMTU3Ljg5MkwxMDAuMTExIDEyOS4zMTRMNjUuMjQxNyAxMDguNjgzTDEwMC4xMTEgMTU3Ljg5MloiIGZpbGw9IiNBMkEyQTIiLz4KPHBhdGggZD0iTTEwMC4xMTEgMTIyLjcwMkwxMzQuOTc4IDEwMi4wNjFMMTAwLjExMSA4Ni4xODg5TDEwMC4xMTEgMTIyLjcwMloiIGZpbGw9IiM3OTc5NzkiLz4KPHBhdGggZD0iTTY1LjI0MTcgMTAyLjA2MUwxMDAuMTExIDEyMi43MDJMMTAwLjExMSA4Ni4xODg5TDY1LjI0MTcgMTAyLjA2MVoiIGZpbGw9IiNENEQ0RDQiLz4KPGcgc3R5bGU9Im1peC1ibGVuZC1tb2RlOm92ZXJsYXkiPgo8cGF0aCBkPSJNMTAwLjExIDQ0LjEyMDRMOTkuMzQ4MyA0Ni43MTMxTDk5LjM0ODMgMTIxLjk0MUwxMDAuMTEgMTIyLjcwMkwxMzQuOTc4IDEwMi4wNjFMMTAwLjExIDQ0LjEyMDRaIiBmaWxsPSIjQUNFNzMwIi8+CjxwYXRoIGQ9Ik0xMDAuMTEgNDQuMTIwNEw2NS4yNDE3IDEwMi4wNjFMMTAwLjExIDEyMi43MDJMMTAwLjExIDg2LjE4ODlMMTAwLjExIDQ0LjEyMDRaIiBmaWxsPSIjQUNFNzMwIi8+CjxwYXRoIGQ9Ik0xMDAuMTExIDEyOS4zMTRMOTkuNjgwOSAxMjkuODM4TDk5LjY4MDkgMTU2LjYzNkwxMDAuMTExIDE1Ny44OTJMMTM1IDEwOC42ODNMMTAwLjExMSAxMjkuMzE0WiIgZmlsbD0iI0FDRTczMCIvPgo8cGF0aCBkPSJNMTAwLjExMSAxNTcuODkyTDEwMC4xMTEgMTI5LjMxNEw2NS4yNDE3IDEwOC42ODNMMTAwLjExMSAxNTcuODkyWiIgZmlsbD0iI0FDRTczMCIvPgo8cGF0aCBkPSJNMTAwLjExIDEyMi43MDJMMTM0Ljk3OCAxMDIuMDYxTDEwMC4xMSA4Ni4xODg5TDEwMC4xMSAxMjIuNzAyWiIgZmlsbD0iI0FDRTczMCIvPgo8cGF0aCBkPSJNNjUuMjQxNyAxMDIuMDYxTDEwMC4xMSAxMjIuNzAyTDEwMC4xMSA4Ni4xODg5TDY1LjI0MTcgMTAyLjA2MVoiIGZpbGw9IiNBQ0U3MzAiLz4KPC9nPgo8L2c+CjxkZWZzPgo8ZmlsdGVyIGlkPSJmaWx0ZXIwX2RkXzc3XzQzIiB4PSIyMS4yMTMxIiB5PSIwLjA5MTgwMDciIHdpZHRoPSIxNTcuODE1IiBoZWlnaHQ9IjIwMS44MjgiIGZpbHRlclVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgY29sb3ItaW50ZXJwb2xhdGlvbi1maWx0ZXJzPSJzUkdCIj4KPGZlRmxvb2QgZmxvb2Qtb3BhY2l0eT0iMCIgcmVzdWx0PSJCYWNrZ3JvdW5kSW1hZ2VGaXgiLz4KPGZlQ29sb3JNYXRyaXggaW49IlNvdXJjZUFscGhhIiB0eXBlPSJtYXRyaXgiIHZhbHVlcz0iMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMTI3IDAiIHJlc3VsdD0iaGFyZEFscGhhIi8+CjxmZU9mZnNldC8+CjxmZUdhdXNzaWFuQmx1ciBzdGREZXZpYXRpb249IjEwLjY3MjUiLz4KPGZlQ29tcG9zaXRlIGluMj0iaGFyZEFscGhhIiBvcGVyYXRvcj0ib3V0Ii8+CjxmZUNvbG9yTWF0cml4IHR5cGU9Im1hdHJpeCIgdmFsdWVzPSIwIDAgMCAwIDAuNjc0NTEgMCAwIDAgMCAwLjkwNTg4MiAwIDAgMCAwIDAuMTg4MjM1IDAgMCAwIDAuNSAwIi8+CjxmZUJsZW5kIG1vZGU9Im5vcm1hbCIgaW4yPSJCYWNrZ3JvdW5kSW1hZ2VGaXgiIHJlc3VsdD0iZWZmZWN0MV9kcm9wU2hhZG93Xzc3XzQzIi8+CjxmZUNvbG9yTWF0cml4IGluPSJTb3VyY2VBbHBoYSIgdHlwZT0ibWF0cml4IiB2YWx1ZXM9IjAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDEyNyAwIiByZXN1bHQ9ImhhcmRBbHBoYSIvPgo8ZmVPZmZzZXQvPgo8ZmVHYXVzc2lhbkJsdXIgc3RkRGV2aWF0aW9uPSIyMi4wMTQzIi8+CjxmZUNvbXBvc2l0ZSBpbjI9ImhhcmRBbHBoYSIgb3BlcmF0b3I9Im91dCIvPgo8ZmVDb2xvck1hdHJpeCB0eXBlPSJtYXRyaXgiIHZhbHVlcz0iMCAwIDAgMCAwLjY3NDUxIDAgMCAwIDAgMC45MDU4ODIgMCAwIDAgMCAwLjE4ODIzNSAwIDAgMCAxIDAiLz4KPGZlQmxlbmQgbW9kZT0ibm9ybWFsIiBpbjI9ImVmZmVjdDFfZHJvcFNoYWRvd183N180MyIgcmVzdWx0PSJlZmZlY3QyX2Ryb3BTaGFkb3dfNzdfNDMiLz4KPGZlQmxlbmQgbW9kZT0ibm9ybWFsIiBpbj0iU291cmNlR3JhcGhpYyIgaW4yPSJlZmZlY3QyX2Ryb3BTaGFkb3dfNzdfNDMiIHJlc3VsdD0ic2hhcGUiLz4KPC9maWx0ZXI+CjwvZGVmcz4KPC9zdmc+Cg==",
-      tags: ["yieldSource", "ezeth"],
-      extensions: {
-        shortName: "Renzo ezETH",
-        protocol: "renzo",
-      },
-    },
-    {
       address: "0xF4A3178BC28DaE9a842837a3421f8652CBCdf7bF",
       decimals: 18,
       places: 4,
@@ -57,19 +44,37 @@ export const sepoliaAppConfig: AppConfig = {
       extensions: {
         shortName: "Rocket Pool ETH",
         protocol: "rocketPool",
+        isSharesPeggedToBase: false,
       },
     },
     {
-      address: "0xAb1895c74902F2dbd40e76CB616d80e4aA780713",
+      address: "0x3B57E3b2531a376Ee5B248943Bb6DE99E333BB5D",
+      decimals: 18,
+      places: 4,
+      name: "Renzo ezETH",
+      symbol: "ezETH",
+      iconUrl:
+        "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjIwMiIgdmlld0JveD0iMCAwIDIwMCAyMDIiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxyZWN0IHdpZHRoPSIyMDAiIGhlaWdodD0iMTk4LjM2NCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMCAyKSIgZmlsbD0iIzA4MEIxQiIvPgo8ZyBmaWx0ZXI9InVybCgjZmlsdGVyMF9kZF83N180MykiPgo8cGF0aCBkPSJNMTAwLjExMSA0NC4xMjA0TDk5LjM0ODMgNDYuNzEzMUw5OS4zNDgzIDEyMS45NDFMMTAwLjExMSAxMjIuNzAyTDEzNC45NzggMTAyLjA2MUwxMDAuMTExIDQ0LjEyMDRaIiBmaWxsPSIjNkI2QjZCIi8+CjxwYXRoIGQ9Ik0xMDAuMTExIDQ0LjEyMDRMNjUuMjQxNyAxMDIuMDYxTDEwMC4xMTEgMTIyLjcwMkwxMDAuMTExIDg2LjE4ODlMMTAwLjExMSA0NC4xMjA0WiIgZmlsbD0iI0EyQTJBMiIvPgo8cGF0aCBkPSJNMTAwLjExMSAxMjkuMzE0TDk5LjY4MDkgMTI5LjgzOEw5OS42ODA5IDE1Ni42MzZMMTAwLjExMSAxNTcuODkyTDEzNSAxMDguNjgzTDEwMC4xMTEgMTI5LjMxNFoiIGZpbGw9IiM0RjRFNEUiLz4KPHBhdGggZD0iTTEwMC4xMTEgMTU3Ljg5MkwxMDAuMTExIDEyOS4zMTRMNjUuMjQxNyAxMDguNjgzTDEwMC4xMTEgMTU3Ljg5MloiIGZpbGw9IiNBMkEyQTIiLz4KPHBhdGggZD0iTTEwMC4xMTEgMTIyLjcwMkwxMzQuOTc4IDEwMi4wNjFMMTAwLjExMSA4Ni4xODg5TDEwMC4xMTEgMTIyLjcwMloiIGZpbGw9IiM3OTc5NzkiLz4KPHBhdGggZD0iTTY1LjI0MTcgMTAyLjA2MUwxMDAuMTExIDEyMi43MDJMMTAwLjExMSA4Ni4xODg5TDY1LjI0MTcgMTAyLjA2MVoiIGZpbGw9IiNENEQ0RDQiLz4KPGcgc3R5bGU9Im1peC1ibGVuZC1tb2RlOm92ZXJsYXkiPgo8cGF0aCBkPSJNMTAwLjExIDQ0LjEyMDRMOTkuMzQ4MyA0Ni43MTMxTDk5LjM0ODMgMTIxLjk0MUwxMDAuMTEgMTIyLjcwMkwxMzQuOTc4IDEwMi4wNjFMMTAwLjExIDQ0LjEyMDRaIiBmaWxsPSIjQUNFNzMwIi8+CjxwYXRoIGQ9Ik0xMDAuMTEgNDQuMTIwNEw2NS4yNDE3IDEwMi4wNjFMMTAwLjExIDEyMi43MDJMMTAwLjExIDg2LjE4ODlMMTAwLjExIDQ0LjEyMDRaIiBmaWxsPSIjQUNFNzMwIi8+CjxwYXRoIGQ9Ik0xMDAuMTExIDEyOS4zMTRMOTkuNjgwOSAxMjkuODM4TDk5LjY4MDkgMTU2LjYzNkwxMDAuMTExIDE1Ny44OTJMMTM1IDEwOC42ODNMMTAwLjExMSAxMjkuMzE0WiIgZmlsbD0iI0FDRTczMCIvPgo8cGF0aCBkPSJNMTAwLjExMSAxNTcuODkyTDEwMC4xMTEgMTI5LjMxNEw2NS4yNDE3IDEwOC42ODNMMTAwLjExMSAxNTcuODkyWiIgZmlsbD0iI0FDRTczMCIvPgo8cGF0aCBkPSJNMTAwLjExIDEyMi43MDJMMTM0Ljk3OCAxMDIuMDYxTDEwMC4xMSA4Ni4xODg5TDEwMC4xMSAxMjIuNzAyWiIgZmlsbD0iI0FDRTczMCIvPgo8cGF0aCBkPSJNNjUuMjQxNyAxMDIuMDYxTDEwMC4xMSAxMjIuNzAyTDEwMC4xMSA4Ni4xODg5TDY1LjI0MTcgMTAyLjA2MVoiIGZpbGw9IiNBQ0U3MzAiLz4KPC9nPgo8L2c+CjxkZWZzPgo8ZmlsdGVyIGlkPSJmaWx0ZXIwX2RkXzc3XzQzIiB4PSIyMS4yMTMxIiB5PSIwLjA5MTgwMDciIHdpZHRoPSIxNTcuODE1IiBoZWlnaHQ9IjIwMS44MjgiIGZpbHRlclVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgY29sb3ItaW50ZXJwb2xhdGlvbi1maWx0ZXJzPSJzUkdCIj4KPGZlRmxvb2QgZmxvb2Qtb3BhY2l0eT0iMCIgcmVzdWx0PSJCYWNrZ3JvdW5kSW1hZ2VGaXgiLz4KPGZlQ29sb3JNYXRyaXggaW49IlNvdXJjZUFscGhhIiB0eXBlPSJtYXRyaXgiIHZhbHVlcz0iMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMTI3IDAiIHJlc3VsdD0iaGFyZEFscGhhIi8+CjxmZU9mZnNldC8+CjxmZUdhdXNzaWFuQmx1ciBzdGREZXZpYXRpb249IjEwLjY3MjUiLz4KPGZlQ29tcG9zaXRlIGluMj0iaGFyZEFscGhhIiBvcGVyYXRvcj0ib3V0Ii8+CjxmZUNvbG9yTWF0cml4IHR5cGU9Im1hdHJpeCIgdmFsdWVzPSIwIDAgMCAwIDAuNjc0NTEgMCAwIDAgMCAwLjkwNTg4MiAwIDAgMCAwIDAuMTg4MjM1IDAgMCAwIDAuNSAwIi8+CjxmZUJsZW5kIG1vZGU9Im5vcm1hbCIgaW4yPSJCYWNrZ3JvdW5kSW1hZ2VGaXgiIHJlc3VsdD0iZWZmZWN0MV9kcm9wU2hhZG93Xzc3XzQzIi8+CjxmZUNvbG9yTWF0cml4IGluPSJTb3VyY2VBbHBoYSIgdHlwZT0ibWF0cml4IiB2YWx1ZXM9IjAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDEyNyAwIiByZXN1bHQ9ImhhcmRBbHBoYSIvPgo8ZmVPZmZzZXQvPgo8ZmVHYXVzc2lhbkJsdXIgc3RkRGV2aWF0aW9uPSIyMi4wMTQzIi8+CjxmZUNvbXBvc2l0ZSBpbjI9ImhhcmRBbHBoYSIgb3BlcmF0b3I9Im91dCIvPgo8ZmVDb2xvck1hdHJpeCB0eXBlPSJtYXRyaXgiIHZhbHVlcz0iMCAwIDAgMCAwLjY3NDUxIDAgMCAwIDAgMC45MDU4ODIgMCAwIDAgMCAwLjE4ODIzNSAwIDAgMCAxIDAiLz4KPGZlQmxlbmQgbW9kZT0ibm9ybWFsIiBpbjI9ImVmZmVjdDFfZHJvcFNoYWRvd183N180MyIgcmVzdWx0PSJlZmZlY3QyX2Ryb3BTaGFkb3dfNzdfNDMiLz4KPGZlQmxlbmQgbW9kZT0ibm9ybWFsIiBpbj0iU291cmNlR3JhcGhpYyIgaW4yPSJlZmZlY3QyX2Ryb3BTaGFkb3dfNzdfNDMiIHJlc3VsdD0ic2hhcGUiLz4KPC9maWx0ZXI+CjwvZGVmcz4KPC9zdmc+Cg==",
+      tags: ["yieldSource", "ezeth"],
+      extensions: {
+        shortName: "Renzo ezETH",
+        protocol: "renzo",
+        isSharesPeggedToBase: false,
+      },
+    },
+    {
+      address: "0x80191B6a6A8E2026209fB5d1e4e9CC9A73029511",
       decimals: 18,
       places: 2,
-      name: "Savings DAI",
-      symbol: "SDAI",
-      iconUrl: "https://etherscan.io/token/images/Badgedai_32.svg",
+      name: "Hyperdrive DAI",
+      symbol: "hyperdriveDAI",
+      iconUrl:
+        "https://assets.coingecko.com/coins/images/29837/large/2022-official-morpho-token.png?1696528764",
       tags: ["yieldSource", "erc4626"],
       extensions: {
-        shortName: "Maker DSR",
-        protocol: "maker",
+        shortName: "MetaMorpho",
+        protocol: "morpho",
+        isSharesPeggedToBase: false,
       },
     },
     {
@@ -84,17 +89,17 @@ export const sepoliaAppConfig: AppConfig = {
       extensions: {},
     },
     {
-      address: "0x80191B6a6A8E2026209fB5d1e4e9CC9A73029511",
+      address: "0xAb1895c74902F2dbd40e76CB616d80e4aA780713",
       decimals: 18,
       places: 2,
-      name: "Hyperdrive DAI",
-      symbol: "hyperdriveDAI",
-      iconUrl:
-        "https://assets.coingecko.com/coins/images/29837/large/2022-official-morpho-token.png?1696528764",
+      name: "Savings DAI",
+      symbol: "SDAI",
+      iconUrl: "https://etherscan.io/token/images/Badgedai_32.svg",
       tags: ["yieldSource", "erc4626"],
       extensions: {
-        shortName: "MetaMorpho",
-        protocol: "morpho",
+        shortName: "Maker DSR",
+        protocol: "maker",
+        isSharesPeggedToBase: false,
       },
     },
   ],

--- a/packages/hyperdrive-appconfig/src/yieldSources/YieldSourceTokenConfig.ts
+++ b/packages/hyperdrive-appconfig/src/yieldSources/YieldSourceTokenConfig.ts
@@ -3,4 +3,5 @@ import { protocols } from "src/protocols/protocols";
 export interface YieldSourceExtensions {
   shortName: string;
   protocol: keyof typeof protocols;
+  isSharesPeggedToBase: boolean;
 }

--- a/packages/hyperdrive-appconfig/src/yieldSources/extensions.ts
+++ b/packages/hyperdrive-appconfig/src/yieldSources/extensions.ts
@@ -3,24 +3,29 @@ import { YieldSourceExtensions } from "src/index";
 export const sdaiExtensions: YieldSourceExtensions = {
   shortName: "Maker DSR",
   protocol: "maker",
+  isSharesPeggedToBase: false,
 };
 
 export const stethExtensions: YieldSourceExtensions = {
   shortName: "Lido stETH",
   protocol: "lido",
+  isSharesPeggedToBase: true,
 };
 
 export const metaMorphoExtensions: YieldSourceExtensions = {
   shortName: "MetaMorpho",
   protocol: "morpho",
+  isSharesPeggedToBase: false,
 };
 
 export const rethExtensions: YieldSourceExtensions = {
   shortName: "Rocket Pool ETH",
   protocol: "rocketPool",
+  isSharesPeggedToBase: false,
 };
 
 export const ezethExtensions: YieldSourceExtensions = {
   shortName: "Renzo ezETH",
   protocol: "renzo",
+  isSharesPeggedToBase: false,
 };


### PR DESCRIPTION
Since the stEth amount is essentially a baseAmount, we don't need to do a convertSharesToBase if we are on a steth market. This PR just checks if we are on a steth market and passes the baseAmountPaid instead of a converted amount. This closes #1114 
![image](https://github.com/delvtech/hyperdrive-frontend/assets/22210106/096a22ee-8dd8-42a5-b3f2-9c40e52da4a4)
