### PR TITLE
Replace `break` with `return` in `forEach`

### DIFF
--- a/packages/hyperdrive-js-core/src/hyperdrive/base/ReadHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/base/ReadHyperdrive.ts
@@ -744,7 +744,7 @@ export class ReadHyperdrive extends ReadModel {
             baseAmountPaid: long.baseAmountPaid + baseAmount,
             bondAmount: long.bondAmount + event.args.bondAmount,
           };
-          break;
+          return;
 
         case "CloseLong":
           // If a user closes their whole position, we should remove the whole
@@ -760,7 +760,7 @@ export class ReadHyperdrive extends ReadModel {
               bondAmount: long.bondAmount - event.args.bondAmount,
             };
           }
-          break;
+          return;
 
         default:
           assertNever(event, true);
@@ -1375,7 +1375,7 @@ export class ReadHyperdrive extends ReadModel {
         case "AddLiquidity":
           lpShareBalance += event.args.lpAmount;
           baseAmountPaid += baseAmount;
-          break;
+          return;
 
         case "RemoveLiquidity":
           lpShareBalance -= event.args.lpAmount;
@@ -1384,7 +1384,7 @@ export class ReadHyperdrive extends ReadModel {
           // baseAmountPaid, since it's basically starting over
           baseAmountPaid =
             lpShareBalance <= 0n ? 0n : baseAmountPaid - baseAmount;
-          break;
+          return;
 
         default:
           assertNever(event, true);


### PR DESCRIPTION
Reverts a change made in #1306.

My `biome` extension was enabled when I started the PR and showing errors about using `forEach` over `for..of`, so I ran the format fix to see if the changes would be minor. They weren't, so I reverted the changes and disabled the extension, but these `break`s snuck in some how.