### PR TITLE
Don't require allowance for previewing Add Liquidity

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
@@ -183,7 +183,6 @@ export function AddLiquidityForm({
     asBase: isBaseActiveToken,
     destination: account,
     ethValue: isActiveTokenEth ? depositAmountAsBigInt : undefined,
-    enabled: hasEnoughAllowance && hasEnoughBalance,
   };
 
   const {
@@ -206,7 +205,9 @@ export function AddLiquidityForm({
   const { addLiquidity, addLiquidityStatus } = useAddLiquidity({
     ...addLiquidityParams,
     enabled:
-      addLiquidityParams.enabled && addLiquidityPreviewStatus === "success",
+      hasEnoughAllowance &&
+      hasEnoughBalance &&
+      addLiquidityPreviewStatus === "success",
     onSubmitted: () => {
       (window as any)["add-lp"].close();
     },

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/usePreviewAddLiquidity.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/usePreviewAddLiquidity.ts
@@ -83,9 +83,9 @@ export function usePreviewAddLiquidity({
           return readHyperdrive.previewAddLiquidity({
             destination,
             contribution: finalContribution,
-            minAPR: minApr,
+            minApr,
             minLpSharePrice,
-            maxAPR: maxApr,
+            maxApr,
             asBase,
           });
         }

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/usePreviewAddLiquidity.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/usePreviewAddLiquidity.ts
@@ -83,9 +83,9 @@ export function usePreviewAddLiquidity({
           return readHyperdrive.previewAddLiquidity({
             destination,
             contribution: finalContribution,
-            minApr,
+            minAPR: minApr,
             minLpSharePrice,
-            maxApr,
+            maxAPR: maxApr,
             asBase,
           });
         }


### PR DESCRIPTION
We use hyperwasm now for the previewAddLiquidity, but were still checking allowances. This PR makes it so you can get a tx preview without approving anything first.

<img width="564" alt="image" src="https://github.com/delvtech/hyperdrive-frontend/assets/4524175/953f4bb0-b36b-4ce7-88f4-cb5e78856271">
