### PR TITLE
add ui to switch to bridge modal

### DIFF
--- a/apps/hyperdrive-trading/src/ui/base/components/Modal/Modal.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/Modal/Modal.tsx
@@ -3,11 +3,12 @@ import { ReactElement, ReactNode, useRef } from "react";
 
 interface ModalProps {
   modalId: string;
-  modalContent: ReactNode;
-  modalHeader?: ReactNode;
+  modalContent: ReactNode | ReactNode[];
+  modalHeader?: ReactNode | ReactNode[];
   children?: (options: ModalChildrenOptions) => ReactNode;
   className?: string;
   forceOpen?: boolean;
+  activeIndex?: number;
 }
 
 interface ModalChildrenOptions {
@@ -21,9 +22,12 @@ export function Modal({
   children,
   className,
   forceOpen = false,
+  activeIndex,
 }: ModalProps): ReactElement {
   const modalRef = useRef<HTMLDialogElement>(null);
   const showModal = () => modalRef.current?.showModal();
+
+  const isMultiModal = getIsMultiModal(modalContent, modalHeader, activeIndex);
 
   return (
     <>
@@ -39,8 +43,14 @@ export function Modal({
           className={classNames("daisy-modal-box bg-base-200 p-0", className)}
         >
           <div className="flex flex-col gap-4">
-            {modalHeader}
-            <div className="px-2 pb-8 pt-0 sm:px-10">{modalContent}</div>
+            {isMultiModal && Array.isArray(modalHeader)
+              ? modalHeader[activeIndex!]
+              : modalHeader}
+            <div className="px-2 pb-8 pt-0 sm:px-10">
+              {isMultiModal && Array.isArray(modalContent)
+                ? modalContent[activeIndex!]
+                : modalContent}
+            </div>
           </div>
         </form>
         <form method="dialog" className="daisy-modal-backdrop">
@@ -49,4 +59,27 @@ export function Modal({
       </dialog>
     </>
   );
+}
+
+function getIsMultiModal(
+  modalContent: ReactNode | ReactNode[],
+  modalHeader?: ReactNode | ReactNode[],
+  activeIndex?: number,
+): boolean {
+  if (activeIndex === undefined) {
+    return false;
+  }
+
+  if (
+    Array.isArray(modalContent) === false ||
+    Array.isArray(modalHeader) === false
+  ) {
+    return false;
+  }
+
+  if (modalContent.length !== modalHeader.length) {
+    return false;
+  }
+
+  return true;
 }

--- a/apps/hyperdrive-trading/src/ui/bridge/BridgeAssetsForm/BridgeAssetsForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/bridge/BridgeAssetsForm/BridgeAssetsForm.tsx
@@ -1,0 +1,320 @@
+import { adjustAmountByPercentage } from "@delvtech/hyperdrive-js-core";
+import {
+  findBaseToken,
+  findYieldSourceToken,
+  HyperdriveConfig,
+} from "@hyperdrive/appconfig";
+
+import { MouseEvent, ReactElement } from "react";
+import { getIsValidTradeSize } from "src/hyperdrive/getIsValidTradeSize";
+import { getHasEnoughAllowance } from "src/token/getHasEnoughAllowance";
+import { getHasEnoughBalance } from "src/token/getHasEnoughBalance";
+import { useAppConfig } from "src/ui/appconfig/useAppConfig";
+import { ConnectWalletButton } from "src/ui/base/components/ConnectWallet";
+import { LoadingButton } from "src/ui/base/components/LoadingButton";
+import { formatBalance } from "src/ui/base/formatting/formatBalance";
+import { useNumericInput } from "src/ui/base/hooks/useNumericInput";
+import { usePoolInfo } from "src/ui/hyperdrive/hooks/usePoolInfo";
+import { useMaxLong } from "src/ui/hyperdrive/longs/hooks/useMaxLong";
+import { useOpenLong } from "src/ui/hyperdrive/longs/hooks/useOpenLong";
+import { usePreviewOpenLong } from "src/ui/hyperdrive/longs/hooks/usePreviewOpenLong";
+import { OpenLongPreview } from "src/ui/hyperdrive/longs/OpenLongPreview/OpenLongPreview";
+import { TransactionView } from "src/ui/hyperdrive/TransactionView";
+import { ApproveTokenChoices } from "src/ui/token/ApproveTokenChoices";
+import { useActiveToken } from "src/ui/token/hooks/useActiveToken";
+import { useSlippageSettings } from "src/ui/token/hooks/useSlippageSettings";
+import { useTokenAllowance } from "src/ui/token/hooks/useTokenAllowance";
+import { useTokenBalance } from "src/ui/token/hooks/useTokenBalance";
+import { SlippageSettings } from "src/ui/token/SlippageSettings";
+import { TokenInput } from "src/ui/token/TokenInput";
+import { TokenPicker } from "src/ui/token/TokenPicker";
+import { formatUnits } from "viem";
+import { useAccount } from "wagmi";
+interface BridgeAssetsFormProps {
+  hyperdrive: HyperdriveConfig;
+  onCloseBridgeUI?: (e: MouseEvent<HTMLButtonElement>) => void;
+}
+
+export function BridgeAssetsForm({
+  hyperdrive,
+  onCloseBridgeUI,
+}: BridgeAssetsFormProps): ReactElement {
+  const { address: account } = useAccount();
+  const appConfig = useAppConfig();
+  const { poolInfo } = usePoolInfo({ hyperdriveAddress: hyperdrive.address });
+
+  const baseToken = findBaseToken({
+    baseTokenAddress: hyperdrive.baseToken,
+    tokens: appConfig.tokens,
+  });
+  const sharesToken = findYieldSourceToken({
+    yieldSourceTokenAddress: hyperdrive.sharesToken,
+    tokens: appConfig.tokens,
+  });
+
+  const { balance: baseTokenBalance } = useTokenBalance({
+    account,
+    tokenAddress: baseToken.address,
+    decimals: baseToken.decimals,
+  });
+
+  const { balance: sharesTokenBalance } = useTokenBalance({
+    account,
+    tokenAddress: sharesToken.address,
+    decimals: sharesToken.decimals,
+  });
+
+  const baseTokenDepositEnabled =
+    hyperdrive.depositOptions.isBaseTokenDepositEnabled;
+  const shareTokenDepositsEnabled =
+    hyperdrive.depositOptions.isShareTokenDepositsEnabled;
+  const tokenOptions = [];
+
+  if (baseTokenDepositEnabled) {
+    tokenOptions.push({
+      tokenConfig: baseToken,
+      tokenBalance: baseTokenBalance?.value,
+    });
+  }
+
+  if (shareTokenDepositsEnabled) {
+    tokenOptions.push({
+      tokenConfig: sharesToken,
+      tokenBalance: sharesTokenBalance?.value,
+    });
+  }
+
+  const { activeToken, activeTokenBalance, setActiveToken, isActiveTokenEth } =
+    useActiveToken({
+      account,
+      defaultActiveToken: baseTokenDepositEnabled
+        ? baseToken.address
+        : sharesToken.address,
+      tokens: baseTokenDepositEnabled
+        ? [baseToken, sharesToken]
+        : [sharesToken],
+    });
+
+  // All tokens besides ETH require an allowance to spend it on hyperdrive
+  const requiresAllowance = !isActiveTokenEth;
+  const { tokenAllowance: activeTokenAllowance } = useTokenAllowance({
+    account,
+    enabled: requiresAllowance,
+    spender: hyperdrive.address,
+    tokenAddress: activeToken.address,
+  });
+
+  const {
+    amount: depositAmount,
+    amountAsBigInt: depositAmountAsBigInt,
+    setAmount,
+  } = useNumericInput({
+    decimals: activeToken.decimals,
+  });
+
+  const hasEnoughAllowance = getHasEnoughAllowance({
+    requiresAllowance,
+    allowance: activeTokenAllowance,
+    amount: depositAmountAsBigInt,
+  });
+  const hasEnoughBalance = getHasEnoughBalance({
+    balance: activeTokenBalance?.value,
+    amount: depositAmountAsBigInt,
+  });
+
+  const { maxBaseIn, maxSharesIn, maxBondsOut } = useMaxLong({
+    hyperdriveAddress: hyperdrive.address,
+  });
+  const activeTokenMaxTradeSize =
+    activeToken.address === baseToken.address ? maxBaseIn : maxSharesIn;
+
+  const hasEnoughLiquidity = getIsValidTradeSize({
+    tradeAmount: depositAmountAsBigInt,
+    maxTradeSize: activeTokenMaxTradeSize,
+  });
+
+  const {
+    bondsReceived,
+    spotRateAfterOpen,
+    curveFee,
+    status: openLongPreviewStatus,
+  } = usePreviewOpenLong({
+    hyperdriveAddress: hyperdrive.address,
+    amountIn: depositAmountAsBigInt,
+    asBase: activeToken.address === baseToken.address,
+  });
+
+  const {
+    setSlippage,
+    slippage,
+    slippageAsBigInt,
+    activeOption: activeSlippageOption,
+    setActiveOption: setActiveSlippageOption,
+  } = useSlippageSettings({ decimals: activeToken.decimals });
+
+  const bondsReceivedAfterSlippage =
+    bondsReceived &&
+    adjustAmountByPercentage({
+      amount: bondsReceived,
+      percentage: slippageAsBigInt,
+      decimals: activeToken.decimals,
+      direction: "down",
+    });
+
+  const { openLong, openLongStatus } = useOpenLong({
+    hyperdriveAddress: hyperdrive.address,
+    asBase: activeToken.address === baseToken.address,
+    amount: depositAmountAsBigInt,
+    ethValue: isActiveTokenEth ? depositAmountAsBigInt : undefined,
+    minBondsOut: bondsReceivedAfterSlippage,
+    minSharePrice: poolInfo?.vaultSharePrice,
+    destination: account,
+    enabled: openLongPreviewStatus === "success" && hasEnoughAllowance,
+    onSubmitted: () => {
+      (window as any)["open-long"].close();
+    },
+    onExecuted: () => {
+      setAmount("");
+    },
+  });
+
+  // Max button is wired up to the user's balance, or the pool's max long.
+  // Whichever is smallest.
+  let maxButtonValue = "0";
+  if (activeTokenBalance && activeTokenMaxTradeSize) {
+    maxButtonValue = formatUnits(
+      activeTokenBalance.value > activeTokenMaxTradeSize
+        ? activeTokenMaxTradeSize
+        : activeTokenBalance?.value,
+      activeToken.decimals,
+    );
+  }
+
+  return (
+    <TransactionView
+      tokenInput={
+        <TokenInput
+          settings={
+            <SlippageSettings
+              onSlippageChange={setSlippage}
+              slippage={slippage}
+              activeOption={activeSlippageOption}
+              onActiveOptionChange={setActiveSlippageOption}
+              tooltip="Your transaction will revert if the price changes unfavorably by more than this percentage."
+            />
+          }
+          name={activeToken.symbol}
+          token={
+            <TokenPicker
+              // TODO: Remove check for Sepolia chain after testnet period.
+              tokens={tokenOptions}
+              activeTokenAddress={activeToken.address}
+              onChange={(tokenAddress) => {
+                setActiveToken(tokenAddress);
+                setAmount("0");
+              }}
+              joined={true}
+            />
+          }
+          value={depositAmount ?? ""}
+          maxValue={maxButtonValue}
+          inputLabel="Amount to bridge"
+          stat={
+            <div className="flex flex-col gap-1 text-xs text-neutral-content">
+              <span>
+                {activeTokenBalance
+                  ? `Balance: ${formatBalance({
+                      balance: activeTokenBalance?.value,
+                      decimals: activeToken.decimals,
+                      places: activeToken.places,
+                    })} ${activeToken.symbol}`
+                  : undefined}
+              </span>
+              <span>{`Slippage: ${slippage || "0.5"}%`}</span>
+            </div>
+          }
+          onChange={(newAmount) => setAmount(newAmount)}
+        />
+      }
+      setting={<button onClick={onCloseBridgeUI}>{"<-- Back"}</button>}
+      transactionPreview={
+        <OpenLongPreview
+          hyperdrive={hyperdrive}
+          spotRateAfterOpen={spotRateAfterOpen}
+          curveFee={curveFee}
+          activeToken={activeToken}
+          amountPaid={depositAmountAsBigInt || 0n}
+          bondAmount={bondsReceived || 0n}
+          openLongPreviewStatus={openLongPreviewStatus}
+          asBase={activeToken.address === baseToken.address}
+          vaultSharePrice={poolInfo?.vaultSharePrice}
+        />
+      }
+      disclaimer={(() => {
+        if (!!depositAmountAsBigInt && !hasEnoughLiquidity) {
+          return (
+            <p className="text-center text-sm text-error">
+              Pool limit exceeded. Max long size is{" "}
+              {formatBalance({
+                balance: maxBondsOut || 0n,
+                decimals: baseToken.decimals,
+              })}{" "}
+              hy{baseToken.symbol}
+            </p>
+          );
+        }
+        if (!!depositAmountAsBigInt && !hasEnoughBalance) {
+          return (
+            <p className="text-center text-sm text-error">
+              Insufficient balance
+            </p>
+          );
+        }
+      })()}
+      actionButton={(() => {
+        if (!account) {
+          return <ConnectWalletButton />;
+        }
+
+        if (!hasEnoughBalance || !hasEnoughLiquidity) {
+          return (
+            <button
+              disabled
+              className="daisy-btn daisy-btn-circle daisy-btn-primary w-full disabled:bg-primary disabled:text-base-100 disabled:opacity-30"
+            >
+              Bridge Assets
+            </button>
+          );
+        }
+
+        if (!hasEnoughAllowance) {
+          return (
+            <ApproveTokenChoices
+              spender={hyperdrive.address}
+              token={activeToken}
+              amountAsBigInt={depositAmountAsBigInt}
+              amount={depositAmount}
+            />
+          );
+        }
+
+        if (openLongStatus === "loading") {
+          return <LoadingButton label="Opening Long" variant="primary" />;
+        }
+
+        return (
+          <button
+            disabled={!openLong}
+            className="daisy-btn daisy-btn-circle daisy-btn-primary w-full disabled:bg-primary disabled:text-base-100 disabled:opacity-30"
+            onClick={(e) => {
+              openLong?.();
+              onCloseBridgeUI?.(e);
+            }}
+          >
+            Bridge Assets
+          </button>
+        );
+      })()}
+    />
+  );
+}

--- a/apps/hyperdrive-trading/src/ui/bridge/BridgeAssetsModal/BridgeAssetsModal.tsx
+++ b/apps/hyperdrive-trading/src/ui/bridge/BridgeAssetsModal/BridgeAssetsModal.tsx
@@ -1,0 +1,105 @@
+import { HyperdriveConfig } from "@hyperdrive/appconfig";
+
+import { XMarkIcon } from "@heroicons/react/24/solid";
+import { ReactElement } from "react";
+import { Modal } from "src/ui/base/components/Modal/Modal";
+import { ModalHeader } from "src/ui/base/components/Modal/ModalHeader";
+import { Stat } from "src/ui/base/components/Stat";
+import { BridgeAssetsForm } from "src/ui/bridge/BridgeAssetsForm/BridgeAssetsForm";
+
+interface BridgeAssetsModalProps {
+  modalId: string;
+  tokenSymbol: string;
+  hyperdrive: HyperdriveConfig;
+  closeModal: () => void;
+  setShowBridgeUI: (showBridgeUI: boolean) => void;
+}
+export function BridgeAssetsModal({
+  modalId,
+  tokenSymbol,
+  hyperdrive,
+  closeModal,
+  setShowBridgeUI,
+}: BridgeAssetsModalProps): ReactElement {
+  return (
+    <Modal
+      modalId={modalId}
+      modalHeader={<BridgeAssetsModalHeader tokenSymbol={tokenSymbol} />}
+      modalContent={
+        <BridgeAssetsModalForm
+          hyperdrive={hyperdrive}
+          setShowBridgeUI={setShowBridgeUI}
+          closeModal={closeModal}
+        />
+      }
+    >
+      {({ showModal }) => (
+        <button
+          className="daisy-btn daisy-btn-primary rounded-full"
+          onClick={() => showModal()}
+        >
+          + Bridge Assets
+        </button>
+      )}
+    </Modal>
+  );
+}
+
+interface BridgeAssetsHeaderProps {
+  tokenSymbol: string;
+}
+
+export function BridgeAssetsModalHeader({
+  tokenSymbol,
+}: BridgeAssetsHeaderProps): ReactElement {
+  return (
+    <ModalHeader
+      heading={`Bridge ${tokenSymbol}`}
+      subHeading="Bring your assets to Mainnet from other chains to use on Hyperdrive"
+    >
+      <div className="mt-5 flex w-full flex-wrap justify-between gap-4">
+        <div className="daisy-badge daisy-badge-lg">
+          <Stat
+            horizontal
+            size="small"
+            label={"Balance:"}
+            value={`${100} ${tokenSymbol}`}
+          />
+        </div>
+        <div className="daisy-badge daisy-badge-lg"></div>
+      </div>
+    </ModalHeader>
+  );
+}
+
+interface BridgeAssetsModalFormProps {
+  hyperdrive: HyperdriveConfig;
+  closeModal: () => void;
+  setShowBridgeUI: (showBridgeUI: boolean) => void;
+}
+
+export function BridgeAssetsModalForm({
+  hyperdrive,
+  closeModal,
+  setShowBridgeUI,
+}: BridgeAssetsModalFormProps): ReactElement {
+  return (
+    <div>
+      <button
+        className="daisy-btn daisy-btn-circle daisy-btn-ghost daisy-btn-sm absolute right-4 top-4"
+        onClick={closeModal}
+      >
+        <XMarkIcon className="w-6 " title="Close position" />
+      </button>
+      <BridgeAssetsForm
+        hyperdrive={hyperdrive}
+        onCloseBridgeUI={(e) => {
+          // preventDefault since we don't want to close the modal while the
+          // tx is temporarily pending the user's signature in their wallet.
+          e.preventDefault();
+          setShowBridgeUI(false);
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
@@ -12,6 +12,7 @@ import { getHasEnoughBalance } from "src/token/getHasEnoughBalance";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { ConnectWalletButton } from "src/ui/base/components/ConnectWallet";
 import { LoadingButton } from "src/ui/base/components/LoadingButton";
+import { useFeatureFlag } from "src/ui/base/featureFlags/featureFlags";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { useNumericInput } from "src/ui/base/hooks/useNumericInput";
 import { usePoolInfo } from "src/ui/hyperdrive/hooks/usePoolInfo";
@@ -42,6 +43,7 @@ export function OpenLongForm({
   onOpenBridge,
 }: OpenLongFormProps): ReactElement {
   const { address: account } = useAccount();
+  const isBridgingEnabled = useFeatureFlag("bridge");
   const appConfig = useAppConfig();
   const { poolInfo } = usePoolInfo({ hyperdriveAddress: hyperdrive.address });
 
@@ -191,6 +193,9 @@ export function OpenLongForm({
       activeToken.decimals,
     );
   }
+  const switchToBridgeUIButton = (
+    <button onClick={onOpenBridge}>Bridge DAI from L2s</button>
+  );
 
   return (
     <TransactionView
@@ -238,7 +243,7 @@ export function OpenLongForm({
           onChange={(newAmount) => setAmount(newAmount)}
         />
       }
-      setting={<button onClick={onOpenBridge}>Bridge DAI from L2s</button>}
+      setting={isBridgingEnabled ? switchToBridgeUIButton : null}
       transactionPreview={
         <OpenLongPreview
           hyperdrive={hyperdrive}

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
@@ -33,11 +33,13 @@ import { useAccount } from "wagmi";
 interface OpenLongFormProps {
   hyperdrive: HyperdriveConfig;
   onOpenLong?: (e: MouseEvent<HTMLButtonElement>) => void;
+  onOpenBridge?: (e: MouseEvent<HTMLButtonElement>) => void;
 }
 
 export function OpenLongForm({
   hyperdrive: hyperdrive,
   onOpenLong,
+  onOpenBridge,
 }: OpenLongFormProps): ReactElement {
   const { address: account } = useAccount();
   const appConfig = useAppConfig();
@@ -236,6 +238,7 @@ export function OpenLongForm({
           onChange={(newAmount) => setAmount(newAmount)}
         />
       }
+      setting={<button onClick={onOpenBridge}>Bridge DAI from L2s</button>}
       transactionPreview={
         <OpenLongPreview
           hyperdrive={hyperdrive}

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongModal/OpenLongModal.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongModal/OpenLongModal.tsx
@@ -54,7 +54,7 @@ interface OpenLongModalHeaderProps {
   termLengthMS: number;
 }
 
-function OpenLongModalHeader({
+export function OpenLongModalHeader({
   numDays,
   termLengthMS,
 }: OpenLongModalHeaderProps): ReactElement {

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongModal/OpenLongModal.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongModal/OpenLongModal.tsx
@@ -1,0 +1,123 @@
+import { XMarkIcon } from "@heroicons/react/24/solid";
+import { HyperdriveConfig } from "@hyperdrive/appconfig";
+import { ReactElement } from "react";
+import { Modal } from "src/ui/base/components/Modal/Modal";
+import { ModalHeader } from "src/ui/base/components/Modal/ModalHeader";
+import { Stat } from "src/ui/base/components/Stat";
+import { formatDate } from "src/ui/base/formatting/formatDate";
+import { OpenLongForm } from "src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm";
+
+interface OpenLongModalProps {
+  modalId: string;
+  numDays: number;
+  termLengthMS: number;
+  hyperdrive: HyperdriveConfig;
+  closeModal: () => void;
+  setShowBridgeUI: (showBridgeUI: boolean) => void;
+}
+export function OpenLongModal({
+  modalId,
+  numDays,
+  termLengthMS,
+  hyperdrive,
+  closeModal,
+  setShowBridgeUI,
+}: OpenLongModalProps): ReactElement {
+  return (
+    <Modal
+      modalId={modalId}
+      modalHeader={
+        <OpenLongModalHeader numDays={numDays} termLengthMS={termLengthMS} />
+      }
+      modalContent={
+        <OpenLongModalForm
+          hyperdrive={hyperdrive}
+          setShowBridgeUI={setShowBridgeUI}
+          closeModal={closeModal}
+        />
+      }
+    >
+      {({ showModal }) => (
+        <button
+          className="daisy-btn daisy-btn-primary rounded-full"
+          onClick={() => showModal()}
+        >
+          + Open a Long
+        </button>
+      )}
+    </Modal>
+  );
+}
+
+interface OpenLongModalHeaderProps {
+  numDays: number;
+  termLengthMS: number;
+}
+
+function OpenLongModalHeader({
+  numDays,
+  termLengthMS,
+}: OpenLongModalHeaderProps): ReactElement {
+  return (
+    <ModalHeader
+      heading="Open a Long"
+      subHeading="Buy the fixed rate and know your exact yield upfront"
+    >
+      <div className="mt-5 flex w-full flex-wrap justify-between gap-4">
+        <div className="daisy-badge daisy-badge-lg">
+          <Stat
+            horizontal
+            size="small"
+            label={"Term:"}
+            value={`${numDays} days`}
+          />
+        </div>
+        <div className="daisy-badge daisy-badge-lg">
+          <Stat
+            horizontal
+            size="small"
+            label="Maturity Date:"
+            value={formatDate(Date.now() + termLengthMS)}
+          />
+        </div>
+      </div>
+    </ModalHeader>
+  );
+}
+
+interface OpenLongModalFormProps {
+  hyperdrive: HyperdriveConfig;
+  closeModal: () => void;
+  setShowBridgeUI: (showBridgeUI: boolean) => void;
+}
+
+export function OpenLongModalForm({
+  hyperdrive,
+  closeModal,
+  setShowBridgeUI,
+}: OpenLongModalFormProps): ReactElement {
+  return (
+    <div>
+      <button
+        className="daisy-btn daisy-btn-circle daisy-btn-ghost daisy-btn-sm absolute right-4 top-4"
+        onClick={closeModal}
+      >
+        <XMarkIcon className="w-6 " title="Close position" />
+      </button>
+      <OpenLongForm
+        hyperdrive={hyperdrive}
+        onOpenLong={(e) => {
+          // preventDefault since we don't want to close the modal while the
+          // tx is temporarily pending the user's signature in their wallet.
+          e.preventDefault();
+        }}
+        onOpenBridge={(e) => {
+          // preventDefault since we don't want to close the modal while the
+          // tx is temporarily pending the user's signature in their wallet.
+          e.preventDefault();
+          setShowBridgeUI(true);
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongModalButton/OpenLongModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongModalButton/OpenLongModalButton.tsx
@@ -1,14 +1,16 @@
 import { PauseCircleIcon, XMarkIcon } from "@heroicons/react/24/solid";
 import { HyperdriveConfig } from "@hyperdrive/appconfig";
-import { ReactElement } from "react";
+import { ReactElement, useState } from "react";
 import { convertMillisecondsToDays } from "src/base/convertMillisecondsToDays";
 import { Modal } from "src/ui/base/components/Modal/Modal";
 import { ModalHeader } from "src/ui/base/components/Modal/ModalHeader";
 import { Stat } from "src/ui/base/components/Stat";
 import { WarningButton } from "src/ui/base/components/WarningButton";
 import { formatDate } from "src/ui/base/formatting/formatDate";
+import { useTokens } from "src/ui/bridge/hooks/useTokens";
 import { useMarketState } from "src/ui/hyperdrive/hooks/useMarketState";
 import { OpenLongForm } from "src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm";
+import { mainnet } from "viem/chains";
 
 export interface OpenLongModalButtonProps {
   modalId: string;
@@ -19,6 +21,14 @@ export function OpenLongModalButton({
   hyperdrive,
 }: OpenLongModalButtonProps): ReactElement {
   const { marketState } = useMarketState(hyperdrive.address);
+  const [showBridgeUI, setShowBridgeUI] = useState(false);
+  const { tokens } = useTokens();
+  console.log("tokens", tokens);
+  const token = tokens?.find(
+    (token) => token.addresses?.[String(mainnet.id)] === hyperdrive.baseToken,
+  );
+  console.log("hyperdrive", hyperdrive);
+  console.log("token", token);
   const termLengthMS = Number(hyperdrive.poolConfig.positionDuration * 1000n);
   const numDays = convertMillisecondsToDays(termLengthMS);
   function closeModal() {
@@ -34,33 +44,16 @@ export function OpenLongModalButton({
       />
     );
   }
+
   return (
     <Modal
       modalId={modalId}
       modalHeader={
-        <ModalHeader
-          heading="Open a Long"
-          subHeading="Buy the fixed rate and know your exact yield upfront"
-        >
-          <div className="mt-5 flex w-full flex-wrap justify-between gap-4">
-            <div className="daisy-badge daisy-badge-lg">
-              <Stat
-                horizontal
-                size="small"
-                label={"Term:"}
-                value={`${numDays} days`}
-              />
-            </div>
-            <div className="daisy-badge daisy-badge-lg">
-              <Stat
-                horizontal
-                size="small"
-                label="Maturity Date:"
-                value={formatDate(Date.now() + termLengthMS)}
-              />
-            </div>
-          </div>
-        </ModalHeader>
+        showBridgeUI && token ? (
+          <BridgeAssetsHeader tokenSymbol={token.symbol!} />
+        ) : (
+          <OpenLongHeader numDays={numDays} termLengthMS={termLengthMS} />
+        )
       }
       modalContent={
         <div>
@@ -77,6 +70,12 @@ export function OpenLongModalButton({
               // tx is temporarily pending the user's signature in their wallet.
               e.preventDefault();
             }}
+            onOpenBridge={(e) => {
+              // preventDefault since we don't want to close the modal while the
+              // tx is temporarily pending the user's signature in their wallet.
+              e.preventDefault();
+              setShowBridgeUI(true);
+            }}
           />
         </div>
       }
@@ -90,5 +89,68 @@ export function OpenLongModalButton({
         </button>
       )}
     </Modal>
+  );
+}
+
+interface OpenLongHeaderProps {
+  numDays: number;
+  termLengthMS: number;
+}
+
+function OpenLongHeader({
+  numDays,
+  termLengthMS,
+}: OpenLongHeaderProps): ReactElement {
+  return (
+    <ModalHeader
+      heading="Open a Long"
+      subHeading="Buy the fixed rate and know your exact yield upfront"
+    >
+      <div className="mt-5 flex w-full flex-wrap justify-between gap-4">
+        <div className="daisy-badge daisy-badge-lg">
+          <Stat
+            horizontal
+            size="small"
+            label={"Term:"}
+            value={`${numDays} days`}
+          />
+        </div>
+        <div className="daisy-badge daisy-badge-lg">
+          <Stat
+            horizontal
+            size="small"
+            label="Maturity Date:"
+            value={formatDate(Date.now() + termLengthMS)}
+          />
+        </div>
+      </div>
+    </ModalHeader>
+  );
+}
+
+interface BridgeAssetsHeaderProps {
+  tokenSymbol: string;
+}
+
+function BridgeAssetsHeader({
+  tokenSymbol,
+}: BridgeAssetsHeaderProps): ReactElement {
+  return (
+    <ModalHeader
+      heading={`Bridge ${tokenSymbol}`}
+      subHeading="Bring your assets to Mainnet from other chains to use on Hyperdrive"
+    >
+      <div className="mt-5 flex w-full flex-wrap justify-between gap-4">
+        <div className="daisy-badge daisy-badge-lg">
+          <Stat
+            horizontal
+            size="small"
+            label={"Balance:"}
+            value={`${100} ${tokenSymbol}`}
+          />
+        </div>
+        <div className="daisy-badge daisy-badge-lg"></div>
+      </div>
+    </ModalHeader>
   );
 }

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongModalButton/OpenLongModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongModalButton/OpenLongModalButton.tsx
@@ -1,16 +1,10 @@
-import { PauseCircleIcon, XMarkIcon } from "@heroicons/react/24/solid";
+import { PauseCircleIcon } from "@heroicons/react/24/solid";
 import { HyperdriveConfig } from "@hyperdrive/appconfig";
-import { ReactElement, useState } from "react";
+import { ReactElement } from "react";
 import { convertMillisecondsToDays } from "src/base/convertMillisecondsToDays";
-import { Modal } from "src/ui/base/components/Modal/Modal";
-import { ModalHeader } from "src/ui/base/components/Modal/ModalHeader";
-import { Stat } from "src/ui/base/components/Stat";
 import { WarningButton } from "src/ui/base/components/WarningButton";
-import { formatDate } from "src/ui/base/formatting/formatDate";
-import { useTokens } from "src/ui/bridge/hooks/useTokens";
 import { useMarketState } from "src/ui/hyperdrive/hooks/useMarketState";
-import { OpenLongForm } from "src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm";
-import { mainnet } from "viem/chains";
+import { OpenLongModal } from "src/ui/hyperdrive/longs/OpenLongModal/OpenLongModal";
 
 export interface OpenLongModalButtonProps {
   modalId: string;
@@ -21,14 +15,7 @@ export function OpenLongModalButton({
   hyperdrive,
 }: OpenLongModalButtonProps): ReactElement {
   const { marketState } = useMarketState(hyperdrive.address);
-  const [showBridgeUI, setShowBridgeUI] = useState(false);
-  const { tokens } = useTokens();
-  console.log("tokens", tokens);
-  const token = tokens?.find(
-    (token) => token.addresses?.[String(mainnet.id)] === hyperdrive.baseToken,
-  );
-  console.log("hyperdrive", hyperdrive);
-  console.log("token", token);
+
   const termLengthMS = Number(hyperdrive.poolConfig.positionDuration * 1000n);
   const numDays = convertMillisecondsToDays(termLengthMS);
   function closeModal() {
@@ -46,111 +33,13 @@ export function OpenLongModalButton({
   }
 
   return (
-    <Modal
+    <OpenLongModal
       modalId={modalId}
-      modalHeader={
-        showBridgeUI && token ? (
-          <BridgeAssetsHeader tokenSymbol={token.symbol!} />
-        ) : (
-          <OpenLongHeader numDays={numDays} termLengthMS={termLengthMS} />
-        )
-      }
-      modalContent={
-        <div>
-          <button
-            className="daisy-btn daisy-btn-circle daisy-btn-ghost daisy-btn-sm absolute right-4 top-4"
-            onClick={closeModal}
-          >
-            <XMarkIcon className="w-6 " title="Close position" />
-          </button>
-          <OpenLongForm
-            hyperdrive={hyperdrive}
-            onOpenLong={(e) => {
-              // preventDefault since we don't want to close the modal while the
-              // tx is temporarily pending the user's signature in their wallet.
-              e.preventDefault();
-            }}
-            onOpenBridge={(e) => {
-              // preventDefault since we don't want to close the modal while the
-              // tx is temporarily pending the user's signature in their wallet.
-              e.preventDefault();
-              setShowBridgeUI(true);
-            }}
-          />
-        </div>
-      }
-    >
-      {({ showModal }) => (
-        <button
-          className="daisy-btn daisy-btn-primary rounded-full"
-          onClick={() => showModal()}
-        >
-          + Open a Long
-        </button>
-      )}
-    </Modal>
-  );
-}
-
-interface OpenLongHeaderProps {
-  numDays: number;
-  termLengthMS: number;
-}
-
-function OpenLongHeader({
-  numDays,
-  termLengthMS,
-}: OpenLongHeaderProps): ReactElement {
-  return (
-    <ModalHeader
-      heading="Open a Long"
-      subHeading="Buy the fixed rate and know your exact yield upfront"
-    >
-      <div className="mt-5 flex w-full flex-wrap justify-between gap-4">
-        <div className="daisy-badge daisy-badge-lg">
-          <Stat
-            horizontal
-            size="small"
-            label={"Term:"}
-            value={`${numDays} days`}
-          />
-        </div>
-        <div className="daisy-badge daisy-badge-lg">
-          <Stat
-            horizontal
-            size="small"
-            label="Maturity Date:"
-            value={formatDate(Date.now() + termLengthMS)}
-          />
-        </div>
-      </div>
-    </ModalHeader>
-  );
-}
-
-interface BridgeAssetsHeaderProps {
-  tokenSymbol: string;
-}
-
-function BridgeAssetsHeader({
-  tokenSymbol,
-}: BridgeAssetsHeaderProps): ReactElement {
-  return (
-    <ModalHeader
-      heading={`Bridge ${tokenSymbol}`}
-      subHeading="Bring your assets to Mainnet from other chains to use on Hyperdrive"
-    >
-      <div className="mt-5 flex w-full flex-wrap justify-between gap-4">
-        <div className="daisy-badge daisy-badge-lg">
-          <Stat
-            horizontal
-            size="small"
-            label={"Balance:"}
-            value={`${100} ${tokenSymbol}`}
-          />
-        </div>
-        <div className="daisy-badge daisy-badge-lg"></div>
-      </div>
-    </ModalHeader>
+      termLengthMS={termLengthMS}
+      numDays={numDays}
+      hyperdrive={hyperdrive}
+      closeModal={closeModal}
+      setShowBridgeUI={setShowBridgeUI}
+    />
   );
 }

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongModalButton/OpenLongModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongModalButton/OpenLongModalButton.tsx
@@ -1,10 +1,21 @@
 import { PauseCircleIcon } from "@heroicons/react/24/solid";
 import { HyperdriveConfig } from "@hyperdrive/appconfig";
-import { ReactElement } from "react";
+import { ReactElement, useState } from "react";
 import { convertMillisecondsToDays } from "src/base/convertMillisecondsToDays";
+import { Modal } from "src/ui/base/components/Modal/Modal";
 import { WarningButton } from "src/ui/base/components/WarningButton";
+import {
+  BridgeAssetsModalForm,
+  BridgeAssetsModalHeader,
+} from "src/ui/bridge/BridgeAssetsModal/BridgeAssetsModal";
+import { useToken } from "src/ui/bridge/hooks/useToken";
+import { useTokens } from "src/ui/bridge/hooks/useTokens";
 import { useMarketState } from "src/ui/hyperdrive/hooks/useMarketState";
-import { OpenLongModal } from "src/ui/hyperdrive/longs/OpenLongModal/OpenLongModal";
+import {
+  OpenLongModalForm,
+  OpenLongModalHeader,
+} from "src/ui/hyperdrive/longs/OpenLongModal/OpenLongModal";
+import { mainnet } from "viem/chains";
 
 export interface OpenLongModalButtonProps {
   modalId: string;
@@ -15,6 +26,13 @@ export function OpenLongModalButton({
   hyperdrive,
 }: OpenLongModalButtonProps): ReactElement {
   const { marketState } = useMarketState(hyperdrive.address);
+  const [showBridgeUI, setShowBridgeUI] = useState(false);
+  const { tokens } = useTokens();
+  let token = tokens?.find(
+    (token) => token.addresses?.[String(mainnet.id)] === hyperdrive.baseToken,
+  );
+  // TODO: remove this when stubs work
+  ({ token } = useToken("DAI"));
 
   const termLengthMS = Number(hyperdrive.poolConfig.positionDuration * 1000n);
   const numDays = convertMillisecondsToDays(termLengthMS);
@@ -33,13 +51,43 @@ export function OpenLongModalButton({
   }
 
   return (
-    <OpenLongModal
+    <Modal
       modalId={modalId}
-      termLengthMS={termLengthMS}
-      numDays={numDays}
-      hyperdrive={hyperdrive}
-      closeModal={closeModal}
-      setShowBridgeUI={setShowBridgeUI}
-    />
+      activeIndex={showBridgeUI ? 1 : 0}
+      modalHeader={[
+        <OpenLongModalHeader
+          key="long"
+          numDays={numDays}
+          termLengthMS={termLengthMS}
+        />,
+        <BridgeAssetsModalHeader
+          key="bridge"
+          tokenSymbol={token?.symbol || "DAI"}
+        />,
+      ]}
+      modalContent={[
+        <OpenLongModalForm
+          key="long"
+          hyperdrive={hyperdrive}
+          closeModal={closeModal}
+          setShowBridgeUI={setShowBridgeUI}
+        />,
+        <BridgeAssetsModalForm
+          key="bridge"
+          hyperdrive={hyperdrive}
+          closeModal={closeModal}
+          setShowBridgeUI={setShowBridgeUI}
+        />,
+      ]}
+    >
+      {({ showModal }) => (
+        <button
+          className="daisy-btn daisy-btn-primary rounded-full"
+          onClick={() => showModal()}
+        >
+          + Open a Long
+        </button>
+      )}
+    </Modal>
   );
 }


### PR DESCRIPTION
This PR does the minimum to let us switch modal UIs.  I copied code from the OpenLongModal for now so we can see how it looks.  Next step will be fill out the logic for the `<BridgeAssetsModalForm />`.


- add ui to switch to bridge modal
- refactor OpenLongModal
- add BridgeAssetsModal
- allow multi modal mode
- toggle between modal uis

![bridge](https://github.com/delvtech/hyperdrive-frontend/assets/9002261/220d36d7-4296-4c3f-b49a-e4122db21591)

