### PR TITLE
Improve default values for minOutputPerShare

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
@@ -140,10 +140,18 @@ export function AddLiquidityForm({
   } = useSlippageSettings({ decimals: activeToken.decimals });
 
   const isBaseActiveToken = activeToken.address === baseToken.address;
+
+  // if depositing in shares, we need to also convert the minLpSharePrice to be
+  // priced in terms of shares
+  const lpSharePrice = !isBaseActiveToken
+    ? dnum.div(
+        [poolInfo?.lpSharePrice || 0n, baseToken.decimals],
+        [poolInfo?.vaultSharePrice || 0n, baseToken.decimals],
+      )[0]
+    : poolInfo?.lpSharePrice || 0n;
+
   const minLpSharePriceAfterSlippage = adjustAmountByPercentage({
-    amount: !isBaseActiveToken
-      ? (poolInfo?.lpSharePrice ?? 0n) / (poolInfo?.vaultSharePrice ?? 0n)
-      : poolInfo?.lpSharePrice || 0n,
+    amount: lpSharePrice,
     percentage: slippageAsBigInt,
     decimals: activeToken.decimals,
     direction: "down",

--- a/packages/hyperdrive-js-core/src/base/adjustAmountByPercentage.ts
+++ b/packages/hyperdrive-js-core/src/base/adjustAmountByPercentage.ts
@@ -4,7 +4,7 @@ interface AdjustAmountByPercentageOptions {
    */
   amount: bigint;
   /**
-   * The percentage to adjust it by, eg: 1n for 1%
+   * The percentage to adjust it by, eg: 1e18 for 1%
    */
   percentage: bigint;
 
@@ -24,7 +24,7 @@ interface AdjustAmountByPercentageOptions {
  * adjustAmountByPercentage({
  *   amount: parseUnits("100", 18),
  *   decimals: 18,
- *   percentage: 1n
+ *   percentage: BigInt(1e18),
  *   direction: "down",
  * }) === parseUnits("99")
  * ```
@@ -33,7 +33,7 @@ interface AdjustAmountByPercentageOptions {
  * adjustAmountByPercentage({
  *   amount: parseUnits("100", 18),
  *   decimals: 18,
- *   percentage: 1n
+ *   percentage: BigInt(1e18),
  *   direction: "up",
  * }) === parseUnits("101")
  * ```


### PR DESCRIPTION
Related to #1226 

This sets a 0.5% threshold for removing liquidity and a 2% threshold for redeeming withdrawal shares.