### PR TITLE
Display Negative Short APR/ROI in Red in Yield Stats

### DIFF
--- a/apps/hyperdrive-trading/src/ui/markets/LongsTab/LongsTab.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/LongsTab/LongsTab.tsx
@@ -42,13 +42,18 @@ export function LongsTab({
     longs: openLongs,
     enabled: activeOpenOrClosedTab === "Open",
   });
-  const { totalClosedLongsValue, isLoading: isTotalClosedLongsValueLoading } =
+  const { totalClosedLongsValue, isLoading: isTotalClosedValueLoading } =
     useTotalClosedLongsValue({
       hyperdrive,
       account,
       closedLongs,
       enabled: activeOpenOrClosedTab === "Closed",
     });
+  const isTotalValueLoading =
+    activeOpenOrClosedTab === "Open"
+      ? isTotalOpenValueLoading
+      : isTotalClosedValueLoading;
+
   const baseToken = findBaseToken({
     baseTokenAddress: hyperdrive.baseToken,
     tokens: appConfig.tokens,
@@ -67,29 +72,27 @@ export function LongsTab({
           <div className="flex flex-wrap items-center justify-between gap-4 p-8">
             <div className="flex flex-col items-start gap-2">
               <h5 className="font-medium">Long Positions</h5>
-              {!isTotalOpenValueLoading || !isTotalClosedLongsValueLoading ? (
-                longs?.length ? (
-                  <p className="text-sm text-neutral-content">
-                    Total Value:{" "}
-                    {formatBalance({
-                      balance: totalValue || 0n,
-                      decimals: baseToken.decimals,
-                      places: baseToken.places,
-                    })}{" "}
-                    {baseToken.symbol}
-                    {totalOpenLongsValueError ? (
-                      <span
-                        className="daisy-tooltip before:font-normal"
-                        data-tip="One or more positions cannot be fully closed at this time. Once all positions can be fully closed the total value of your positions will appear here."
-                      >
-                        <ExclamationTriangleIcon className=" ml-1 size-4 text-warning" />
-                      </span>
-                    ) : undefined}
-                  </p>
-                ) : undefined
-              ) : (
+              {isTotalValueLoading ? (
                 <Skeleton width={100} />
-              )}
+              ) : longs?.length ? (
+                <p className="text-sm text-neutral-content">
+                  Total Value:{" "}
+                  {formatBalance({
+                    balance: totalValue || 0n,
+                    decimals: baseToken.decimals,
+                    places: baseToken.places,
+                  })}{" "}
+                  {baseToken.symbol}
+                  {totalOpenLongsValueError ? (
+                    <span
+                      className="daisy-tooltip before:font-normal"
+                      data-tip="One or more positions cannot be fully closed at this time. Once all positions can be fully closed the total value of your positions will appear here."
+                    >
+                      <ExclamationTriangleIcon className=" ml-1 size-4 text-warning" />
+                    </span>
+                  ) : undefined}
+                </p>
+              ) : undefined}
             </div>
             <div className="flex items-center gap-4">
               {account && openLongs?.length ? (

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/FixedRateStat.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/FixedRateStat.tsx
@@ -9,7 +9,9 @@ import { useFixedRate } from "src/ui/hyperdrive/longs/hooks/useFixedRate";
 
 export function FixedRateStat({
   hyperdrive,
+  isActive,
 }: {
+  isActive: boolean;
   hyperdrive: HyperdriveConfig;
 }): ReactElement {
   const isTailwindSmallScreen = useIsTailwindSmallScreen();
@@ -22,6 +24,10 @@ export function FixedRateStat({
     "yield-stats-long-rate-type",
     "fixedApr",
   );
+  const rateClassName = classNames("flex items-center gap-1.5", {
+    "gradient-text": isActive,
+  });
+
   return (
     <MultiStat
       activeStatId={
@@ -36,7 +42,7 @@ export function FixedRateStat({
             fixedAprStatus === "loading" && fixedApr === undefined ? (
               <Skeleton className="w-20" />
             ) : (
-              <span className={classNames("flex items-center gap-1.5")}>
+              <span className={rateClassName}>
                 {fixedApr?.formatted || "0"}%
               </span>
             ),
@@ -52,7 +58,7 @@ export function FixedRateStat({
             fixedAprStatus === "loading" && fixedApr === undefined ? (
               <Skeleton className="w-20" />
             ) : (
-              <span className={classNames("flex items-center gap-1.5")}>
+              <span className={rateClassName}>
                 {fixedRoi?.formatted || "0"}%
               </span>
             ),

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/ShortRateStat.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/ShortRateStat.tsx
@@ -9,8 +9,10 @@ import { useShortRate } from "src/ui/hyperdrive/shorts/hooks/useShortRate";
 import { useYieldSourceRate } from "src/ui/vaults/useYieldSourceRate";
 
 export function ShortRateStat({
+  isActive,
   hyperdrive,
 }: {
+  isActive: boolean;
   hyperdrive: HyperdriveConfig;
 }): ReactElement {
   const [rateType, setRateType] = useLocalStorage<"shortApr" | "shortRoi">(
@@ -30,6 +32,13 @@ export function ShortRateStat({
   const isLoadingShortRate =
     shortRateStatus === "loading" && shortApr === undefined;
 
+  const isNegative = (shortApr?.apr || 0) < 0n;
+
+  const rateClassName = classNames("flex items-center gap-1.5", {
+    "gradient-text": isActive && shortRateStatus === "success" && !isNegative,
+    "text-error": isActive && isNegative,
+  });
+
   return (
     <MultiStat
       activeStatId={
@@ -46,7 +55,7 @@ export function ShortRateStat({
           value: isLoadingShortRate ? (
             <Skeleton className="w-20" />
           ) : (
-            <span className={classNames("flex items-center gap-1.5")}>
+            <span className={rateClassName}>
               {shortApr?.formatted ? `${shortApr.formatted}%` : "-"}
             </span>
           ),
@@ -60,7 +69,7 @@ export function ShortRateStat({
           value: isLoadingShortRate ? (
             <Skeleton className="w-20" />
           ) : (
-            <span className={classNames("flex items-center gap-1.5")}>
+            <span className={rateClassName}>
               {shortRoi?.formatted ? `${shortRoi.formatted}%` : "-"}
             </span>
           ),

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/YieldStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/YieldStats.tsx
@@ -43,10 +43,16 @@ export function YieldStats({
         </div>
         <div className="flex flex-wrap gap-8 lg:gap-16">
           <Animated isActive={position === "Longs"}>
-            <FixedRateStat hyperdrive={hyperdrive} />
+            <FixedRateStat
+              isActive={position === "Longs"}
+              hyperdrive={hyperdrive}
+            />
           </Animated>
           <Animated isActive={position === "Shorts"}>
-            <ShortRateStat hyperdrive={hyperdrive} />
+            <ShortRateStat
+              isActive={position === "Shorts"}
+              hyperdrive={hyperdrive}
+            />
           </Animated>
           <Animated isActive={position === "LP"}>
             <Stat
@@ -79,7 +85,7 @@ function Animated({
   return (
     <div
       className={classNames("transition-all duration-200 ease-in-out", {
-        "gradient-text z-20 scale-105": isActive,
+        "z-20 scale-105": isActive,
       })}
     >
       {children}

--- a/apps/hyperdrive-trading/src/ui/markets/ShortsTab/ShortsTab.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/ShortsTab/ShortsTab.tsx
@@ -50,6 +50,11 @@ export function ShortsTab({
     enabled: activeOpenOrClosedTab === "Closed",
   });
 
+  const isTotalValueLoading =
+    activeOpenOrClosedTab === "Open"
+      ? isTotalOpenValueLoading
+      : isTotalClosedValueLoading;
+
   const baseToken = findBaseToken({
     baseTokenAddress: hyperdrive.baseToken,
     tokens: appConfig.tokens,
@@ -68,29 +73,27 @@ export function ShortsTab({
           <div className="flex flex-wrap items-center justify-between gap-4 p-8">
             <div className="flex flex-col items-start gap-2">
               <h5 className="font-medium">Short Positions</h5>
-              {!isTotalOpenValueLoading || !isTotalClosedValueLoading ? (
-                shorts?.length ? (
-                  <p className="text-sm text-neutral-content">
-                    Total Value:{" "}
-                    {formatBalance({
-                      balance: totalValue || 0n,
-                      decimals: baseToken.decimals,
-                      places: baseToken.places,
-                    })}{" "}
-                    {baseToken.symbol}
-                    {totalClosedShortsValueError ? (
-                      <span
-                        className="daisy-tooltip before:font-normal"
-                        data-tip="One or more positions cannot be fully closed at this time. Once all positions can be fully closed the total value of your positions will appear here."
-                      >
-                        <ExclamationTriangleIcon className=" ml-1 size-4 text-warning" />
-                      </span>
-                    ) : undefined}
-                  </p>
-                ) : undefined
-              ) : (
+              {isTotalValueLoading ? (
                 <Skeleton width={100} />
-              )}
+              ) : shorts?.length ? (
+                <p className="text-sm text-neutral-content">
+                  Total Value:{" "}
+                  {formatBalance({
+                    balance: totalValue || 0n,
+                    decimals: baseToken.decimals,
+                    places: baseToken.places,
+                  })}{" "}
+                  {baseToken.symbol}
+                  {totalClosedShortsValueError ? (
+                    <span
+                      className="daisy-tooltip before:font-normal"
+                      data-tip="One or more positions cannot be fully closed at this time. Once all positions can be fully closed the total value of your positions will appear here."
+                    >
+                      <ExclamationTriangleIcon className=" ml-1 size-4 text-warning" />
+                    </span>
+                  ) : undefined}
+                </p>
+              ) : undefined}
             </div>
             <div className="flex items-center gap-4">
               {account && openShorts?.length ? (


### PR DESCRIPTION
Makes reading the Yield rates more intuitive by coloring negative Short rates in red.

<img width="1326" alt="image" src="https://github.com/delvtech/hyperdrive-frontend/assets/4524175/ca929446-82a3-45f1-933f-b8854585ace3">
