### PR TITLE
Add status column to chainlog

### DIFF
--- a/apps/hyperdrive-trading/src/registry/data.ts
+++ b/apps/hyperdrive-trading/src/registry/data.ts
@@ -1,0 +1,52 @@
+import { Hex } from "viem";
+
+export const statusById = {
+  "1": "active",
+  "2": "sunset",
+} as const;
+
+/**
+ * An ID used to represent status in the registry.
+ */
+export type StatusId = keyof typeof statusById;
+
+/**
+ * The status of an instance or factory in the registry.
+ */
+export type Status = (typeof statusById)[StatusId];
+
+/**
+ * The decoded data of an instance in the registry.
+ */
+export interface InstanceData {
+  status: Status;
+}
+
+/**
+ * Decodes the `data` field of an instance in the registry according to the
+ * ElementDAO registry schema.
+ */
+export function decodeInstanceData(data: Hex): InstanceData {
+  const statusId = BigInt(data).toString() as StatusId;
+  return {
+    status: statusById[statusId],
+  };
+}
+
+/**
+ * The decoded data of a factory in the registry.
+ */
+export interface FactoryData {
+  status: Status;
+}
+
+/**
+ * Decodes the `data` field of a factory in the registry according to the
+ * ElementDAO registry schema.
+ */
+export function decodeFactoryData(data: Hex): FactoryData {
+  const statusId = BigInt(data).toString() as StatusId;
+  return {
+    status: statusById[statusId],
+  };
+}

--- a/apps/hyperdrive-trading/src/ui/chainlog/PausedCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/chainlog/PausedCell.tsx
@@ -1,0 +1,14 @@
+import classNames from "classnames";
+import { ReactElement } from "react";
+
+export function PausedCell({ isPaused }: { isPaused: boolean }): ReactElement {
+  return (
+    <span
+      className={classNames({
+        "text-error": isPaused,
+      })}
+    >
+      {isPaused.toString()}
+    </span>
+  );
+}

--- a/apps/hyperdrive-trading/src/ui/chainlog/StatusCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/chainlog/StatusCell.tsx
@@ -1,0 +1,16 @@
+import classNames from "classnames";
+import { ReactElement } from "react";
+import { Status } from "src/registry/data";
+
+export function StatusCell({ status }: { status: Status }): ReactElement {
+  return (
+    <span
+      className={classNames({
+        "text-success": status === "active",
+        "text-error": status === "sunset",
+      })}
+    >
+      {status}
+    </span>
+  );
+}


### PR DESCRIPTION
Add a "Status" column to the chainlog tables and some utils for decoding registry data. The utils are added to the UI rather than the SDK because the encoding is specific to the ElementDAO's registry. Another deployment could use a different schema.

closes #1120 