### PR TITLE
Polish Preview Transaction sections in open position modals

### DIFF
--- a/apps/hyperdrive-trading/src/ui/base/components/LabelValue.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/LabelValue.tsx
@@ -1,3 +1,4 @@
+import { InformationCircleIcon } from "@heroicons/react/24/outline";
 import classNames from "classnames";
 import { ReactNode } from "react";
 
@@ -5,22 +6,51 @@ export function LabelValue({
   size = "medium",
   label: label,
   value: value,
+  tooltipContent,
+  tooltipPosition,
+  tooltipSize,
 }: {
   size?: "small" | "medium";
+  tooltipContent?: string;
+  tooltipPosition?: "top" | "bottom" | "left" | "right";
+  /**
+   * Small = 256px
+   *
+   * Default = 320px
+   */
+  tooltipSize?: "small" | "default";
   label: ReactNode;
   value: ReactNode;
 }): JSX.Element {
   return (
     <div
       className={classNames(
-        "flex w-full justify-between border-b border-dotted border-neutral-content/30 pb-1 ",
+        "flex w-full justify-between border-b border-dotted border-neutral-content/30 pb-2 ",
         {
           "text-md": size === "medium",
           "text-sm": size === "small",
         },
       )}
     >
-      <div className="text-neutral-content">{label}</div>
+      <div
+        className={classNames(
+          "flex items-center text-neutral-content before:bg-base-100",
+          {
+            "group daisy-tooltip cursor-help": tooltipContent,
+            "daisy-tooltip-top": tooltipPosition === "top",
+            "daisy-tooltip-bottom": tooltipPosition === "bottom",
+            "daisy-tooltip-left": tooltipPosition === "left",
+            "daisy-tooltip-right": tooltipPosition === "right",
+            "before:w-64": tooltipSize === "small",
+          },
+        )}
+        data-tip={tooltipContent}
+      >
+        {label}
+        {!tooltipContent ? undefined : (
+          <InformationCircleIcon className="ml-1.5 w-5 opacity-50 transition duration-150 ease-in-out group-hover:opacity-100 lg:inline-block" />
+        )}
+      </div>
       <div>{value}</div>
     </div>
   );

--- a/apps/hyperdrive-trading/src/ui/base/components/LabelValue.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/LabelValue.tsx
@@ -47,9 +47,9 @@ export function LabelValue({
         data-tip={tooltipContent}
       >
         {label}
-        {!tooltipContent ? undefined : (
+        {tooltipContent ? (
           <InformationCircleIcon className="ml-1.5 w-5 opacity-50 transition duration-150 ease-in-out group-hover:opacity-100 lg:inline-block" />
-        )}
+        ) : null}
       </div>
       <div>{value}</div>
     </div>

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongPreview.tsx
@@ -11,6 +11,7 @@ import * as dnum from "dnum";
 import { ReactElement } from "react";
 import Skeleton from "react-loading-skeleton";
 import { formatRate } from "src/base/formatRate";
+import { QueryStatusWithIdle } from "src/base/queryStatus";
 import { convertSharesToBase } from "src/hyperdrive/convertSharesToBase";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { CollapseSection } from "src/ui/base/components/CollapseSection/CollapseSection";
@@ -22,7 +23,7 @@ interface OpenLongPreviewProps {
   hyperdrive: HyperdriveConfig;
   bondAmount: bigint;
   amountPaid: bigint;
-  openLongPreviewStatus: "error" | "idle" | "loading" | "success";
+  openLongPreviewStatus: QueryStatusWithIdle;
   spotRateAfterOpen: bigint | undefined;
   activeToken: TokenConfig<any>;
   curveFee: bigint | undefined;
@@ -91,14 +92,14 @@ export function OpenLongPreview({
         />
         <LabelValue
           label="Pool fee"
+          tooltipContent="Total combined fee paid to LPs and governance to open the long."
+          tooltipPosition="right"
+          tooltipSize="small"
           value={
             openLongPreviewStatus === "loading" ? (
               <Skeleton width={100} />
             ) : (
-              <span
-                className="daisy-tooltip daisy-tooltip-top daisy-tooltip-left cursor-help border-b border-dashed border-current before:border"
-                data-tip="Total combined fee paid to LPs and governance to open the long."
-              >
+              <span>
                 {curveFee
                   ? `${formatBalance({
                       balance: curveFee,
@@ -112,14 +113,14 @@ export function OpenLongPreview({
         />
         <LabelValue
           label="Fixed APR"
+          tooltipContent="Your net fixed rate after pool fees and slippage are applied."
+          tooltipPosition="right"
+          tooltipSize="small"
           value={
             openLongPreviewStatus === "loading" ? (
               <Skeleton width={100} />
             ) : (
-              <span
-                className="gradient-text daisy-tooltip daisy-tooltip-top daisy-tooltip-left cursor-help border-b border-dashed border-current before:border"
-                data-tip="Your net fixed rate after pool fees and slippage are applied."
-              >
+              <span className="gradient-text">
                 {bondAmount > 0
                   ? `${formatRate(
                       calculateAprFromPrice({
@@ -137,31 +138,25 @@ export function OpenLongPreview({
         />
         <LabelValue
           label="Yield at maturity"
+          tooltipContent={`Total ${baseToken.symbol} expected in return at the end of the term, excluding fees.`}
+          tooltipPosition="right"
+          tooltipSize="small"
           value={
             openLongPreviewStatus === "loading" ? (
               <Skeleton width={100} />
+            ) : bondAmount > 0 ? (
+              <span className="text-success">
+                {yieldAtMaturity
+                  ? // TODO: Add ROI here in parenthesis after the yield amount
+                    `+${formatBalance({
+                      balance: yieldAtMaturity,
+                      decimals: baseToken.decimals,
+                      places: baseToken.places,
+                    })} ${baseToken.symbol}`
+                  : undefined}
+              </span>
             ) : (
-              <div
-                className="daisy-tooltip daisy-tooltip-top daisy-tooltip-left cursor-help before:border"
-                data-tip={`Total ${baseToken.symbol} expected in return at the end of the term, excluding fees.`}
-              >
-                {bondAmount > 0 ? (
-                  <span className="cursor-help border-b border-dashed border-success text-success">
-                    {yieldAtMaturity
-                      ? // TODO: Add ROI here in parenthesis after the yield amount
-                        `+${formatBalance({
-                          balance: yieldAtMaturity,
-                          decimals: baseToken.decimals,
-                          places: baseToken.places,
-                        })} ${baseToken.symbol}`
-                      : undefined}
-                  </span>
-                ) : (
-                  <span className="cursor-help border-b border-dashed">
-                    0 {baseToken.symbol}
-                  </span>
-                )}
-              </div>
+              <span>0 {baseToken.symbol}</span>
             )
           }
         />

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongPreview.tsx
@@ -69,7 +69,11 @@ export function OpenLongPreview({
         <LabelValue
           label="You spend"
           value={
-            <span>{`${formatBalance({
+            <span
+              className={classNames({
+                "text-base-content/80": !amountPaid,
+              })}
+            >{`${formatBalance({
               balance: amountPaid,
               decimals: baseToken.decimals,
               places: baseToken.places,
@@ -82,7 +86,11 @@ export function OpenLongPreview({
             openLongPreviewStatus === "loading" ? (
               <Skeleton width={100} />
             ) : (
-              <span className="">{`${formatBalance({
+              <span
+                className={classNames({
+                  "text-base-content/80": !bondAmount,
+                })}
+              >{`${formatBalance({
                 balance: bondAmount,
                 decimals: baseToken.decimals,
                 places: baseToken.places,
@@ -99,7 +107,11 @@ export function OpenLongPreview({
             openLongPreviewStatus === "loading" ? (
               <Skeleton width={100} />
             ) : (
-              <span>
+              <span
+                className={classNames({
+                  "text-base-content/80": !curveFee,
+                })}
+              >
                 {curveFee
                   ? `${formatBalance({
                       balance: curveFee,
@@ -156,7 +168,9 @@ export function OpenLongPreview({
                   : undefined}
               </span>
             ) : (
-              <span>0 {baseToken.symbol}</span>
+              <span className={"text-base-content/80"}>
+                0 {baseToken.symbol}
+              </span>
             )
           }
         />
@@ -170,7 +184,11 @@ export function OpenLongPreview({
             openLongPreviewStatus === "loading" ? (
               <Skeleton width={100} />
             ) : (
-              <span>
+              <span
+                className={classNames({
+                  "text-base-content/80": !spotRateAfterOpen,
+                })}
+              >
                 {spotRateAfterOpen ? (
                   <span className="flex gap-2">
                     <span className="text-base-content/80">{`${fixedApr?.formatted}% `}</span>
@@ -191,7 +209,12 @@ export function OpenLongPreview({
             openLongPreviewStatus === "loading" ? (
               <Skeleton width={100} />
             ) : (
-              <span className={classNames({ "text-error": spotRateAfterOpen })}>
+              <span
+                className={classNames({
+                  "text-error": spotRateAfterOpen,
+                  "text-base-content/80": !spotRateAfterOpen,
+                })}
+              >
                 {getMarketImpactLabel(fixedApr?.apr, spotRateAfterOpen)}
               </span>
             )

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongPreview.tsx
@@ -82,7 +82,7 @@ export function OpenLongPreview({
             openLongPreviewStatus === "loading" ? (
               <Skeleton width={100} />
             ) : (
-              <span className="font-bold">{`${formatBalance({
+              <span className="">{`${formatBalance({
                 balance: bondAmount,
                 decimals: baseToken.decimals,
                 places: baseToken.places,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityPreview/AddLiquidityPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityPreview/AddLiquidityPreview.tsx
@@ -34,22 +34,20 @@ export function AddLiquidityPreview({
     tokens: appConfig.tokens,
   });
   return (
-    <div className="flex flex-col gap-3">
+    <div className="flex flex-col gap-3.5 px-2">
       <LabelValue
         label="Your pool share"
+        tooltipContent="Your share of the total liquidity in the pool"
+        tooltipPosition="right"
+        tooltipSize="small"
         value={
           addLiquidityPreviewStatus === "loading" ? (
             <Skeleton width={100} />
           ) : (
             <span
-              className={classNames(
-                "daisy-tooltip daisy-tooltip-top daisy-tooltip-left cursor-help before:border",
-                {
-                  "border-b border-dashed border-current":
-                    poolShareAfterDeposit,
-                },
-              )}
-              data-tip="Your share of the total liquidity in the pool"
+              className={classNames({
+                "text-base-content/80": !poolShareAfterDeposit,
+              })}
             >
               {poolShareAfterDeposit
                 ? `${dnum.format(
@@ -64,7 +62,11 @@ export function AddLiquidityPreview({
       <LabelValue
         label="You deposit"
         value={
-          <p>
+          <p
+            className={classNames({
+              "text-base-content/80": !depositAmount,
+            })}
+          >
             {depositAmount
               ? `${formatBalance({
                   balance: depositAmount,
@@ -81,7 +83,12 @@ export function AddLiquidityPreview({
           addLiquidityPreviewStatus === "loading" ? (
             <Skeleton width={100} />
           ) : (
-            <p className="font-bold">
+            <p
+              className={classNames({
+                "text-base-content/80": !lpSharesOut,
+                "font-bold": lpSharesOut,
+              })}
+            >
               {lpSharesOut
                 ? `${formatBalance({
                     balance: lpSharesOut,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
@@ -52,45 +52,7 @@ export function OpenShortPreview({
   });
 
   return (
-    <div className="flex flex-col gap-3">
-      <LabelValue
-        label="Short size"
-        value={
-          <span
-            className="daisy-tooltip daisy-tooltip-top daisy-tooltip-left cursor-help border-b border-dashed border-current before:border"
-            data-tip="The amount of pool liquidity deposited into the yield source."
-          >
-            {shortSize
-              ? `${formatBalance({
-                  balance: shortSize,
-                  decimals: baseToken.decimals,
-                  places: baseToken.places,
-                })} hy${baseToken.symbol}`
-              : `0 hy${baseToken.symbol}`}
-          </span>
-        }
-      />
-      <LabelValue
-        label="Pool fee"
-        value={
-          openShortPreviewStatus === "loading" ? (
-            <Skeleton width={100} />
-          ) : (
-            <span
-              className="daisy-tooltip daisy-tooltip-top daisy-tooltip-left cursor-help border-b border-dashed border-current before:border"
-              data-tip="Total combined fee paid to LPs and governance to open the short."
-            >
-              {curveFee
-                ? `${formatBalance({
-                    balance: curveFee,
-                    decimals: tokenIn.decimals,
-                    places: tokenIn.places,
-                  })} ${tokenIn.symbol}`
-                : `0 ${tokenIn.symbol}`}
-            </span>
-          )
-        }
-      />
+    <div className="flex flex-col gap-3 px-2">
       <LabelValue
         label="You pay"
         value={
@@ -98,8 +60,9 @@ export function OpenShortPreview({
             <Skeleton width={100} />
           ) : (
             <span
-              className="daisy-tooltip daisy-tooltip-top daisy-tooltip-left cursor-help border-b border-dashed border-current before:border"
-              data-tip="The upfront cost to open a short."
+              className={classNames({
+                "text-base-content/80": !costBasis,
+              })}
             >
               {costBasis
                 ? `${formatBalance({
@@ -113,21 +76,66 @@ export function OpenShortPreview({
         }
       />
       <LabelValue
+        label="Short size"
+        tooltipContent="The amount of pool liquidity deposited into the yield source."
+        tooltipPosition="right"
+        tooltipSize="small"
+        value={
+          <span
+            className={classNames({
+              "text-base-content/80": !shortSize,
+            })}
+          >
+            {shortSize
+              ? `${formatBalance({
+                  balance: shortSize,
+                  decimals: baseToken.decimals,
+                  places: baseToken.places,
+                })} hy${baseToken.symbol}`
+              : `0 hy${baseToken.symbol}`}
+          </span>
+        }
+      />
+      <LabelValue
+        label="Pool fee"
+        tooltipContent="Total combined fee paid to LPs and governance to open the short."
+        tooltipPosition="right"
+        tooltipSize="small"
+        value={
+          openShortPreviewStatus === "loading" ? (
+            <Skeleton width={100} />
+          ) : (
+            <span
+              className={classNames({
+                "text-base-content/80": !shortSize,
+              })}
+            >
+              {curveFee
+                ? `${formatBalance({
+                    balance: curveFee,
+                    decimals: tokenIn.decimals,
+                    places: tokenIn.places,
+                  })} ${tokenIn.symbol}`
+                : `0 ${tokenIn.symbol}`}
+            </span>
+          )
+        }
+      />
+      <LabelValue
         label="Short APR"
+        tooltipContent="Your annualized return on this position assuming the current yield source rate stays the same for one year"
+        tooltipPosition="right"
+        tooltipSize="small"
         value={
           shortRateStatus === "loading" ? (
             <Skeleton width={100} />
           ) : (
             <span
-              className={classNames(
-                "daisy-tooltip daisy-tooltip-top daisy-tooltip-left cursor-help before:border",
-                {
-                  "border-b border-dashed border-current": spotRateAfterOpen,
-                  "text-success": shortApr && shortApr.apr > 0n,
-                  "text-error": shortApr && shortApr.apr < 0n,
-                },
-              )}
-              data-tip="The annualized return on shorts assuming the current yield source rate stays the same for one year"
+              className={classNames({
+                "text-base-content/80": !shortApr,
+                "text-success": shortApr && shortApr.apr > 0n,
+                "text-error": shortApr && shortApr.apr < 0n,
+              })}
             >
               {shortApr ? `${shortApr.formatted}%` : "-"}
             </span>
@@ -142,9 +150,13 @@ export function OpenShortPreview({
             openShortPreviewStatus === "loading" ? (
               <Skeleton width={100} />
             ) : (
-              <span>
+              <span
+                className={classNames({
+                  "text-base-content/80": !shortSize,
+                })}
+              >
                 {spotRateAfterOpen ? (
-                  <span className="flex gap-2">
+                  <span className="flex gap-2 text-base-content">
                     <span className="text-base-content/80">{`${fixedApr?.formatted}% `}</span>
                     <ArrowRightIcon className="h-4 text-neutral-content" />
                     {formatRate(spotRateAfterOpen)}%
@@ -164,14 +176,10 @@ export function OpenShortPreview({
               <Skeleton width={100} />
             ) : (
               <span
-                className={classNames(
-                  "daisy-tooltip daisy-tooltip-top daisy-tooltip-left cursor-help  before:border",
-                  {
-                    "border-b border-dashed border-success text-success":
-                      spotRateAfterOpen,
-                  },
-                )}
-                data-tip={`The net market impact on the fixed rate after opening the short.`}
+                className={classNames({
+                  "text-base-content/80": !spotRateAfterOpen,
+                  "text-success": spotRateAfterOpen,
+                })}
               >
                 {getMarketImpactLabel(fixedApr?.apr, spotRateAfterOpen)}
               </span>

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
@@ -16,6 +16,7 @@ import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { useFixedRate } from "src/ui/hyperdrive/longs/hooks/useFixedRate";
 import { useShortRate } from "src/ui/hyperdrive/shorts/hooks/useShortRate";
 import { useYieldSourceRate } from "src/ui/vaults/useYieldSourceRate";
+import { parseUnits } from "viem";
 interface OpenShortPreviewProps {
   hyperdrive: HyperdriveConfig;
   tokenIn: TokenConfig<any>;
@@ -45,7 +46,9 @@ export function OpenShortPreview({
     hyperdriveAddress: hyperdrive.address,
   });
   const { shortApr, shortRateStatus } = useShortRate({
-    bondAmount: shortSize,
+    // show the market short rate (aka bond amount of 1) if the user hasn't
+    // already entered a short size
+    bondAmount: shortSize || parseUnits("1", 18),
     hyperdriveAddress: hyperdrive.address,
     timestamp: BigInt(Math.floor(Date.now() / 1000)),
     variableApy: vaultRate?.vaultRate,

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/YieldStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/YieldStats.tsx
@@ -59,7 +59,11 @@ export function YieldStats({
               label="LP APY (7d)"
               value={
                 lpApyStatus !== "loading" ? (
-                  <span className="flex items-center gap-1.5">
+                  <span
+                    className={classNames("flex items-center gap-1.5", {
+                      "gradient-text": position === "LP",
+                    })}
+                  >
                     {lpApy === undefined
                       ? "no data"
                       : `${(lpApy * 100).toFixed(2) === "-0.00" ? "0.00" : (lpApy * 100).toFixed(2)}%`}{" "}

--- a/apps/hyperdrive-trading/src/ui/markets/YourBalanceWell/YourBalanceWell.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/YourBalanceWell/YourBalanceWell.tsx
@@ -46,7 +46,7 @@ export function YourBalanceWell({
     <Well elevation="flat">
       <div className="flex flex-col">
         <h5 className="mb-2 text-neutral-content">Available Assets</h5>
-        <div className="flex flex-col gap-2">
+        <div className="flex flex-col gap-2 px-2">
           <AvailableAsset token={baseToken} spender={hyperdrive.address} />
           {hyperdrive.depositOptions.isShareTokenDepositsEnabled && (
             <AvailableAsset token={sharesToken} spender={hyperdrive.address} />


### PR DESCRIPTION
This round of polish solves the issue where Preview Transaction values each had a different UI treatment to try and make it stand out. In doing so, none of them stood out.  See comments in #1181 

To solve this we move tooltipping off of the value and onto the label, eliminating the underlining treatment and making those numbers easier to read at the same time.


|Before|After|
|---|---|
|![image](https://github.com/delvtech/hyperdrive-frontend/assets/4524175/7c30e813-0246-4486-bcb3-b40daf582355)|<img alt="image" src="https://github.com/delvtech/hyperdrive-frontend/assets/4524175/01b4d490-7d34-42a6-9d6c-dbb1d3b2b14a">|
