### PR TITLE
Show warning on Current Value cell when no value exists

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/MaturesOnCell/MaturesOnCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/MaturesOnCell/MaturesOnCell.tsx
@@ -17,14 +17,12 @@ export function MaturesOnCell({
     Number(maturity),
   );
 
-  let remainingTime;
-  if (isTermComplete) {
-    remainingTime = "Term complete";
-  } else if (days > 0) {
-    remainingTime = `${days} days left`;
-  } else {
-    remainingTime = `${hours} hours, ${minutes} minutes left`;
-  }
+  const remainingTime = getRemainingTimeLabel(
+    isTermComplete,
+    days,
+    hours,
+    minutes,
+  );
 
   return (
     <div className="daisy-stat flex flex-row p-0 xl:flex-col">
@@ -40,4 +38,29 @@ export function MaturesOnCell({
       </div>
     </div>
   );
+}
+
+function getRemainingTimeLabel(
+  isTermComplete: boolean,
+  days: number,
+  hours: number,
+  minutes: number,
+): string {
+  if (isTermComplete) {
+    return "Term complete";
+  }
+
+  if (days > 0) {
+    return `${days} days left`;
+  }
+
+  if (hours > 0) {
+    return `${hours} hours, ${minutes} minutes left`;
+  }
+
+  if (minutes > 0) {
+    return `${minutes} minutes left`;
+  }
+
+  return "-";
 }

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/usePreviewCloseLong.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/usePreviewCloseLong.ts
@@ -1,5 +1,6 @@
-import { QueryStatus, useQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
+import { QueryStatusWithIdle, getStatus } from "src/base/queryStatus";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
 
@@ -17,7 +18,8 @@ interface UsePreviewCloseLongOptions {
 interface UsePreviewCloseLongResult {
   amountOut: bigint | undefined;
   flatPlusCurveFee: bigint | undefined;
-  previewCloseLongStatus: QueryStatus;
+  previewCloseLongStatus: QueryStatusWithIdle;
+  previewCloseLongError: Error;
 }
 
 export function usePreviewCloseLong({
@@ -35,7 +37,7 @@ export function usePreviewCloseLong({
     !!readHyperdrive &&
     enabled;
 
-  const { data, status } = useQuery({
+  const { data, status, fetchStatus, error } = useQuery({
     queryKey: makeQueryKey("previewCloseLong", {
       hyperdriveAddress,
       maturityTime: maturityTime?.toString(),
@@ -56,6 +58,7 @@ export function usePreviewCloseLong({
   return {
     amountOut: data?.amountOut,
     flatPlusCurveFee: data?.flatPlusCurveFee,
-    previewCloseLongStatus: status,
+    previewCloseLongStatus: getStatus(status, fetchStatus),
+    previewCloseLongError: error as Error,
   };
 }

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/CurrentValueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/CurrentValueCell.tsx
@@ -1,7 +1,9 @@
 import { OpenShort } from "@delvtech/hyperdrive-viem";
+import { ExclamationTriangleIcon } from "@heroicons/react/20/solid";
 import { HyperdriveConfig, findBaseToken } from "@hyperdrive/appconfig";
 import classNames from "classnames";
 import { ReactElement } from "react";
+import Skeleton from "react-loading-skeleton";
 import { convertSharesToBase } from "src/hyperdrive/convertSharesToBase";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
@@ -23,16 +25,19 @@ export function CurrentValueCell({
     tokens: appConfig.tokens,
   });
 
-  const { amountOut: currentValueInShares, previewCloseShortStatus } =
-    usePreviewCloseShort({
-      hyperdriveAddress: hyperdrive.address,
-      maturityTime: openShort.maturity,
-      shortAmountIn: openShort.bondAmount,
-      // Withdraw as shares and convert to base separately to show the current
-      // value, as not all hyperdrives allow withdrawing to base, (see
-      // HyperdriveConfig).
-      asBase: false,
-    });
+  const {
+    amountOut: currentValueInShares,
+    previewCloseShortStatus,
+    previewCloseShortError,
+  } = usePreviewCloseShort({
+    hyperdriveAddress: hyperdrive.address,
+    maturityTime: openShort.maturity,
+    shortAmountIn: openShort.bondAmount,
+    // Withdraw as shares and convert to base separately to show the current
+    // value, as not all hyperdrives allow withdrawing to base, (see
+    // HyperdriveConfig).
+    asBase: false,
+  });
   const { poolInfo } = usePoolInfo({ hyperdriveAddress: hyperdrive.address });
   const currentValueInBase = convertSharesToBase({
     sharesAmount: currentValueInShares,
@@ -55,29 +60,50 @@ export function CurrentValueCell({
   const isPositiveChangeInValue =
     currentValueInBase && currentValueInBase > openShort.baseAmountPaid;
 
+  const cellClassName = classNames("daisy-stat p-0", {
+    "flex w-32 flex-col items-end": !isTailwindSmallScreen,
+  });
+
+  if (previewCloseShortStatus === "loading") {
+    return (
+      <div className={cellClassName}>
+        <Skeleton width={100} />
+      </div>
+    );
+  }
+
   return (
-    <div
-      className={classNames("daisy-stat p-0", {
-        "flex w-32 flex-col items-end": !isTailwindSmallScreen,
-      })}
-    >
-      <span className="daisy-stat-value text-md font-bold">
+    <div className={cellClassName}>
+      <span className="daisy-stat-value flex items-center gap-2 text-md font-bold">
+        {/* warning icon with tooltip for liquidity issues
+         TODO: Add "Current withdrawabale amount: xxx" to the tooltip once we
+         have calcMaxCloseShort */}
+        {previewCloseShortError ? (
+          <span
+            className="daisy-tooltip before:font-normal"
+            data-tip="This position cannot be fully closed at this time"
+          >
+            <ExclamationTriangleIcon className="size-4 text-warning" />
+          </span>
+        ) : (
+          ""
+        )}{" "}
         {currentValueLabel?.toString()}
       </span>
+
+      {/* the current value of the user's position */}
       {currentValueInBase && openShort.bondAmount !== 0n ? (
         <div
           data-tip={"Profit/Loss since open, after closing fees."}
           className={classNames(
             "daisy-tooltip daisy-tooltip-left mt-1 flex text-xs before:border",
-            { "text-success": isPositiveChangeInValue },
             {
-              "text-error":
-                !isPositiveChangeInValue &&
-                profitLoss !== "-0" &&
-                previewCloseShortStatus !== "loading",
+              "text-success": isPositiveChangeInValue,
+              "text-error": !isPositiveChangeInValue && profitLoss !== "-0",
             },
           )}
         >
+          {/* the Profit/Loss badge indicator */}
           <span>{isPositiveChangeInValue ? "+" : ""}</span>
           {profitLoss
             ? `${profitLoss === "-0" ? "" : `${profitLoss} ${baseToken.symbol}`}`


### PR DESCRIPTION
Related to #1144 

This adds the warning icon w/ tooltip on the Shorts table.

Some things of note:

- Tanstack's default `retry` behavior is not a fit for our previewCloseShort hook. If the sdk method fails, no amount of retrying will fix the issue, as it's indicative of bad inputs...not a network problem. 
- I've turned this off in this hook so that it quiets down the console significantly, gives the error back to the user almost immediately, and prevents unwanted skeleton flickering.

<img width="1340" alt="image" src="https://github.com/delvtech/hyperdrive-frontend/assets/4524175/7623973f-0fbb-4de4-a8fc-92b4e053e234">
