### PR TITLE
Fix primary stat spacing

### DIFF
--- a/apps/hyperdrive-trading/src/ui/base/components/PrimaryStat.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/PrimaryStat.tsx
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import { ReactNode } from "react";
 
 export function PrimaryStat({
@@ -6,15 +7,22 @@ export function PrimaryStat({
   valueUnit,
   subValue,
   valueClassName,
+  alignment,
 }: {
   label: string;
   value: ReactNode;
   valueUnit: string;
   subValue?: ReactNode;
   valueClassName?: string;
+  alignment?: "left" | "right";
 }): JSX.Element {
   return (
-    <div className="flex flex-col gap-1">
+    <div
+      className={classNames("flex flex-col gap-1", {
+        "text-left": alignment === "left",
+        "text-right": alignment === "right",
+      })}
+    >
       <p className="text-sm text-neutral-content">{label}</p>
       <div className={valueClassName}>
         <p className="text-h3 font-bold">{value}</p>

--- a/apps/hyperdrive-trading/src/ui/base/components/PrimaryStat.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/PrimaryStat.tsx
@@ -7,22 +7,15 @@ export function PrimaryStat({
   valueUnit,
   subValue,
   valueClassName,
-  alignment,
 }: {
   label: string;
   value: ReactNode;
   valueUnit: string;
   subValue?: ReactNode;
   valueClassName?: string;
-  alignment?: "left" | "right";
 }): JSX.Element {
   return (
-    <div
-      className={classNames("flex flex-col gap-1", {
-        "text-left": alignment === "left",
-        "text-right": alignment === "right",
-      })}
-    >
+    <div className={classNames("flex flex-col gap-1")}>
       <p className="text-sm text-neutral-content">{label}</p>
       <div className={valueClassName}>
         <p className="text-h3 font-bold">{value}</p>

--- a/apps/hyperdrive-trading/src/ui/base/components/PrimaryStat.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/PrimaryStat.tsx
@@ -1,4 +1,3 @@
-import classNames from "classnames";
 import { ReactNode } from "react";
 
 export function PrimaryStat({
@@ -15,7 +14,7 @@ export function PrimaryStat({
   valueClassName?: string;
 }): JSX.Element {
   return (
-    <div className={classNames("flex flex-col gap-1")}>
+    <div className="flex flex-col gap-1">
       <p className="text-sm text-neutral-content">{label}</p>
       <div className={valueClassName}>
         <p className="text-h3 font-bold">{value}</p>

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/TransactionView.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/TransactionView.tsx
@@ -22,18 +22,20 @@ export function TransactionView({
   actionButton,
 }: TransactionViewProps): ReactElement {
   return (
-    <div className="flex w-full flex-col gap-4">
+    <div className="flex w-full flex-col">
       {heading !== undefined && <h5>{heading}</h5>}
       <div>
         {tokenInput}
         {setting}
       </div>
-      <div className="flex flex-col gap-8">
+      <div className="flex flex-col">
         {primaryStats}
-        <div className="text-center">{actionButton}</div>
-        {disclaimer ? <div>{disclaimer}</div> : null}
+        <div className="flex flex-col gap-4">
+          <div className="text-center">{actionButton}</div>
+          {disclaimer ? <div>{disclaimer}</div> : null}
+          {transactionPreview}
+        </div>
       </div>
-      {transactionPreview}
     </div>
   );
 }

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongModal/OpenLongModal.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongModal/OpenLongModal.tsx
@@ -1,4 +1,3 @@
-import { XMarkIcon } from "@heroicons/react/24/solid";
 import { HyperdriveConfig } from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
 import { Modal } from "src/ui/base/components/Modal/Modal";
@@ -41,7 +40,7 @@ export function OpenLongModalHeader(): ReactElement {
   return (
     <ModalHeader
       heading="Open a Long"
-      subHeading="Buy the fixed rate and know your exact yield up front"
+      subHeading="Lock in a fixed rate and know your exact yield upfront"
     />
   );
 }
@@ -53,16 +52,9 @@ interface OpenLongModalFormProps {
 
 export function OpenLongModalForm({
   hyperdrive,
-  closeModal,
 }: OpenLongModalFormProps): ReactElement {
   return (
     <div>
-      <button
-        className="daisy-btn daisy-btn-circle daisy-btn-ghost daisy-btn-sm absolute right-4 top-4"
-        onClick={closeModal}
-      >
-        <XMarkIcon className="w-6 " title="Close position" />
-      </button>
       <OpenLongForm
         hyperdrive={hyperdrive}
         onOpenLong={(e) => {

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongStats.tsx
@@ -65,7 +65,7 @@ export function OpenLongStats({
   const termLengthMS = Number(hyperdrive.poolConfig.positionDuration * 1000n);
   const numDays = convertMillisecondsToDays(termLengthMS);
   return (
-    <div className="flex flex-row justify-between px-4">
+    <div className="flex flex-row justify-between px-4 py-8">
       <PrimaryStat
         label="Your Fixed Rate"
         value={

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongStats.tsx
@@ -88,7 +88,6 @@ export function OpenLongStats({
           )
         }
         valueUnit="APR"
-        alignment="left"
         subValue={
           openLongPreviewStatus === "loading" ? (
             <Skeleton width={100} />
@@ -128,7 +127,6 @@ export function OpenLongStats({
         }
         valueUnit={`${baseToken.symbol}`}
         valueClassName="text-base-content flex items-end"
-        alignment="right"
         subValue={
           // Defillama fetches the token price via {chain}:{tokenAddress}. Since the token address differs on testnet, term length is displayed instead.
 

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongStats.tsx
@@ -88,6 +88,7 @@ export function OpenLongStats({
           )
         }
         valueUnit="APR"
+        alignment="left"
         subValue={
           openLongPreviewStatus === "loading" ? (
             <Skeleton width={100} />
@@ -127,6 +128,7 @@ export function OpenLongStats({
         }
         valueUnit={`${baseToken.symbol}`}
         valueClassName="text-base-content flex items-end"
+        alignment="right"
         subValue={
           // Defillama fetches the token price via {chain}:{tokenAddress}. Since the token address differs on testnet, term length is displayed instead.
 


### PR DESCRIPTION
This PR fixes some of the spacing on the primary stats. A couple more details are aligned with the design in the figma. Removing the close modal button and updating some copy. There is some additional padding around the modal, but I think it's okay to leave this until all the position forms are updated and we can fix it all at once in the modal component.
![Screenshot 2024-07-30 at 5 19 43 PM](https://github.com/user-attachments/assets/e91a6ae8-ecb9-48ff-b2d9-d5b326a460be)
