### PR TITLE
add onClose to `Modal`, use min-width for `TokenInput`

### DIFF
--- a/apps/hyperdrive-trading/src/ui/base/components/Modal/Modal.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/Modal/Modal.tsx
@@ -9,7 +9,7 @@ interface ModalProps {
   className?: string;
   forceOpen?: boolean;
   activeIndex?: number;
-  onClose?: EventListener;
+  onClose?: () => void;
 }
 
 interface ModalChildrenOptions {

--- a/apps/hyperdrive-trading/src/ui/base/components/Modal/Modal.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/Modal/Modal.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import { ReactElement, ReactNode, useRef } from "react";
+import { ReactElement, ReactNode, useEffect, useRef } from "react";
 
 interface ModalProps {
   modalId: string;
@@ -9,6 +9,7 @@ interface ModalProps {
   className?: string;
   forceOpen?: boolean;
   activeIndex?: number;
+  onClose?: EventListener;
 }
 
 interface ModalChildrenOptions {
@@ -23,6 +24,7 @@ export function Modal({
   className,
   forceOpen = false,
   activeIndex,
+  onClose,
 }: ModalProps): ReactElement {
   const modalRef = useRef<HTMLDialogElement>(null);
   function showModal() {
@@ -30,6 +32,22 @@ export function Modal({
   }
 
   const isMultiModal = getIsMultiModal(modalContent, modalHeader, activeIndex);
+
+  useEffect(() => {
+    const modal = modalRef.current;
+
+    if (!modal || !onClose) {
+      return;
+    }
+
+    if (onClose) {
+      modal.addEventListener("close", onClose);
+    }
+
+    return () => {
+      modal.removeEventListener("close", onClose);
+    };
+  }, [onClose, modalRef]);
 
   return (
     <>

--- a/apps/hyperdrive-trading/src/ui/token/TokenInput.tsx
+++ b/apps/hyperdrive-trading/src/ui/token/TokenInput.tsx
@@ -126,7 +126,7 @@ export function TokenInput({
             >
               <Cog6ToothIcon className="h-4" />
             </button>
-            <div className="daisy-menu daisy-dropdown-content absolute right-0 z-[1] w-64 justify-evenly rounded-lg bg-base-100 p-4 shadow">
+            <div className="daisy-menu daisy-dropdown-content absolute right-0 z-[1] min-w-64 justify-evenly rounded-lg bg-base-100 p-4 shadow">
               {settings}
             </div>
           </div>


### PR DESCRIPTION
The Modal component needs an onClose listener for upcoming bridging UI.  Mainly want to make sure that we can reset the modal to the default open long ui when it closes.

Also added a small css tweak to TokenInput to allow it to grow when its contents are larger than w-64.