### PR TITLE
Navbar Cleanup

### DIFF
--- a/apps/hyperdrive-trading/src/ui/app/Navbar/DevtoolsMenu.tsx
+++ b/apps/hyperdrive-trading/src/ui/app/Navbar/DevtoolsMenu.tsx
@@ -19,14 +19,9 @@ export function DevtoolsMenu(): ReactElement {
         <FeatureFlagMenuItem flagName="bridge">
           Bridge Assets
         </FeatureFlagMenuItem>
-        <MenuItem
-          onClick={() => {
-            throw new Error(
-              `Rollbar Test Error: Thrown in ${import.meta.env.VITE_ROLLBAR_ENV as string} environment on Rollbar.`,
-            );
-          }}
-          title={"Throw Test Error"}
-        />
+        <FeatureFlagMenuItem flagName="version-picker">
+          Show Version Picker
+        </FeatureFlagMenuItem>
       </ul>
     </div>
   );
@@ -54,14 +49,6 @@ function FeatureFlagMenuItem({
           </div>
         )}
       </button>
-    </li>
-  );
-}
-
-function MenuItem({ onClick, title }: { onClick?: () => void; title: string }) {
-  return (
-    <li>
-      <button onClick={onClick}>{title}</button>
     </li>
   );
 }

--- a/apps/hyperdrive-trading/src/ui/app/Navbar/DevtoolsMenu.tsx
+++ b/apps/hyperdrive-trading/src/ui/app/Navbar/DevtoolsMenu.tsx
@@ -22,6 +22,14 @@ export function DevtoolsMenu(): ReactElement {
         <FeatureFlagMenuItem flagName="version-picker">
           Show Version Picker
         </FeatureFlagMenuItem>
+        <MenuItem
+          onClick={() => {
+            throw new Error(
+              `Rollbar Test Error: Thrown in ${import.meta.env.VITE_ROLLBAR_ENV as string} environment on Rollbar.`,
+            );
+          }}
+          title={"Throw Test Error"}
+        />
       </ul>
     </div>
   );
@@ -49,6 +57,13 @@ function FeatureFlagMenuItem({
           </div>
         )}
       </button>
+    </li>
+  );
+}
+function MenuItem({ onClick, title }: { onClick?: () => void; title: string }) {
+  return (
+    <li>
+      <button onClick={onClick}>{title}</button>
     </li>
   );
 }

--- a/apps/hyperdrive-trading/src/ui/app/Navbar/Navbar.tsx
+++ b/apps/hyperdrive-trading/src/ui/app/Navbar/Navbar.tsx
@@ -8,9 +8,11 @@ import { DevtoolsMenu } from "src/ui/app/Navbar/DevtoolsMenu";
 import { HyperdriveLogo } from "src/ui/app/Navbar/HyperdriveLogo";
 import { ConnectWalletButton } from "src/ui/base/components/ConnectWallet";
 import VersionPicker from "src/ui/base/components/VersionPicker";
+import { useFeatureFlag } from "src/ui/base/featureFlags/featureFlags";
 import { useIsTailwindSmallScreen } from "src/ui/base/mediaBreakpoints";
 export function Navbar(): ReactElement {
   const isTailwindSmallScreen = useIsTailwindSmallScreen();
+  const { isFlagEnabled: showVersionPicker } = useFeatureFlag("version-picker");
   return (
     <div className="daisy-navbar">
       <div className="daisy-navbar-start ml-2">
@@ -34,7 +36,7 @@ export function Navbar(): ReactElement {
           </span>
           <ArrowTopRightOnSquareIcon className="-mt-0.5 inline h-4" />
         </a>
-        <VersionPicker />
+        {showVersionPicker ? <VersionPicker /> : undefined}
 
         {import.meta.env.DEV && !isTailwindSmallScreen ? (
           <DevtoolsMenu />

--- a/apps/hyperdrive-trading/src/ui/app/Navbar/Navbar.tsx
+++ b/apps/hyperdrive-trading/src/ui/app/Navbar/Navbar.tsx
@@ -36,7 +36,23 @@ export function Navbar(): ReactElement {
           </span>
           <ArrowTopRightOnSquareIcon className="-mt-0.5 inline h-4" />
         </a>
-        {showVersionPicker ? <VersionPicker /> : undefined}
+        {showVersionPicker ? (
+          <VersionPicker />
+        ) : (
+          <a
+            target="_blank"
+            rel="noreferrer"
+            href="https://warpcast.com/~/compose?text=Can%20you%20outtrade%20me%20on%20Hyperdrive%3F%20Warp%20your%20best%20Hyperdrive%20trade%20screenshot%20below%20%F0%9F%93%88%20%2Fdelv&embeds[]=https://frames.hyperdrive.trade"
+            className="text-white daisy-btn rounded-full"
+          >
+            <span className="hidden sm:inline">Cast on Warpcast</span>
+            <span className="inline sm:hidden">Cast</span>
+            <img
+              className="h-4"
+              src="https://raw.githubusercontent.com/vrypan/farcaster-brand/ea95543f6d1308dd52631f5e81f395a60447df0b/icons/icon-transparent/transparent-white.svg"
+            />
+          </a>
+        )}
 
         {import.meta.env.DEV && !isTailwindSmallScreen ? (
           <DevtoolsMenu />

--- a/apps/hyperdrive-trading/src/ui/app/Navbar/Navbar.tsx
+++ b/apps/hyperdrive-trading/src/ui/app/Navbar/Navbar.tsx
@@ -7,6 +7,7 @@ import { ReactElement } from "react";
 import { DevtoolsMenu } from "src/ui/app/Navbar/DevtoolsMenu";
 import { HyperdriveLogo } from "src/ui/app/Navbar/HyperdriveLogo";
 import { ConnectWalletButton } from "src/ui/base/components/ConnectWallet";
+import VersionPicker from "src/ui/base/components/VersionPicker";
 import { useIsTailwindSmallScreen } from "src/ui/base/mediaBreakpoints";
 export function Navbar(): ReactElement {
   const isTailwindSmallScreen = useIsTailwindSmallScreen();
@@ -33,19 +34,8 @@ export function Navbar(): ReactElement {
           </span>
           <ArrowTopRightOnSquareIcon className="-mt-0.5 inline h-4" />
         </a>
-        <a
-          target="_blank"
-          rel="noreferrer"
-          href="https://warpcast.com/~/compose?text=Can%20you%20outtrade%20me%20on%20Hyperdrive%3F%20Warp%20your%20best%20Hyperdrive%20trade%20screenshot%20below%20%F0%9F%93%88%20%2Fdelv&embeds[]=https://frames.hyperdrive.trade"
-          className="text-white daisy-btn rounded-full"
-        >
-          <span className="hidden sm:inline">Cast on Warpcast</span>
-          <span className="inline sm:hidden">Cast</span>
-          <img
-            className="h-4"
-            src="https://raw.githubusercontent.com/vrypan/farcaster-brand/ea95543f6d1308dd52631f5e81f395a60447df0b/icons/icon-transparent/transparent-white.svg"
-          />
-        </a>
+        <VersionPicker />
+
         {import.meta.env.DEV && !isTailwindSmallScreen ? (
           <DevtoolsMenu />
         ) : null}

--- a/apps/hyperdrive-trading/src/ui/base/components/ConnectWallet.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/ConnectWallet.tsx
@@ -40,15 +40,18 @@ export function ConnectWalletButton(): JSX.Element {
                 );
               }
               return (
-                <div className="flex items-center gap-4">
+                <div className="daisy-join flex items-center">
                   <button
+                    className="daisy-btn daisy-btn-circle daisy-join-item flex size-12 bg-base-300"
                     onClick={openChainModal}
-                    className="daisy-btn rounded-full"
                   >
-                    {chain.name}
+                    <img
+                      className="w-auto hover:scale-105"
+                      src={chain.iconUrl}
+                    />
                   </button>
                   <button
-                    className="daisy-btn daisy-btn-circle daisy-btn-primary mx-0 w-24 md:w-32"
+                    className="daisy-btn daisy-btn-circle daisy-join-item mx-0 w-24  md:w-32"
                     onClick={openAccountModal}
                   >
                     {account.displayName}

--- a/apps/hyperdrive-trading/src/ui/base/components/ConnectWallet.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/ConnectWallet.tsx
@@ -45,10 +45,10 @@ export function ConnectWalletButton(): JSX.Element {
                     className="daisy-btn daisy-btn-circle daisy-join-item flex size-12 bg-base-300"
                     onClick={openChainModal}
                   >
-                    <img className=" w-6 hover:scale-105" src={chain.iconUrl} />
+                    <img className="w-6 hover:scale-105" src={chain.iconUrl} />
                   </button>
                   <button
-                    className="daisy-btn daisy-btn-circle daisy-join-item mx-0 w-24  md:w-32"
+                    className="daisy-btn daisy-btn-circle daisy-join-item mx-0 w-24 md:w-32"
                     onClick={openAccountModal}
                   >
                     {account.displayName}

--- a/apps/hyperdrive-trading/src/ui/base/components/ConnectWallet.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/ConnectWallet.tsx
@@ -40,15 +40,12 @@ export function ConnectWalletButton(): JSX.Element {
                 );
               }
               return (
-                <div className="daisy-join flex items-center">
+                <div className="daisy-join flex items-center rounded-full">
                   <button
                     className="daisy-btn daisy-btn-circle daisy-join-item flex size-12 bg-base-300"
                     onClick={openChainModal}
                   >
-                    <img
-                      className="w-auto hover:scale-105"
-                      src={chain.iconUrl}
-                    />
+                    <img className=" w-6 hover:scale-105" src={chain.iconUrl} />
                   </button>
                   <button
                     className="daisy-btn daisy-btn-circle daisy-join-item mx-0 w-24  md:w-32"

--- a/apps/hyperdrive-trading/src/ui/base/components/VersionPicker.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/VersionPicker.tsx
@@ -7,7 +7,7 @@ export default function VersionPicker(): JSX.Element {
         tabIndex={0}
         className="daisy-btn flex items-center justify-center rounded-full"
       >
-        v1.0.0
+        Latest Version
         <ChevronDownIcon className="hidden h-4 sm:inline" />
       </div>
       <ul
@@ -15,13 +15,13 @@ export default function VersionPicker(): JSX.Element {
         className="daisy-menu daisy-dropdown-content z-[1] w-auto gap-2 rounded-lg bg-base-100 p-4 shadow"
       >
         <li>
-          <a>v1.0.0</a>
-        </li>
-        <li>
-          <a>v1.0.1</a>
-        </li>
-        <li>
-          <a>v1.0.2</a>
+          <a
+            rel="noreferrer"
+            target="_blank"
+            href="https://testnet-v1.hyperdrive.box/"
+          >
+            V1 Pools
+          </a>
         </li>
       </ul>
     </div>

--- a/apps/hyperdrive-trading/src/ui/base/components/VersionPicker.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/VersionPicker.tsx
@@ -3,22 +3,25 @@ import { ChevronDownIcon } from "@heroicons/react/24/outline";
 export default function VersionPicker(): JSX.Element {
   return (
     <div className="daisy-dropdown">
-      <div tabIndex={0} className="daisy-btn flex items-center justify-center">
-        Version 1.0.0
-        <ChevronDownIcon className="h-4" />
+      <div
+        tabIndex={0}
+        className="daisy-btn flex items-center justify-center rounded-full"
+      >
+        v1.0.0
+        <ChevronDownIcon className="hidden h-4 sm:inline" />
       </div>
       <ul
         tabIndex={0}
-        className="daisy-menu daisy-dropdown-content z-[1] w-52 gap-2 rounded-lg bg-base-100 p-4 shadow"
+        className="daisy-menu daisy-dropdown-content z-[1] w-auto gap-2 rounded-lg bg-base-100 p-4 shadow"
       >
         <li>
-          <a>Version 1.0.0</a>
+          <a>v1.0.0</a>
         </li>
         <li>
-          <a>Version 1.0.1</a>
+          <a>v1.0.1</a>
         </li>
         <li>
-          <a>Version 1.0.2</a>
+          <a>v1.0.2</a>
         </li>
       </ul>
     </div>

--- a/apps/hyperdrive-trading/src/ui/base/components/VersionPicker.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/VersionPicker.tsx
@@ -1,0 +1,26 @@
+import { ChevronDownIcon } from "@heroicons/react/24/outline";
+
+export default function VersionPicker(): JSX.Element {
+  return (
+    <div className="daisy-dropdown">
+      <div tabIndex={0} className="daisy-btn flex items-center justify-center">
+        Version 1.0.0
+        <ChevronDownIcon className="h-4" />
+      </div>
+      <ul
+        tabIndex={0}
+        className="daisy-menu daisy-dropdown-content z-[1] w-52 gap-2 rounded-lg bg-base-100 p-4 shadow"
+      >
+        <li>
+          <a>Version 1.0.0</a>
+        </li>
+        <li>
+          <a>Version 1.0.1</a>
+        </li>
+        <li>
+          <a>Version 1.0.2</a>
+        </li>
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
This PR cleans up the Navbar:

1. Removes primary color used in the ConnectWallet button if the user is already connected. I think we should save that green color for actions we want the user to take, Connect Wallet, Open Long. If the wallet is already connected no further action is needed.
2. The chain name is replaced with the chain icon and joined with the connect wallet button.
3. A version picker is placed behind a feature flag and this replaces the "Cast on Warpcast" button. 


https://github.com/delvtech/hyperdrive-frontend/assets/22210106/93d1f397-7fcd-499a-8226-bd35c5df81e2


