### PR TITLE
remove unused tableheader on mobile

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableMobile.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableMobile.tsx
@@ -1,5 +1,4 @@
 import { Long } from "@delvtech/hyperdrive-viem";
-import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/outline";
 import {
   AppConfig,
   EmptyExtensions,
@@ -118,36 +117,6 @@ export function OpenLongsTableMobile({
         );
       })}
       <table className="daisy-table daisy-table-zebra daisy-table-lg">
-        <thead>
-          {tableInstance.getHeaderGroups().map((headerGroup) => (
-            <tr key={headerGroup.id}>
-              {headerGroup.headers.map((header) => (
-                <th
-                  className="sticky z-10 font-normal text-neutral-content"
-                  key={header.id}
-                >
-                  <div
-                    className={classNames({
-                      "flex cursor-pointer select-none items-center gap-2":
-                        header.column.getCanSort(),
-                    })}
-                    onClick={header.column.getToggleSortingHandler()}
-                  >
-                    {flexRender(
-                      header.column.columnDef.header,
-                      header.getContext(),
-                    )}
-                    {{
-                      asc: <ChevronUpIcon height={15} />,
-                      desc: <ChevronDownIcon height={15} />,
-                    }[header.column.getIsSorted() as string] ?? null}
-                  </div>
-                </th>
-              ))}
-            </tr>
-          ))}
-        </thead>
-
         <tbody>
           {tableInstance.getRowModel().rows.map((row, index) => {
             const isLastRow =

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableMobile.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableMobile.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/jsx-key */
 import { OpenShort } from "@delvtech/hyperdrive-viem";
-import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/outline";
 import {
   AppConfig,
   HyperdriveConfig,
@@ -65,35 +64,6 @@ export function OpenShortsTableMobile({
         );
       })}
       <table className="daisy-table daisy-table-zebra daisy-table-lg">
-        <thead>
-          {tableInstance.getHeaderGroups().map((headerGroup) => (
-            <tr key={headerGroup.id}>
-              {headerGroup.headers.map((header) => (
-                <th
-                  className="sticky z-10 font-normal text-neutral-content"
-                  key={header.id}
-                >
-                  <div
-                    className={classNames({
-                      "flex cursor-pointer select-none items-center gap-2":
-                        header.column.getCanSort(),
-                    })}
-                    onClick={header.column.getToggleSortingHandler()}
-                  >
-                    {flexRender(
-                      header.column.columnDef.header,
-                      header.getContext(),
-                    )}
-                    {{
-                      asc: <ChevronUpIcon height={15} />,
-                      desc: <ChevronDownIcon height={15} />,
-                    }[header.column.getIsSorted() as string] ?? null}
-                  </div>
-                </th>
-              ))}
-            </tr>
-          ))}
-        </thead>
         <tbody>
           {tableInstance.getRowModel().rows.map((row, index) => {
             const isLastRow =


### PR DESCRIPTION
While investigating a straggling ⌄ icon on mobile tables, I realized we aren't using the `<tableheader/>` at all and just rendering the labels in the cell itself. I've removed the table header for now. But in the near future we will probably want to have a mobile table filtering/sorting menu. React Table should make this straight forward and i've added an issue for it:
https://github.com/delvtech/hyperdrive-frontend/issues/1185