### PR TITLE
Don't retry queries

### DIFF
--- a/apps/hyperdrive-trading/src/network/queryClient.ts
+++ b/apps/hyperdrive-trading/src/network/queryClient.ts
@@ -3,6 +3,14 @@ import { QueryClient } from "@tanstack/react-query";
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
+      // Retrying read queries is not useful in this app. We aren't interacting
+      // with any 3rd-party apis, and since most of the Hyperdrive SDK is just
+      // calling wasm functions which throw errors on bad inputs, a retry with
+      // bad arguments isn't going to change those results. By turning this off
+      // (the default is 3 retries w/ exponential backoff), users will get a
+      // much better and faster experience seeing and loading data in the app.
+      retry: false,
+
       // The duration until a query transitions from fresh to stale. As long as
       // the query is fresh, data will always be read from the cache only - no
       // network request will happen! If the query is stale (which per default

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/usePreviewCloseLong.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/usePreviewCloseLong.ts
@@ -44,11 +44,6 @@ export function usePreviewCloseLong({
       bondAmountIn: bondAmountIn?.toString(),
       asBase,
     }),
-    // Don't retry this if it throws an error. Normally react-query will retry a
-    // failed request 3 times w/ exponential backoff before showing an error to
-    // the user. In this case, retrying isn't helpful, since previewCloseLong
-    // throws errors on bad inputs and is pretty much a pure function.
-    retry: false,
     enabled: queryEnabled,
     queryFn: queryEnabled
       ? () =>

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/usePreviewCloseShort.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/usePreviewCloseShort.ts
@@ -38,11 +38,6 @@ export function usePreviewCloseShort({
       asBase,
     }),
 
-    // Don't retry this if it throws an error. Normally react-query will retry a
-    // failed request 3 times w/ exponential backoff before showing an error to
-    // the user. In this case, retrying isn't helpful, since previewCloseShort
-    // throws errors on bad inputs and is pretty much a pure function.
-    retry: false,
     enabled: queryEnabled,
     queryFn: queryEnabled
       ? async () =>

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useShortRate.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useShortRate.ts
@@ -52,7 +52,6 @@ export function useShortRate({
       timestamp: timestamp?.toString(),
       variableApy: variableApy?.toString(),
     }),
-    retry: false,
     enabled: queryEnabled,
     queryFn: queryEnabled
       ? async () => {


### PR DESCRIPTION
Finding myself doing this a few times now, and I think it's safe to just turn off globally. 

If we need to set a retries for a specific query that's totally fine. We do this in place already, in `useAddressScreen`, where a  custom `retries: 6` is set.