### PR TITLE
adds new text to lpapy

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityModalButton/AddLiquidityModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityModalButton/AddLiquidityModalButton.tsx
@@ -1,4 +1,5 @@
 import { PauseCircleIcon } from "@heroicons/react/16/solid";
+import { SparklesIcon } from "@heroicons/react/24/outline";
 import { XMarkIcon } from "@heroicons/react/24/solid";
 import { HyperdriveConfig, findYieldSourceToken } from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
@@ -24,9 +25,14 @@ export function AddLiquidityModalButton({
   const { lpApy } = useLpApy(hyperdrive.address);
   // TODO: copied from YieldStats, this should be formalized in useLpApy
   const lpApyLabel =
-    lpApy === undefined
-      ? "no data"
-      : `${(lpApy * 100).toFixed(2) === "-0.00" ? "0.00" : (lpApy * 100).toFixed(2)}%`;
+    lpApy === undefined ? (
+      <span className="gradient-text flex flex-row items-center">
+        <SparklesIcon width={18} className="fill-primary stroke-none" />
+        New
+      </span>
+    ) : (
+      `${(lpApy * 100).toFixed(2) === "-0.00" ? "0.00" : (lpApy * 100).toFixed(2)}%`
+    );
 
   const { vaultRate } = useYieldSourceRate({
     hyperdriveAddress: hyperdrive.address,

--- a/apps/hyperdrive-trading/src/ui/markets/AllMarketsTable/LpApyCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/AllMarketsTable/LpApyCell.tsx
@@ -1,3 +1,4 @@
+import { SparklesIcon } from "@heroicons/react/24/outline";
 import classNames from "classnames";
 import { ReactElement } from "react";
 import Skeleton from "react-loading-skeleton";
@@ -16,7 +17,12 @@ export function LpApyCell({
     return <Skeleton className="h-6 w-20" />;
   }
   if (!lpApy) {
-    return <span>no data</span>;
+    return (
+      <span className="gradient-text flex flex-row">
+        <SparklesIcon width={24} className="fill-primary stroke-none" />
+        New
+      </span>
+    );
   }
   return (
     <span

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/YieldStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/YieldStats.tsx
@@ -1,3 +1,4 @@
+import { SparklesIcon } from "@heroicons/react/24/outline";
 import { HyperdriveConfig, findYieldSourceToken } from "@hyperdrive/appconfig";
 import { useSearch } from "@tanstack/react-router";
 import classNames from "classnames";
@@ -64,9 +65,17 @@ export function YieldStats({
                       "gradient-text": position === "LP",
                     })}
                   >
-                    {lpApy === undefined
-                      ? "no data"
-                      : `${(lpApy * 100).toFixed(2) === "-0.00" ? "0.00" : (lpApy * 100).toFixed(2)}%`}{" "}
+                    {lpApy === undefined ? (
+                      <span className="gradient-text flex flex-row">
+                        <SparklesIcon
+                          width={24}
+                          className="fill-primary stroke-none"
+                        />
+                        New
+                      </span>
+                    ) : (
+                      `${(lpApy * 100).toFixed(2) === "-0.00" ? "0.00" : (lpApy * 100).toFixed(2)}%`
+                    )}{" "}
                   </span>
                 ) : (
                   <Skeleton className="w-20" />


### PR DESCRIPTION
This PR adds a shiny ✨ New text to the lpapi if no data is available. One additional thing we could add is a tooltip to explain why there is no data.
![image](https://github.com/delvtech/hyperdrive-frontend/assets/22210106/9efa567b-0f2e-4841-817a-fe873de271d3)
![image](https://github.com/delvtech/hyperdrive-frontend/assets/22210106/496c929c-9b18-4e10-b844-913f53e95de8)
