### PR TITLE
Fix bug causing incorrect formatting of rates

### DIFF
--- a/apps/hyperdrive-trading/src/base/formatRate.test.ts
+++ b/apps/hyperdrive-trading/src/base/formatRate.test.ts
@@ -3,8 +3,11 @@ import { parseUnits } from "viem";
 import { expect, test } from "vitest";
 
 test("formatRate should return positive bigints formatted as a percent", async () => {
-  const value = formatRate(parseUnits("1", 18), 18);
+  const value = formatRate(BigInt(1e18), 18);
   expect(value).toEqual("100.00");
+
+  const valueWithCommas = formatRate(BigInt(10e18), 18);
+  expect(valueWithCommas).toEqual("1,000.00");
 
   // rounds down
   const value2 = formatRate(parseUnits("0.056721", 18), 18);
@@ -16,8 +19,11 @@ test("formatRate should return positive bigints formatted as a percent", async (
 });
 
 test("formatRate should return negative bigints formatted as a percent", async () => {
-  const value = formatRate(parseUnits("-1", 18), 18);
+  const value = formatRate(BigInt(-1e18), 18);
   expect(value).toEqual("-100.00");
+
+  const valueWithCommas = formatRate(BigInt(-10e18), 18);
+  expect(valueWithCommas).toEqual("-1,000.00");
 
   // rounds down
   const value2 = formatRate(parseUnits("-1.0281219", 18), 18);

--- a/apps/hyperdrive-trading/src/base/formatRate.ts
+++ b/apps/hyperdrive-trading/src/base/formatRate.ts
@@ -1,3 +1,4 @@
+import { format } from "d3-format";
 import { formatUnits } from "viem";
 
 export function formatRate(rate: bigint, decimals = 18): string {
@@ -5,9 +6,20 @@ export function formatRate(rate: bigint, decimals = 18): string {
   // 0.049999999999999996 * 100 = 5, we just take the first 10 characters after
   // the decimal, and format those to a percent, eg: 0.0499999999 * 100 = 4.99.
   const truncatedAPR = +formatUnits(rate, decimals).slice(0, 10);
-  const formatted = `${Number((100 * truncatedAPR).toFixed(2)).toLocaleString()}`;
-  if (formatted.indexOf(".") === -1) {
-    return `${formatted}.00`;
+
+  function formatter(value: number) {
+    const formatter = format(",.2f");
+    let formattedNumber = formatter(value);
+
+    if (value < 0) {
+      // Replace the minus character with the hyphen-minus character.
+      // D3-format returns negative numbers with a minus character,
+      // which matches what Number.prototype.toString() returns.
+      // However, the minus sign on your keyboard maps to the hyphen-minus
+      // character, and is more useful in tests.
+      formattedNumber = formattedNumber.replace("−", "-");
+    }
+    return formattedNumber;
   }
-  return formatted;
+  return formatter(truncatedAPR * 100);
 }


### PR DESCRIPTION
Refactor formatRate to use d3-format instead of toLocaleString(). This fixes an issue where users were seeing weird rate formatting, (they use `,` instead of `.` in other languages)

