### PR TITLE
Add Your Transactions table to market details

### DIFF
--- a/apps/hyperdrive-trading/src/ui/base/components/Tabs/Tabs.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/Tabs/Tabs.tsx
@@ -1,7 +1,7 @@
 import classNames from "classnames";
 import { ReactElement, ReactNode } from "react";
 
-interface Tab {
+export interface Tab {
   id: string;
   onClick: () => void;
   label: string;

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/TransactionTable/TransactionsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/TransactionTable/TransactionsTable.tsx
@@ -59,11 +59,14 @@ const columnHelper = createColumnHelper<TransactionData>();
 
 export function TransactionTable({
   hyperdrive,
+  account,
 }: {
   hyperdrive: HyperdriveConfig;
+  account?: Address;
 }): JSX.Element {
   const { data: transactionData, isLoading } = useTransactionData({
     hyperdriveAddress: hyperdrive.address,
+    account,
   });
   const appConfig = useAppConfig();
   const isSmallScreenView = useIsTailwindSmallScreen();

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/TransactionTable/useTransactionData.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/TransactionTable/useTransactionData.ts
@@ -20,7 +20,9 @@ export type TransactionData = {
 
 export function useTransactionData({
   hyperdriveAddress,
+  account,
 }: {
+  account?: Address;
   hyperdriveAddress: Address;
 }): {
   data: TransactionData[] | undefined;
@@ -34,17 +36,26 @@ export function useTransactionData({
   });
 
   const { data: longs, status: longEventsStatus } = useQuery({
-    queryKey: makeQueryKey("longEvents", { hyperdriveAddress }),
-    queryFn: async () => readHyperdrive?.getLongEvents(),
+    queryKey: makeQueryKey("longEvents", { hyperdriveAddress, account }),
+    queryFn: async () =>
+      readHyperdrive?.getLongEvents({
+        filter: { trader: account },
+      }),
   });
 
   const { data: shorts, status: shortEventsStatus } = useQuery({
-    queryKey: makeQueryKey("shortEvents", { hyperdriveAddress }),
-    queryFn: async () => readHyperdrive?.getShortEvents(),
+    queryKey: makeQueryKey("shortEvents", { hyperdriveAddress, account }),
+    queryFn: async () =>
+      readHyperdrive?.getShortEvents({
+        filter: { trader: account },
+      }),
   });
   const { data: lpEvents, status: lpEventsStatus } = useQuery({
-    queryKey: makeQueryKey("lpEvents", { hyperdriveAddress }),
-    queryFn: async () => readHyperdrive?.getLpEvents(),
+    queryKey: makeQueryKey("lpEvents", { hyperdriveAddress, account }),
+    queryFn: async () =>
+      readHyperdrive?.getLpEvents({
+        filter: { provider: account },
+      }),
   });
 
   // It's important to memoize this table data because creating new arrays of

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useMaxLong.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useMaxLong.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
-import { getStatus } from "src/base/queryStatus";
+import { QueryStatusWithIdle, getStatus } from "src/base/queryStatus";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { prepareSharesOut } from "src/ui/hyperdrive/hooks/usePrepareSharesOut";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
@@ -14,7 +14,7 @@ export function useMaxLong({
   maxBaseIn: bigint | undefined;
   maxSharesIn: bigint | undefined;
   maxBondsOut: bigint | undefined;
-  status: "error" | "idle" | "loading" | "success";
+  status: QueryStatusWithIdle;
 } {
   const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
   const queryEnabled = !!readHyperdrive;

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/usePreviewOpenLong.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/usePreviewOpenLong.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
-import { getStatus } from "src/base/queryStatus";
+import { QueryStatusWithIdle, getStatus } from "src/base/queryStatus";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { prepareSharesIn } from "src/ui/hyperdrive/hooks/usePrepareSharesIn";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
@@ -13,7 +13,7 @@ interface UsePreviewOpenLongOptions {
 }
 
 interface UsePreviewOpenLongResult {
-  status: "error" | "idle" | "loading" | "success";
+  status: QueryStatusWithIdle;
   bondsReceived: bigint | undefined;
   maturityTime: bigint | undefined;
   spotPriceAfterOpen: bigint | undefined;

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityPreview/AddLiquidityPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityPreview/AddLiquidityPreview.tsx
@@ -3,6 +3,7 @@ import classNames from "classnames";
 import * as dnum from "dnum";
 import { ReactElement } from "react";
 import Skeleton from "react-loading-skeleton";
+import { QueryStatusWithIdle } from "src/base/queryStatus";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { LabelValue } from "src/ui/base/components/LabelValue";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
@@ -15,7 +16,7 @@ interface AddLiquidityPreviewProps {
   depositTokenDecimals: number;
   depositTokenPlaces: number;
   depositTokenSymbol: string;
-  addLiquidityPreviewStatus: "error" | "idle" | "loading" | "success";
+  addLiquidityPreviewStatus: QueryStatusWithIdle;
 }
 
 export function AddLiquidityPreview({

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/usePreviewAddLiquidity.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/usePreviewAddLiquidity.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
+import { QueryStatusWithIdle } from "src/base/queryStatus";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { prepareSharesIn } from "src/ui/hyperdrive/hooks/usePrepareSharesIn";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
@@ -19,7 +20,7 @@ interface UsePreviewAddLiquidityOptions {
 }
 
 interface UsePreviewAddLiquidityResult {
-  status: "error" | "idle" | "loading" | "success";
+  status: QueryStatusWithIdle;
   previewAddLiquidityError: string;
   lpSharesOut: bigint | undefined;
 }

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
@@ -9,6 +9,7 @@ import * as dnum from "dnum";
 import { ReactElement } from "react";
 import Skeleton from "react-loading-skeleton";
 import { formatRate } from "src/base/formatRate";
+import { QueryStatusWithIdle } from "src/base/queryStatus";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { CollapseSection } from "src/ui/base/components/CollapseSection/CollapseSection";
 import { LabelValue } from "src/ui/base/components/LabelValue";
@@ -24,7 +25,7 @@ interface OpenShortPreviewProps {
   shortSize: bigint | undefined;
   spotRateAfterOpen: bigint | undefined;
   curveFee: bigint | undefined;
-  openShortPreviewStatus: "error" | "idle" | "loading" | "success";
+  openShortPreviewStatus: QueryStatusWithIdle;
 }
 
 export function OpenShortPreview({

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useMaxShort.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useMaxShort.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
+import { QueryStatusWithIdle } from "src/base/queryStatus";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { prepareSharesOut } from "src/ui/hyperdrive/hooks/usePrepareSharesOut";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
@@ -9,7 +10,7 @@ interface UseMaxShortResult {
   maxBaseIn: bigint | undefined;
   maxSharesIn: bigint | undefined;
   maxBondsOut: bigint | undefined;
-  status: "error" | "idle" | "loading" | "success";
+  status: QueryStatusWithIdle;
 }
 
 export function useMaxShort({

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/YieldStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/YieldStats.tsx
@@ -89,7 +89,7 @@ function Animated({
   return (
     <div
       className={classNames("transition-all duration-200 ease-in-out", {
-        "z-20 scale-105": isActive,
+        "scale-105": isActive,
       })}
     >
       {children}

--- a/apps/hyperdrive-trading/src/ui/markets/TransactionsAndFaqTabs/TransactionsAndFaqTabs.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/TransactionsAndFaqTabs/TransactionsAndFaqTabs.tsx
@@ -1,27 +1,44 @@
 import { HyperdriveConfig } from "@hyperdrive/appconfig";
-import { ReactElement } from "react";
-import { Tabs } from "src/ui/base/components/Tabs/Tabs";
+import { ReactElement, useState } from "react";
+import { Tab, Tabs } from "src/ui/base/components/Tabs/Tabs";
 import { TransactionTable } from "src/ui/hyperdrive/TransactionTable/TransactionsTable";
 import { FAQEntries } from "src/ui/onboarding/FAQ/FAQ";
+import { useAccount } from "wagmi";
 
 export function TransactionAndFaqTabs({
   hyperdrive,
 }: {
   hyperdrive: HyperdriveConfig;
 }): ReactElement {
+  const { address: account } = useAccount();
+  const [activeTab, setActiveTab] = useState<
+    "Transactions" | "YourTransactions"
+  >("Transactions");
+
+  const transactionTabs: Tab[] = [
+    {
+      id: "Transactions",
+      label: "All Transactions",
+      content: <TransactionTable hyperdrive={hyperdrive} />,
+      onClick: () => {
+        setActiveTab("Transactions");
+      },
+    },
+  ];
+
+  if (account) {
+    transactionTabs.push({
+      id: "YourTransactions",
+      label: "Your Transactions",
+      content: <TransactionTable hyperdrive={hyperdrive} account={account} />,
+      onClick: () => {
+        setActiveTab("YourTransactions");
+      },
+    });
+  }
   return (
     <>
-      <Tabs
-        activeTabId="Transactions"
-        tabs={[
-          {
-            id: "Transactions",
-            label: "All Transactions",
-            content: <TransactionTable hyperdrive={hyperdrive} />,
-            onClick: () => {},
-          },
-        ]}
-      />
+      <Tabs activeTabId={activeTab} tabs={transactionTabs} />
 
       <Tabs
         activeTabId="FAQ"

--- a/apps/hyperdrive-trading/src/ui/markets/TransactionsAndFaqTabs/TransactionsAndFaqTabs.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/TransactionsAndFaqTabs/TransactionsAndFaqTabs.tsx
@@ -12,33 +12,36 @@ export function TransactionAndFaqTabs({
 }): ReactElement {
   const { address: account } = useAccount();
   const [activeTab, setActiveTab] = useState<
-    "Transactions" | "YourTransactions"
-  >("Transactions");
+    "all-transactions" | "your-transactions"
+  >("all-transactions");
 
   const transactionTabs: Tab[] = [
     {
-      id: "Transactions",
+      id: "all-transactions",
       label: "All Transactions",
       content: <TransactionTable hyperdrive={hyperdrive} />,
       onClick: () => {
-        setActiveTab("Transactions");
+        setActiveTab("all-transactions");
       },
     },
   ];
 
   if (account) {
     transactionTabs.push({
-      id: "YourTransactions",
+      id: "your-transactions",
       label: "Your Transactions",
       content: <TransactionTable hyperdrive={hyperdrive} account={account} />,
       onClick: () => {
-        setActiveTab("YourTransactions");
+        setActiveTab("your-transactions");
       },
     });
   }
   return (
     <>
-      <Tabs activeTabId={activeTab} tabs={transactionTabs} />
+      <Tabs
+        activeTabId={account ? activeTab : "all-transactions"}
+        tabs={transactionTabs}
+      />
 
       <Tabs
         activeTabId="FAQ"

--- a/apps/hyperdrive-trading/src/ui/token/hooks/useApproveToken.tsx
+++ b/apps/hyperdrive-trading/src/ui/token/hooks/useApproveToken.tsx
@@ -6,6 +6,7 @@ import { usePublicClient, useWriteContract } from "wagmi";
 
 import { useState } from "react";
 import { MAX_UINT256 } from "src/base/constants";
+import { QueryStatusWithIdle } from "src/base/queryStatus";
 import TransactionToast from "src/ui/base/components/Toaster/TransactionToast";
 import { SUCCESS_TOAST_DURATION } from "src/ui/base/toasts";
 import { Address, erc20Abi, parseUnits } from "viem";
@@ -23,7 +24,7 @@ export function useApproveToken({
   enabled = true,
 }: UseTokenApprovalOptions): {
   approve: (() => void) | undefined;
-  pendingWalletSignatureStatus: "error" | "idle" | "loading" | "success";
+  pendingWalletSignatureStatus: QueryStatusWithIdle;
   isTransactionMined: boolean;
 } {
   const { writeContract, status } = useWriteContract();

--- a/apps/hyperdrive-trading/src/ui/token/hooks/useTokenAllowance.ts
+++ b/apps/hyperdrive-trading/src/ui/token/hooks/useTokenAllowance.ts
@@ -1,3 +1,4 @@
+import { QueryStatusWithIdle } from "src/base/queryStatus";
 import { Address, erc20Abi } from "viem";
 import { useReadContract } from "wagmi";
 
@@ -10,7 +11,7 @@ interface UseTokenAllowanceOptions {
 
 interface useTokenAllowanceResult {
   tokenAllowance: bigint | undefined;
-  status: "error" | "idle" | "loading" | "success";
+  status: QueryStatusWithIdle;
 }
 
 export function useTokenAllowance({


### PR DESCRIPTION
It's nice to see your transaction history separate from everyone else's in the pool. This PR adds a new tab to show just your trades.

![image](https://github.com/delvtech/hyperdrive-frontend/assets/4524175/0fa1bcc0-5766-4567-989a-cc9eb701465f)
