### PR TITLE
Show effective short apr in preview

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
@@ -159,7 +159,7 @@ export function OpenShortPreview({
           }
         />
         <LabelValue
-          label="Short APR after open"
+          label="Net Short Rate"
           value={
             shortRateStatus === "loading" ? (
               <Skeleton width={100} />

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
@@ -14,6 +14,8 @@ import { LabelValue } from "src/ui/base/components/LabelValue";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { formatDate } from "src/ui/base/formatting/formatDate";
 import { useFixedRate } from "src/ui/hyperdrive/longs/hooks/useFixedRate";
+import { useShortRate } from "src/ui/hyperdrive/shorts/hooks/useShortRate";
+import { useYieldSourceRate } from "src/ui/vaults/useYieldSourceRate";
 interface OpenShortPreviewProps {
   hyperdrive: HyperdriveConfig;
   tokenIn: TokenConfig<any>;
@@ -40,6 +42,16 @@ export function OpenShortPreview({
   });
   const { fixedApr } = useFixedRate(hyperdrive.address);
   const termLengthMS = Number(hyperdrive.poolConfig.positionDuration * 1000n);
+  const { vaultRate } = useYieldSourceRate({
+    hyperdriveAddress: hyperdrive.address,
+  });
+  const { shortApr, shortRateStatus } = useShortRate({
+    bondAmount: shortSize,
+    hyperdriveAddress: hyperdrive.address,
+    timestamp: BigInt(Math.floor(Date.now() / 1000)),
+    variableApy: vaultRate?.vaultRate,
+  });
+
   return (
     <div className="flex flex-col gap-3">
       <LabelValue
@@ -121,6 +133,26 @@ export function OpenShortPreview({
                 {spotRateAfterOpen
                   ? `${formatRate(spotRateAfterOpen)}% APR`
                   : "-"}
+              </span>
+            )
+          }
+        />
+        <LabelValue
+          label="Short APR after open"
+          value={
+            shortRateStatus === "loading" ? (
+              <Skeleton width={100} />
+            ) : (
+              <span
+                className={classNames(
+                  "daisy-tooltip daisy-tooltip-top daisy-tooltip-left cursor-help before:border",
+                  {
+                    "border-b border-dashed border-current": spotRateAfterOpen,
+                  },
+                )}
+                data-tip="The market short APR after opening the short."
+              >
+                {shortApr ? `${shortApr.formatted}% APR` : "-"}
               </span>
             )
           }

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
@@ -113,6 +113,26 @@ export function OpenShortPreview({
           )
         }
       />
+      <LabelValue
+        label="Net Short Rate"
+        value={
+          shortRateStatus === "loading" ? (
+            <Skeleton width={100} />
+          ) : (
+            <span
+              className={classNames(
+                "daisy-tooltip daisy-tooltip-top daisy-tooltip-left cursor-help before:border",
+                {
+                  "border-b border-dashed border-current": spotRateAfterOpen,
+                },
+              )}
+              data-tip="The annualized return on shorts assuming the current yield source rate stays the same for one year"
+            >
+              {shortApr ? `${shortApr.formatted}% APR` : "-"}
+            </span>
+          )
+        }
+      />
       <div className="flex flex-col gap-3">
         <h6 className="font-medium">Market Impact</h6>
         <LabelValue
@@ -154,26 +174,6 @@ export function OpenShortPreview({
                 data-tip={`The net market impact on the fixed rate after opening the short.`}
               >
                 {getMarketImpactLabel(fixedApr?.apr, spotRateAfterOpen)}
-              </span>
-            )
-          }
-        />
-        <LabelValue
-          label="Net Short Rate"
-          value={
-            shortRateStatus === "loading" ? (
-              <Skeleton width={100} />
-            ) : (
-              <span
-                className={classNames(
-                  "daisy-tooltip daisy-tooltip-top daisy-tooltip-left cursor-help before:border",
-                  {
-                    "border-b border-dashed border-current": spotRateAfterOpen,
-                  },
-                )}
-                data-tip="The market short APR after opening the short."
-              >
-                {shortApr ? `${shortApr.formatted}% APR` : "-"}
               </span>
             )
           }

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
@@ -138,26 +138,6 @@ export function OpenShortPreview({
           }
         />
         <LabelValue
-          label="Short APR after open"
-          value={
-            shortRateStatus === "loading" ? (
-              <Skeleton width={100} />
-            ) : (
-              <span
-                className={classNames(
-                  "daisy-tooltip daisy-tooltip-top daisy-tooltip-left cursor-help before:border",
-                  {
-                    "border-b border-dashed border-current": spotRateAfterOpen,
-                  },
-                )}
-                data-tip="The market short APR after opening the short."
-              >
-                {shortApr ? `${shortApr.formatted}% APR` : "-"}
-              </span>
-            )
-          }
-        />
-        <LabelValue
           label="Fixed APR impact"
           value={
             openShortPreviewStatus === "loading" ? (
@@ -174,6 +154,26 @@ export function OpenShortPreview({
                 data-tip={`The net market impact on the fixed rate after opening the short.`}
               >
                 {getMarketImpactLabel(fixedApr?.apr, spotRateAfterOpen)}
+              </span>
+            )
+          }
+        />
+        <LabelValue
+          label="Short APR after open"
+          value={
+            shortRateStatus === "loading" ? (
+              <Skeleton width={100} />
+            ) : (
+              <span
+                className={classNames(
+                  "daisy-tooltip daisy-tooltip-top daisy-tooltip-left cursor-help before:border",
+                  {
+                    "border-b border-dashed border-current": spotRateAfterOpen,
+                  },
+                )}
+                data-tip="The market short APR after opening the short."
+              >
+                {shortApr ? `${shortApr.formatted}% APR` : "-"}
               </span>
             )
           }


### PR DESCRIPTION
Show the effective short apr the user is getting once they open the short. Closes #1143 
![image](https://github.com/delvtech/hyperdrive-frontend/assets/22210106/695ff1fd-33ae-4836-b168-7ea5c569667f)
