### PR TITLE
Convert present value to base amount

### DIFF
--- a/crates/hyperdrive-wasm/src/lib.rs
+++ b/crates/hyperdrive-wasm/src/lib.rs
@@ -84,7 +84,7 @@ pub fn idleShareReservesInBase(
     Ok(result_fp.to_u256()?.to_string())
 }
 
-/// Calculates the pool's present value in base
+/// Calculates the pool's present value in shares
 ///
 /// @param poolInfo - The current state of the pool
 ///

--- a/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
@@ -405,7 +405,7 @@ export class ReadHyperdrive extends ReadModel {
   }
 
   /**
-   * Gets the total present value of the pool.
+   * Gets the total present value of the pool in base.
    * @param options
    * @returns
    */
@@ -413,13 +413,22 @@ export class ReadHyperdrive extends ReadModel {
     const poolConfig = await this.getPoolConfig(options);
     const poolInfo = await this.getPoolInfo(options);
 
-    const liquidityString = hyperwasm.presentValue(
+    const result = hyperwasm.presentValue(
       convertBigIntsToStrings(poolInfo),
       convertBigIntsToStrings(poolConfig),
       Math.floor(Date.now() / 1000).toString(),
     );
 
-    return BigInt(liquidityString);
+    const presentValueInShares = BigInt(result);
+
+    // TODO: move this into hyperwasm so that it simply returns the result in
+    // base instead of us having to convert it here
+    const presentValueInBase = dnum.multiply(
+      [presentValueInShares, 18],
+      [poolInfo.vaultSharePrice, 18],
+    )[0];
+
+    return presentValueInBase;
   }
 
   /**

--- a/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/ReadHyperdrive/ReadHyperdrive.ts
@@ -423,9 +423,10 @@ export class ReadHyperdrive extends ReadModel {
 
     // TODO: move this into hyperwasm so that it simply returns the result in
     // base instead of us having to convert it here
+    const decimals = await this.getDecimals();
     const presentValueInBase = dnum.multiply(
-      [presentValueInShares, 18],
-      [poolInfo.vaultSharePrice, 18],
+      [presentValueInShares, decimals],
+      [poolInfo.vaultSharePrice, decimals],
     )[0];
 
     return presentValueInBase;


### PR DESCRIPTION
The present value calculation was wrongly documented as returning the result in base. This PR corrects the documentation and updates the SDK to convert the present value from shares to base.

|Before|After|
|---|---|
|![image](https://github.com/delvtech/hyperdrive-frontend/assets/4524175/9f10d0c2-c49c-4cc4-8a6d-5aef5accaeca)|<img alt="image" src="https://github.com/delvtech/hyperdrive-frontend/assets/4524175/77a7351d-a856-480c-855d-e810a0cd7449">|