### PR TITLE
Fix bug causing current value in open shorts to display 0, polish Yield Source Market cards

### DIFF
--- a/apps/hyperdrive-trading/src/ui/markets/YieldSourceMarketsTable/ShortRateCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/YieldSourceMarketsTable/ShortRateCell.tsx
@@ -1,4 +1,5 @@
 import { HyperdriveConfig } from "@hyperdrive/appconfig";
+import classNames from "classnames";
 import { ReactElement } from "react";
 import { useShortRate } from "src/ui/hyperdrive/shorts/hooks/useShortRate";
 import { useYieldSourceRate } from "src/ui/vaults/useYieldSourceRate";
@@ -19,8 +20,16 @@ export function ShortRateCell({
     timestamp: BigInt(Math.floor(Date.now() / 1000)),
   });
   return (
-    <span key="short-apy" className="lg:flex lg:w-20 lg:justify-end">
-      {shortApr ? `${shortApr.formatted}%` : "-"}
-    </span>
+    <div className="flex flex-col lg:w-24 lg:justify-end">
+      <span
+        className={classNames("lg:flex lg:w-24 lg:justify-end", {
+          "text-neutral-content": !shortApr,
+          "text-success ": (shortApr?.apr || 0n) > 0n,
+          "text-error": (shortApr?.apr || 0n) < 0n,
+        })}
+      >
+        {shortApr ? `${shortApr.formatted}%` : "-"}
+      </span>
+    </div>
   );
 }

--- a/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
@@ -1848,7 +1848,7 @@ export class ReadHyperdrive extends ReadModel {
     // If the position is mature, we use the closing vault share price otherwise
     // use the current vault share price
     let closeSharePrice = poolInfo.vaultSharePrice;
-    if (maturityTime >= currentTime) {
+    if (maturityTime <= currentTime) {
       const closingCheckpoint = await this.getCheckpoint({
         timestamp: maturityTime,
         options,
@@ -1876,6 +1876,15 @@ export class ReadHyperdrive extends ReadModel {
     );
     const flatPlusCurveFee = flatFeeInShares + curveFeeInShares;
 
+    console.log(
+      convertBigIntsToStrings(poolInfo),
+      convertBigIntsToStrings(poolConfig),
+      shortAmountIn.toString(),
+      openSharePrice.toString(),
+      closeSharePrice.toString(),
+      maturityTime.toString(),
+      currentTime.toString(),
+    );
     const amountOutInShares = BigInt(
       hyperwasm.calcCloseShort(
         convertBigIntsToStrings(poolInfo),


### PR DESCRIPTION
We had a comparison operator that was flipped, causing Current Value to show `0` on shorts that were just minted.

While here, I also added red/green coloring to the Short APR on the main page. This is for a few reasons:

- The **fixed rate** can't go negative, so the gradient helps show that it's impervious to "going into the red"
- The short rate _can_ go negative, so when scanning the markets it's nice to immediately see which pools have profitable short sides.  

Comparing the before and after, it's much easier to find profitable markets with the coloring:

|Before|After|
|---|---|
|<img width="1729" alt="image" src="https://github.com/delvtech/hyperdrive-frontend/assets/4524175/6afd3310-4098-45af-85ee-6a03090af9e1">|<img width="1738" alt="image" src="https://github.com/delvtech/hyperdrive-frontend/assets/4524175/d69d231b-5037-4236-a6f6-a8382de8683f">|