### PR TITLE
Update short rate preview size to 1e15 instead of 1e18

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
@@ -17,7 +17,6 @@ import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { useFixedRate } from "src/ui/hyperdrive/longs/hooks/useFixedRate";
 import { useShortRate } from "src/ui/hyperdrive/shorts/hooks/useShortRate";
 import { useYieldSourceRate } from "src/ui/vaults/useYieldSourceRate";
-import { parseUnits } from "viem";
 interface OpenShortPreviewProps {
   hyperdrive: HyperdriveConfig;
   tokenIn: TokenConfig<any>;
@@ -49,7 +48,7 @@ export function OpenShortPreview({
   const { shortApr, shortRateStatus } = useShortRate({
     // show the market short rate (aka bond amount of 1) if the user hasn't
     // already entered a short size
-    bondAmount: shortSize || parseUnits("1", 18),
+    bondAmount: shortSize || BigInt(1e15),
     hyperdriveAddress: hyperdrive.address,
     timestamp: BigInt(Math.floor(Date.now() / 1000)),
     variableApy: vaultRate?.vaultRate,

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/ShortRateStat.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/ShortRateStat.tsx
@@ -3,7 +3,6 @@ import classNames from "classnames";
 import { ReactElement } from "react";
 import Skeleton from "react-loading-skeleton";
 import { useLocalStorage } from "react-use";
-import { parseUnits } from "src/base/parseUnits";
 import { MultiStat, MultiStatProps } from "src/ui/base/components/MultiStat";
 import { useShortRate } from "src/ui/hyperdrive/shorts/hooks/useShortRate";
 import { useYieldSourceRate } from "src/ui/vaults/useYieldSourceRate";
@@ -24,7 +23,7 @@ export function ShortRateStat({
   });
 
   const { shortApr, shortRoi, shortRateStatus } = useShortRate({
-    bondAmount: parseUnits("1", 18),
+    bondAmount: BigInt(1e15),
     hyperdriveAddress: hyperdrive.address,
     variableApy: vaultRate?.vaultRate ? vaultRate.vaultRate : undefined,
     timestamp: BigInt(Math.floor(Date.now() / 1000)),

--- a/apps/hyperdrive-trading/src/ui/markets/YieldSourceMarketsTable/ShortRateCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/YieldSourceMarketsTable/ShortRateCell.tsx
@@ -3,7 +3,6 @@ import classNames from "classnames";
 import { ReactElement } from "react";
 import { useShortRate } from "src/ui/hyperdrive/shorts/hooks/useShortRate";
 import { useYieldSourceRate } from "src/ui/vaults/useYieldSourceRate";
-import { parseUnits } from "viem";
 
 export function ShortRateCell({
   hyperdrive,
@@ -15,7 +14,7 @@ export function ShortRateCell({
   });
   const { shortApr } = useShortRate({
     hyperdriveAddress: hyperdrive.address,
-    bondAmount: parseUnits("1", hyperdrive.decimals),
+    bondAmount: BigInt(1e15),
     variableApy: vaultRate?.vaultRate,
     timestamp: BigInt(Math.floor(Date.now() / 1000)),
   });


### PR DESCRIPTION
Tuning this better, since 1e18 is a whole eth, which doesn't work well when the steth pool is low on idle liquidity