### PR TITLE
Link `hyperdrive-js-core` and `hyperdrive-viem` versions.

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,12 +3,11 @@
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [["@delvtech/hyperdrive-wasm", "hyperdrive-wasm"]],
-  "linked": [],
+  "linked": [["@delvtech/hyperdrive-viem", "@delvtech/hyperdrive-js-core"]],
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "privatePackages": {
     "version": false
   }
-  
 }

--- a/.changeset/sixty-lobsters-give.md
+++ b/.changeset/sixty-lobsters-give.md
@@ -1,0 +1,5 @@
+---
+"@delvtech/hyperdrive-viem": minor
+---
+
+Updated the `@delvtech/hyperdrive-core` version and made it fixed.

--- a/packages/hyperdrive-viem/package.json
+++ b/packages/hyperdrive-viem/package.json
@@ -12,7 +12,7 @@
     "viem": "^2.7.8"
   },
   "dependencies": {
-    "@delvtech/hyperdrive-js-core": "^2.2.1",
+    "@delvtech/hyperdrive-js-core": "2.2.1",
     "@delvtech/evm-client-viem": "^0.6.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #1137 

This should ensure that a new version of `@delvtech/hyperdrive-viem` is released alongside every new version of `@delvtech/hyperdrive-js-core`. The release type (patch, minor, or major) will match that of core. I would have liked to keep these at version `0`, but `@delvtech/hyperdrive-js-core` was bumped passes major version `0` unfortunately.

See: https://github.com/changesets/changesets/blob/main/docs/linked-packages.md#example-with-dependants