### PR TITLE
Change vaultApy and lpApy to use the same calculation method

### DIFF
--- a/apps/hyperdrive-trading/src/base/formatRate.ts
+++ b/apps/hyperdrive-trading/src/base/formatRate.ts
@@ -6,6 +6,5 @@ export function formatRate(rate: bigint, decimals = 18): string {
   return `${sign}${fixed(abs, decimals).format({
     percent: true,
     decimals: 2,
-    rounding: "trunc",
   })}`;
 }

--- a/apps/hyperdrive-trading/src/hyperdrive/getYieldSourceRate.ts
+++ b/apps/hyperdrive-trading/src/hyperdrive/getYieldSourceRate.ts
@@ -3,16 +3,16 @@ import { Block, ReadHyperdrive } from "@delvtech/hyperdrive-viem";
 export async function getYieldSourceRate(
   readHyperdrive: ReadHyperdrive,
 ): Promise<bigint> {
-  // 2 days ago in blocks
-  const twoDaysInBlocks = 172800n / 12n;
+  // 1 day ago in blocks
+  const oneDayInBlocks = 86400n / 12n;
 
   return (
     readHyperdrive
       .getYieldSourceRate({
-        blockRange: twoDaysInBlocks,
+        blockRange: oneDayInBlocks,
       })
-      // If the 48 hour rate doesn't exist, assume the pool was initialized less
-      // than 48 hours ago and try to get the all-time rate
+      // If the 24 hour rate doesn't exist, assume the pool was initialized less
+      // than 24 hours ago and try to get the all-time rate
       .catch(async () => {
         const currentBlock = (await readHyperdrive.network.getBlock()) as Block;
         const initializationBlock =

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useLpApy.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useLpApy.ts
@@ -23,12 +23,11 @@ export function useLpApy(hyperdriveAddress: Address): {
     queryFn: queryEnabled
       ? async () =>
           readHyperdrive.getLpApy({
-            // If on devnet, start from block 1, otherwise start from 7 days ago
+            // If on devnet, start from block 1, otherwise start from 1 day ago
             // TODO: Update this on mainnet and testnet according to average daily blocks
             fromBlock: [31337, 42069].includes(chainId)
               ? 1n
-              : blockNumber - 7000n * 7n,
-            toBlock: blockNumber,
+              : blockNumber - 86400n / 12n, // 1 day, 12 seconds per block
           })
       : undefined,
     enabled: queryEnabled,

--- a/packages/hyperdrive-js-core/src/hyperdrive/base/ReadHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/base/ReadHyperdrive.ts
@@ -2020,8 +2020,5 @@ function calculateApyFromSharePrice({
 }): bigint {
   const priceRatio = fixed(endingSharePrice).div(startingSharePrice);
   const yearFraction = fixed(timeFrame).div(SECONDS_PER_YEAR);
-  return priceRatio
-    .pow(fixed(1e18).div(yearFraction))
-    .sub(fixed(1e18))
-    .toNumber();
+  return priceRatio.pow(fixed(1e18).div(yearFraction)).sub(fixed(1e18)).bigint;
 }

--- a/packages/hyperdrive-js-core/src/hyperdrive/base/ReadHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/base/ReadHyperdrive.ts
@@ -21,7 +21,7 @@ import {
 import { HyperdriveSdkError } from "src/errors/HyperdriveSdkError";
 import { getBlockFromReadOptions } from "src/evm-client/utils/getBlockFromReadOptions";
 import { getBlockOrThrow } from "src/evm-client/utils/getBlockOrThrow";
-import { fixed, ln } from "src/fixed-point";
+import { fixed } from "src/fixed-point";
 import { HyperdriveAbi, hyperdriveAbi } from "src/hyperdrive/base/abi";
 import { MAX_ITERATIONS, NULL_BYTES } from "src/hyperdrive/constants";
 import { calculateAprFromPrice } from "src/hyperdrive/utils/calculateAprFromPrice";
@@ -2024,6 +2024,7 @@ export class ReadHyperdrive extends ReadModel {
  * t = term length in fractions of a year
  *
  * r = ln(p_1 / p_0) / t
+ * r = (p_1 / p_0) ^ (1 / t) - 1
  */
 function calculateLpApy({
   startingLpSharePrice,
@@ -2036,5 +2037,11 @@ function calculateLpApy({
 }): number {
   const priceRatio = fixed(endingLpSharePrice).div(startingLpSharePrice);
   const yearFraction = fixed(timeFrame).div(SECONDS_PER_YEAR);
-  return ln(priceRatio).div(yearFraction).toNumber();
+  return priceRatio
+    .pow(fixed(1e18).div(yearFraction))
+    .sub(fixed(1e18))
+    .toNumber();
+  // const priceRatio = fixed(endingLpSharePrice).div(startingLpSharePrice);
+  // const yearFraction = fixed(timeFrame).div(SECONDS_PER_YEAR);
+  // return ln(priceRatio).div(yearFraction).toNumber();
 }


### PR DESCRIPTION
## Problem
LP APY and Variable APY differ significantly from each other, even in markets with no open long/short positions.

## Explanation
LP APY looks at `lpSharePrice` on a checkpoint-by-checkpoint basis, within a 7-day timeframe.
Yield Source APY looks at `vaultSharePrice` on a block-by-block basis, within a 2-day timeframe.

This difference in methods and time frames results in different rates.

## Solution
This PR changes both to update on a block-by-block basis, within a 1-day timeframe

<img width="842" alt="Hyperdrive_-_DeFi_Yield__your_way" src="https://github.com/user-attachments/assets/d25f7ea4-6a3d-4584-aa03-7aca22f9db09">

<img width="818" alt="Hyperdrive_-_DeFi_Yield__your_way" src="https://github.com/user-attachments/assets/b4f2458c-b91f-4d6d-b3ef-0371cf83e549">
