### PR TITLE
Refresh preview data on new block

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
@@ -254,6 +254,7 @@ export function OpenLongForm({
               ),
             ),
           }}
+          openLongPreviewStatus={openLongPreviewStatus}
           asBase={activeToken.address === baseToken.address}
           vaultSharePrice={poolInfo?.vaultSharePrice}
         />

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/usePreviewOpenLong.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/usePreviewOpenLong.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
+import { useBlockNumber } from "wagmi";
 interface UsePreviewOpenLongOptions {
   hyperdriveAddress: Address;
   amountIn: bigint | undefined;
@@ -23,14 +24,14 @@ export function usePreviewOpenLong({
   asBase,
 }: UsePreviewOpenLongOptions): UsePreviewOpenLongResult {
   const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
-
+  const { data: blockNumber } = useBlockNumber({ watch: true });
   const queryEnabled = !!amountIn && !!readHyperdrive;
-
   const { data, status } = useQuery({
     queryKey: makeQueryKey("previewOpenLong", {
       hyperdrive: hyperdriveAddress,
       amountIn: amountIn?.toString(),
       asBase,
+      blockNumber: blockNumber?.toString(),
     }),
     enabled: queryEnabled,
     queryFn: queryEnabled


### PR DESCRIPTION
This PR refreshes the open long preview data on each new block. I use the wagmi hook to watch for new blocks, and then add it to the query key so the data revalidates. I'll do this next for shorts and LP. 

Note: It isn't actually this slow refetching. I throttled the network to show the skeleton.



https://github.com/delvtech/hyperdrive-frontend/assets/22210106/e1f41a8f-68b6-4d6b-a3da-85d85cb0ae85

