### PR TITLE
Remove double percantages

### DIFF
--- a/apps/hyperdrive-trading/src/ui/base/components/PrimaryStat.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/PrimaryStat.tsx
@@ -18,7 +18,7 @@ export function PrimaryStat({
       <p className="text-sm text-neutral-content">{label}</p>
       <div className={valueClassName}>
         <p className="text-h3 font-bold">{value}</p>
-        <p className="ml-1">{valueUnit}</p>
+        <p>{valueUnit}</p>
       </div>
       {subValue && <p className="text-sm text-neutral-content">{subValue}</p>}
     </div>

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongPreview.tsx
@@ -119,7 +119,7 @@ export function OpenLongPreview({
               >
                 {spotRateAfterOpen ? (
                   <span className="flex gap-2">
-                    <span className="text-base-content/80">{`${fixedApr?.formatted} `}</span>
+                    <span className="text-base-content/80">{`${fixedApr?.formatted}`}</span>
                     <ArrowRightIcon className="h-4 text-neutral-content" />
                     {formatRate(spotRateAfterOpen)}
                   </span>

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongPreview.tsx
@@ -119,9 +119,9 @@ export function OpenLongPreview({
               >
                 {spotRateAfterOpen ? (
                   <span className="flex gap-2">
-                    <span className="text-base-content/80">{`${fixedApr?.formatted}% `}</span>
+                    <span className="text-base-content/80">{`${fixedApr?.formatted} `}</span>
                     <ArrowRightIcon className="h-4 text-neutral-content" />
-                    {formatRate(spotRateAfterOpen)}%
+                    {formatRate(spotRateAfterOpen)}
                   </span>
                 ) : (
                   "-"
@@ -168,5 +168,5 @@ function getMarketImpactLabel(
   if (isChangeInFixedAprLessThanOneBasisPoint) {
     return "-<0.01%";
   }
-  return `-${formatRate(changeInFixedApr)}%`;
+  return `-${formatRate(changeInFixedApr)}`;
 }

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongStats.tsx
@@ -82,8 +82,8 @@ export function OpenLongStats({
                       bondAmount: bondAmount,
                     }),
                     baseToken.decimals,
-                  )}%`
-                : `${fixedApr?.formatted}%`}
+                  )}`
+                : `${fixedApr?.formatted}`}
             </>
           )
         }

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityModalButton/AddLiquidityModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityModalButton/AddLiquidityModalButton.tsx
@@ -82,7 +82,7 @@ export function AddLiquidityModalButton({
                 horizontal
                 size="small"
                 label={`${yieldSourceToken.extensions.shortName}:`}
-                value={`${vaultRate?.formatted || 0n}s`}
+                value={`${vaultRate?.formatted || 0n}`}
               />
             </div>
           </div>

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityModalButton/AddLiquidityModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityModalButton/AddLiquidityModalButton.tsx
@@ -82,7 +82,7 @@ export function AddLiquidityModalButton({
                 horizontal
                 size="small"
                 label={`${yieldSourceToken.extensions.shortName}:`}
-                value={`${vaultRate?.formatted || 0n}%`}
+                value={`${vaultRate?.formatted || 0n}s`}
               />
             </div>
           </div>

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
@@ -140,7 +140,7 @@ export function OpenShortPreview({
                 "text-error": shortApr && shortApr.apr < 0n,
               })}
             >
-              {shortApr ? `${shortApr.formatted}%` : "-"}
+              {shortApr ? `${shortApr.formatted}` : "-"}
             </span>
           )
         }
@@ -160,9 +160,9 @@ export function OpenShortPreview({
               >
                 {spotRateAfterOpen ? (
                   <span className="flex gap-2 text-base-content">
-                    <span className="text-base-content/80">{`${fixedApr?.formatted}% `}</span>
+                    <span className="text-base-content/80">{`${fixedApr?.formatted} `}</span>
                     <ArrowRightIcon className="h-4 text-neutral-content" />
-                    {formatRate(spotRateAfterOpen)}%
+                    {formatRate(spotRateAfterOpen)}
                   </span>
                 ) : (
                   "-"

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/FixedRateStat.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/FixedRateStat.tsx
@@ -43,7 +43,7 @@ export function FixedRateStat({
               <Skeleton className="w-20" />
             ) : (
               <span className={rateClassName}>
-                {fixedApr?.formatted || "0"}%
+                {fixedApr?.formatted || "0"}
               </span>
             ),
 
@@ -59,7 +59,7 @@ export function FixedRateStat({
               <Skeleton className="w-20" />
             ) : (
               <span className={rateClassName}>
-                {fixedRoi?.formatted || "0"}%
+                {fixedRoi?.formatted || "0"}
               </span>
             ),
 

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/ShortRateStat.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/ShortRateStat.tsx
@@ -55,7 +55,7 @@ export function ShortRateStat({
             <Skeleton className="w-20" />
           ) : (
             <span className={rateClassName}>
-              {shortApr?.formatted ? `${shortApr.formatted}%` : "-"}
+              {shortApr?.formatted ? `${shortApr.formatted}` : "-"}
             </span>
           ),
         },
@@ -69,7 +69,7 @@ export function ShortRateStat({
             <Skeleton className="w-20" />
           ) : (
             <span className={rateClassName}>
-              {shortRoi?.formatted ? `${shortRoi.formatted}%` : "-"}
+              {shortRoi?.formatted ? `${shortRoi.formatted}` : "-"}
             </span>
           ),
         },

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/YieldStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/YieldStats.tsx
@@ -37,7 +37,7 @@ export function YieldStats({
             <YieldSourceRateBadge
               hyperdriveAddress={hyperdrive.address}
               labelRenderer={(vaultRate) =>
-                `${sharesToken.extensions.shortName} @ ${vaultRate.formatted || 0} % APY`
+                `${sharesToken.extensions.shortName} @ ${vaultRate.formatted || 0} APY`
               }
             />
           </div>

--- a/apps/hyperdrive-trading/src/ui/markets/YieldSourceMarketsTable/ShortRateCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/YieldSourceMarketsTable/ShortRateCell.tsx
@@ -27,7 +27,7 @@ export function ShortRateCell({
           "text-error": (shortApr?.apr || 0n) < 0n,
         })}
       >
-        {shortApr ? `${shortApr.formatted}%` : "-"}
+        {shortApr ? `${shortApr.formatted}` : "-"}
       </span>
     </div>
   );

--- a/apps/hyperdrive-trading/src/ui/markets/YieldSourceMarketsTable/YieldSourceMarketsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/YieldSourceMarketsTable/YieldSourceMarketsTableDesktop.tsx
@@ -175,7 +175,7 @@ function getColumns(appConfig: AppConfig) {
         const fixedRate = getValue();
         return (
           <span key="fixed-rate" className="lg:flex lg:w-20 lg:justify-end">
-            {formatRate(fixedRate)}%
+            {formatRate(fixedRate)}
           </span>
         );
       },

--- a/apps/hyperdrive-trading/src/ui/vaults/YieldSourceRateBadge.tsx
+++ b/apps/hyperdrive-trading/src/ui/vaults/YieldSourceRateBadge.tsx
@@ -40,7 +40,7 @@ export function YieldSourceRateBadge({
         ) : (
           <>
             Variable APY @{" "}
-            <span className="text-base-content">{vaultRate?.formatted}%</span>
+            <span className="text-base-content">{vaultRate?.formatted}</span>
           </>
         )}
       </span>


### PR DESCRIPTION
This PR removes the extra percentage sign as the sign is already provided by fixed-point-wasm! I'm pretty sure I got them all but let me know if you see any others.

Before:
![Screenshot 2024-07-31 at 1 15 52 PM](https://github.com/user-attachments/assets/0b784f95-8113-42fb-875f-37de2f0e6cf6)
After:
![Screenshot 2024-07-31 at 1 15 28 PM](https://github.com/user-attachments/assets/98a448b1-545c-4c55-a636-a440cc865924)
