### PR TITLE
Fix incorrect openVaultShare price on previewCloseShort

### DIFF
--- a/.changeset/pink-pans-drop.md
+++ b/.changeset/pink-pans-drop.md
@@ -1,0 +1,5 @@
+---
+"@delvtech/hyperdrive-js-core": patch
+---
+
+Fix incorrect openVaultSharePrice argument for previewCloseShort

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useShortRate.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useShortRate.ts
@@ -52,6 +52,7 @@ export function useShortRate({
       timestamp: timestamp?.toString(),
       variableApy: variableApy?.toString(),
     }),
+    retry: false,
     enabled: queryEnabled,
     queryFn: queryEnabled
       ? async () => {

--- a/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
@@ -1690,11 +1690,16 @@ export class ReadHyperdrive extends ReadModel {
   }): Promise<{ amountOut: bigint; flatPlusCurveFee: bigint }> {
     const poolConfig = await this.getPoolConfig(options);
     const poolInfo = await this.getPoolInfo(options);
+
+    // The checkpoint in which this position was opened.
+    // This is always maturity time - position duration thanks to mint on demand
+    const openCheckpointTimestamp = maturityTime - poolConfig.positionDuration;
     const { vaultSharePrice: openSharePrice } = await this.getCheckpoint({
+      timestamp: openCheckpointTimestamp,
       options,
     });
 
-    const currentTime = BigInt(Math.floor(Date.now() / 1000));
+    const currentTime = Math.floor(Date.now() / 1000);
 
     const flatFeeInShares = BigInt(
       hyperwasm.closeShortFlatFee(


### PR DESCRIPTION
We were passing the wrong vaultSharePrice to `calculate_close_short`. Instead of using the current vaultSharePrice, we need to be using the price from the checkpoint in which the position was created.

This fixes the issue where a mature position looked like it couldn't be closed.

|Before|After|
|---|---|
|![image](https://github.com/delvtech/hyperdrive-frontend/assets/4524175/daddb78a-1649-462a-99c9-d6334d27f834)|![image](https://github.com/delvtech/hyperdrive-frontend/assets/4524175/9d4f0540-acd3-4fb8-96f8-22ee5223f52a)|