### PR TITLE
Add chainId field to HyperdriveConfig and TokenConfig

### DIFF
--- a/apps/hyperdrive-trading/src/ui/bridge/BridgeAssetsForm/BridgeAssetsForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/bridge/BridgeAssetsForm/BridgeAssetsForm.tsx
@@ -79,6 +79,7 @@ export function BridgeAssetsForm({
       return {
         tokenConfig: {
           address: token.addresses[destinationChainId],
+          chainId: destinationChainId,
           name: token.name,
           symbol: token.symbol,
           decimals: token.decimals,

--- a/packages/hyperdrive-appconfig/src/appconfig/getAppConfig.ts
+++ b/packages/hyperdrive-appconfig/src/appconfig/getAppConfig.ts
@@ -120,7 +120,6 @@ export async function getAppConfig({
         const { sharesToken, baseToken, hyperdriveConfig } =
           await getStethHyperdrive({
             hyperdrive,
-            chainId,
           });
 
         tokens.push(sharesToken);

--- a/packages/hyperdrive-appconfig/src/generated/1.appconfig.ts
+++ b/packages/hyperdrive-appconfig/src/generated/1.appconfig.ts
@@ -3,6 +3,7 @@ export const mainnetAppConfig: AppConfig = {
   chainId: 1,
   tokens: [
     {
+      chainId: 1,
       address: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
       decimals: 18,
       places: 2,
@@ -14,6 +15,7 @@ export const mainnetAppConfig: AppConfig = {
       extensions: {},
     },
     {
+      chainId: 1,
       address: "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
       decimals: 18,
       places: 4,
@@ -25,6 +27,7 @@ export const mainnetAppConfig: AppConfig = {
     },
     {
       address: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+      chainId: 1,
       name: "Ether",
       symbol: "ETH",
       decimals: 18,
@@ -34,17 +37,7 @@ export const mainnetAppConfig: AppConfig = {
       iconUrl: "https://cryptologos.cc/logos/ethereum-eth-logo.png?v=029",
     },
     {
-      address: "0xae78736Cd615f374D3085123A210448E74Fc6393",
-      decimals: 18,
-      places: 4,
-      name: "Rocket Pool ETH",
-      symbol: "rETH",
-      iconUrl:
-        "https://cryptologos.cc/logos/rocket-pool-eth-reth-logo.svg?v=031",
-      tags: ["liquidStakingToken"],
-      extensions: {},
-    },
-    {
+      chainId: 1,
       address: "0xbf5495Efe5DB9ce00f80364C8B423567e58d2110",
       decimals: 18,
       places: 4,
@@ -56,6 +49,19 @@ export const mainnetAppConfig: AppConfig = {
       extensions: {},
     },
     {
+      chainId: 1,
+      address: "0xae78736Cd615f374D3085123A210448E74Fc6393",
+      decimals: 18,
+      places: 4,
+      name: "Rocket Pool ETH",
+      symbol: "rETH",
+      iconUrl:
+        "https://cryptologos.cc/logos/rocket-pool-eth-reth-logo.svg?v=031",
+      tags: ["liquidStakingToken"],
+      extensions: {},
+    },
+    {
+      chainId: 1,
       address: "0x83F20F44975D03b1b09e64809B757c47f942BEeA",
       decimals: 18,
       places: 2,
@@ -69,6 +75,7 @@ export const mainnetAppConfig: AppConfig = {
   registryAddress: "0xbe082293b646cb619a638d29e8eff7cf2f46aa3a",
   hyperdrives: [
     {
+      chainId: 1,
       address: "0xd7e470043241C10970953Bd8374ee6238e77D735",
       version: "v1.0.13",
       name: "182d Lido stETH",
@@ -108,6 +115,7 @@ export const mainnetAppConfig: AppConfig = {
       },
     },
     {
+      chainId: 1,
       address: "0x324395D5d835F84a02A75Aa26814f6fD22F25698",
       version: "v1.0.13",
       name: "182d Maker DSR",
@@ -147,6 +155,7 @@ export const mainnetAppConfig: AppConfig = {
       },
     },
     {
+      chainId: 1,
       address: "0xca5dB9Bb25D09A9bF3b22360Be3763b5f2d13589",
       version: "v1.0.15",
       name: "182d Rocket Pool ETH",
@@ -186,6 +195,7 @@ export const mainnetAppConfig: AppConfig = {
       },
     },
     {
+      chainId: 1,
       address: "0xd41225855A5c5Ba1C672CcF4d72D1822a5686d30",
       version: "v1.0.17",
       name: "182d Morpho sUSDe/DAI",
@@ -225,6 +235,7 @@ export const mainnetAppConfig: AppConfig = {
       },
     },
     {
+      chainId: 1,
       address: "0xA29A771683b4857bBd16e1e4f27D5B6bfF53209B",
       version: "v1.0.17",
       name: "182d Morpho USDe/DAI",
@@ -264,6 +275,7 @@ export const mainnetAppConfig: AppConfig = {
       },
     },
     {
+      chainId: 1,
       address: "0x4c3054e51b46BE3191be9A05e73D73F1a2147854",
       version: "v1.0.15",
       name: "182d Renzo ezETH",

--- a/packages/hyperdrive-appconfig/src/generated/11155111.appconfig.ts
+++ b/packages/hyperdrive-appconfig/src/generated/11155111.appconfig.ts
@@ -3,6 +3,7 @@ export const sepoliaAppConfig: AppConfig = {
   chainId: 11155111,
   tokens: [
     {
+      chainId: 11155111,
       address: "0xe8b99bF4249D90C0eB900651F92485F7160A0513",
       decimals: 18,
       places: 2,
@@ -14,6 +15,7 @@ export const sepoliaAppConfig: AppConfig = {
       extensions: {},
     },
     {
+      chainId: 11155111,
       address: "0x7c485f458aD1F32FF66BC45306fd32974C963c32",
       decimals: 18,
       places: 4,
@@ -25,6 +27,7 @@ export const sepoliaAppConfig: AppConfig = {
     },
     {
       address: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+      chainId: 11155111,
       name: "Ether",
       symbol: "ETH",
       decimals: 18,
@@ -34,17 +37,7 @@ export const sepoliaAppConfig: AppConfig = {
       iconUrl: "https://cryptologos.cc/logos/ethereum-eth-logo.png?v=029",
     },
     {
-      address: "0xDD0D63E304F3D9d9E54d8945bE95011867c80E4f",
-      decimals: 18,
-      places: 4,
-      name: "Renzo ezETH",
-      symbol: "ezETH",
-      iconUrl:
-        "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjIwMiIgdmlld0JveD0iMCAwIDIwMCAyMDIiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxyZWN0IHdpZHRoPSIyMDAiIGhlaWdodD0iMTk4LjM2NCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMCAyKSIgZmlsbD0iIzA4MEIxQiIvPgo8ZyBmaWx0ZXI9InVybCgjZmlsdGVyMF9kZF83N180MykiPgo8cGF0aCBkPSJNMTAwLjExMSA0NC4xMjA0TDk5LjM0ODMgNDYuNzEzMUw5OS4zNDgzIDEyMS45NDFMMTAwLjExMSAxMjIuNzAyTDEzNC45NzggMTAyLjA2MUwxMDAuMTExIDQ0LjEyMDRaIiBmaWxsPSIjNkI2QjZCIi8+CjxwYXRoIGQ9Ik0xMDAuMTExIDQ0LjEyMDRMNjUuMjQxNyAxMDIuMDYxTDEwMC4xMTEgMTIyLjcwMkwxMDAuMTExIDg2LjE4ODlMMTAwLjExMSA0NC4xMjA0WiIgZmlsbD0iI0EyQTJBMiIvPgo8cGF0aCBkPSJNMTAwLjExMSAxMjkuMzE0TDk5LjY4MDkgMTI5LjgzOEw5OS42ODA5IDE1Ni42MzZMMTAwLjExMSAxNTcuODkyTDEzNSAxMDguNjgzTDEwMC4xMTEgMTI5LjMxNFoiIGZpbGw9IiM0RjRFNEUiLz4KPHBhdGggZD0iTTEwMC4xMTEgMTU3Ljg5MkwxMDAuMTExIDEyOS4zMTRMNjUuMjQxNyAxMDguNjgzTDEwMC4xMTEgMTU3Ljg5MloiIGZpbGw9IiNBMkEyQTIiLz4KPHBhdGggZD0iTTEwMC4xMTEgMTIyLjcwMkwxMzQuOTc4IDEwMi4wNjFMMTAwLjExMSA4Ni4xODg5TDEwMC4xMTEgMTIyLjcwMloiIGZpbGw9IiM3OTc5NzkiLz4KPHBhdGggZD0iTTY1LjI0MTcgMTAyLjA2MUwxMDAuMTExIDEyMi43MDJMMTAwLjExMSA4Ni4xODg5TDY1LjI0MTcgMTAyLjA2MVoiIGZpbGw9IiNENEQ0RDQiLz4KPGcgc3R5bGU9Im1peC1ibGVuZC1tb2RlOm92ZXJsYXkiPgo8cGF0aCBkPSJNMTAwLjExIDQ0LjEyMDRMOTkuMzQ4MyA0Ni43MTMxTDk5LjM0ODMgMTIxLjk0MUwxMDAuMTEgMTIyLjcwMkwxMzQuOTc4IDEwMi4wNjFMMTAwLjExIDQ0LjEyMDRaIiBmaWxsPSIjQUNFNzMwIi8+CjxwYXRoIGQ9Ik0xMDAuMTEgNDQuMTIwNEw2NS4yNDE3IDEwMi4wNjFMMTAwLjExIDEyMi43MDJMMTAwLjExIDg2LjE4ODlMMTAwLjExIDQ0LjEyMDRaIiBmaWxsPSIjQUNFNzMwIi8+CjxwYXRoIGQ9Ik0xMDAuMTExIDEyOS4zMTRMOTkuNjgwOSAxMjkuODM4TDk5LjY4MDkgMTU2LjYzNkwxMDAuMTExIDE1Ny44OTJMMTM1IDEwOC42ODNMMTAwLjExMSAxMjkuMzE0WiIgZmlsbD0iI0FDRTczMCIvPgo8cGF0aCBkPSJNMTAwLjExMSAxNTcuODkyTDEwMC4xMTEgMTI5LjMxNEw2NS4yNDE3IDEwOC42ODNMMTAwLjExMSAxNTcuODkyWiIgZmlsbD0iI0FDRTczMCIvPgo8cGF0aCBkPSJNMTAwLjExIDEyMi43MDJMMTM0Ljk3OCAxMDIuMDYxTDEwMC4xMSA4Ni4xODg5TDEwMC4xMSAxMjIuNzAyWiIgZmlsbD0iI0FDRTczMCIvPgo8cGF0aCBkPSJNNjUuMjQxNyAxMDIuMDYxTDEwMC4xMSAxMjIuNzAyTDEwMC4xMSA4Ni4xODg5TDY1LjI0MTcgMTAyLjA2MVoiIGZpbGw9IiNBQ0U3MzAiLz4KPC9nPgo8L2c+CjxkZWZzPgo8ZmlsdGVyIGlkPSJmaWx0ZXIwX2RkXzc3XzQzIiB4PSIyMS4yMTMxIiB5PSIwLjA5MTgwMDciIHdpZHRoPSIxNTcuODE1IiBoZWlnaHQ9IjIwMS44MjgiIGZpbHRlclVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgY29sb3ItaW50ZXJwb2xhdGlvbi1maWx0ZXJzPSJzUkdCIj4KPGZlRmxvb2QgZmxvb2Qtb3BhY2l0eT0iMCIgcmVzdWx0PSJCYWNrZ3JvdW5kSW1hZ2VGaXgiLz4KPGZlQ29sb3JNYXRyaXggaW49IlNvdXJjZUFscGhhIiB0eXBlPSJtYXRyaXgiIHZhbHVlcz0iMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMTI3IDAiIHJlc3VsdD0iaGFyZEFscGhhIi8+CjxmZU9mZnNldC8+CjxmZUdhdXNzaWFuQmx1ciBzdGREZXZpYXRpb249IjEwLjY3MjUiLz4KPGZlQ29tcG9zaXRlIGluMj0iaGFyZEFscGhhIiBvcGVyYXRvcj0ib3V0Ii8+CjxmZUNvbG9yTWF0cml4IHR5cGU9Im1hdHJpeCIgdmFsdWVzPSIwIDAgMCAwIDAuNjc0NTEgMCAwIDAgMCAwLjkwNTg4MiAwIDAgMCAwIDAuMTg4MjM1IDAgMCAwIDAuNSAwIi8+CjxmZUJsZW5kIG1vZGU9Im5vcm1hbCIgaW4yPSJCYWNrZ3JvdW5kSW1hZ2VGaXgiIHJlc3VsdD0iZWZmZWN0MV9kcm9wU2hhZG93Xzc3XzQzIi8+CjxmZUNvbG9yTWF0cml4IGluPSJTb3VyY2VBbHBoYSIgdHlwZT0ibWF0cml4IiB2YWx1ZXM9IjAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDEyNyAwIiByZXN1bHQ9ImhhcmRBbHBoYSIvPgo8ZmVPZmZzZXQvPgo8ZmVHYXVzc2lhbkJsdXIgc3RkRGV2aWF0aW9uPSIyMi4wMTQzIi8+CjxmZUNvbXBvc2l0ZSBpbjI9ImhhcmRBbHBoYSIgb3BlcmF0b3I9Im91dCIvPgo8ZmVDb2xvck1hdHJpeCB0eXBlPSJtYXRyaXgiIHZhbHVlcz0iMCAwIDAgMCAwLjY3NDUxIDAgMCAwIDAgMC45MDU4ODIgMCAwIDAgMCAwLjE4ODIzNSAwIDAgMCAxIDAiLz4KPGZlQmxlbmQgbW9kZT0ibm9ybWFsIiBpbjI9ImVmZmVjdDFfZHJvcFNoYWRvd183N180MyIgcmVzdWx0PSJlZmZlY3QyX2Ryb3BTaGFkb3dfNzdfNDMiLz4KPGZlQmxlbmQgbW9kZT0ibm9ybWFsIiBpbj0iU291cmNlR3JhcGhpYyIgaW4yPSJlZmZlY3QyX2Ryb3BTaGFkb3dfNzdfNDMiIHJlc3VsdD0ic2hhcGUiLz4KPC9maWx0ZXI+CjwvZGVmcz4KPC9zdmc+Cg==",
-      tags: ["liquidStakingToken"],
-      extensions: {},
-    },
-    {
+      chainId: 11155111,
       address: "0x4713c86d0e467064A4CD2a974b7fDA79F7efc338",
       decimals: 18,
       places: 4,
@@ -56,6 +49,19 @@ export const sepoliaAppConfig: AppConfig = {
       extensions: {},
     },
     {
+      chainId: 11155111,
+      address: "0xDD0D63E304F3D9d9E54d8945bE95011867c80E4f",
+      decimals: 18,
+      places: 4,
+      name: "Renzo ezETH",
+      symbol: "ezETH",
+      iconUrl:
+        "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjIwMiIgdmlld0JveD0iMCAwIDIwMCAyMDIiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxyZWN0IHdpZHRoPSIyMDAiIGhlaWdodD0iMTk4LjM2NCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMCAyKSIgZmlsbD0iIzA4MEIxQiIvPgo8ZyBmaWx0ZXI9InVybCgjZmlsdGVyMF9kZF83N180MykiPgo8cGF0aCBkPSJNMTAwLjExMSA0NC4xMjA0TDk5LjM0ODMgNDYuNzEzMUw5OS4zNDgzIDEyMS45NDFMMTAwLjExMSAxMjIuNzAyTDEzNC45NzggMTAyLjA2MUwxMDAuMTExIDQ0LjEyMDRaIiBmaWxsPSIjNkI2QjZCIi8+CjxwYXRoIGQ9Ik0xMDAuMTExIDQ0LjEyMDRMNjUuMjQxNyAxMDIuMDYxTDEwMC4xMTEgMTIyLjcwMkwxMDAuMTExIDg2LjE4ODlMMTAwLjExMSA0NC4xMjA0WiIgZmlsbD0iI0EyQTJBMiIvPgo8cGF0aCBkPSJNMTAwLjExMSAxMjkuMzE0TDk5LjY4MDkgMTI5LjgzOEw5OS42ODA5IDE1Ni42MzZMMTAwLjExMSAxNTcuODkyTDEzNSAxMDguNjgzTDEwMC4xMTEgMTI5LjMxNFoiIGZpbGw9IiM0RjRFNEUiLz4KPHBhdGggZD0iTTEwMC4xMTEgMTU3Ljg5MkwxMDAuMTExIDEyOS4zMTRMNjUuMjQxNyAxMDguNjgzTDEwMC4xMTEgMTU3Ljg5MloiIGZpbGw9IiNBMkEyQTIiLz4KPHBhdGggZD0iTTEwMC4xMTEgMTIyLjcwMkwxMzQuOTc4IDEwMi4wNjFMMTAwLjExMSA4Ni4xODg5TDEwMC4xMTEgMTIyLjcwMloiIGZpbGw9IiM3OTc5NzkiLz4KPHBhdGggZD0iTTY1LjI0MTcgMTAyLjA2MUwxMDAuMTExIDEyMi43MDJMMTAwLjExMSA4Ni4xODg5TDY1LjI0MTcgMTAyLjA2MVoiIGZpbGw9IiNENEQ0RDQiLz4KPGcgc3R5bGU9Im1peC1ibGVuZC1tb2RlOm92ZXJsYXkiPgo8cGF0aCBkPSJNMTAwLjExIDQ0LjEyMDRMOTkuMzQ4MyA0Ni43MTMxTDk5LjM0ODMgMTIxLjk0MUwxMDAuMTEgMTIyLjcwMkwxMzQuOTc4IDEwMi4wNjFMMTAwLjExIDQ0LjEyMDRaIiBmaWxsPSIjQUNFNzMwIi8+CjxwYXRoIGQ9Ik0xMDAuMTEgNDQuMTIwNEw2NS4yNDE3IDEwMi4wNjFMMTAwLjExIDEyMi43MDJMMTAwLjExIDg2LjE4ODlMMTAwLjExIDQ0LjEyMDRaIiBmaWxsPSIjQUNFNzMwIi8+CjxwYXRoIGQ9Ik0xMDAuMTExIDEyOS4zMTRMOTkuNjgwOSAxMjkuODM4TDk5LjY4MDkgMTU2LjYzNkwxMDAuMTExIDE1Ny44OTJMMTM1IDEwOC42ODNMMTAwLjExMSAxMjkuMzE0WiIgZmlsbD0iI0FDRTczMCIvPgo8cGF0aCBkPSJNMTAwLjExMSAxNTcuODkyTDEwMC4xMTEgMTI5LjMxNEw2NS4yNDE3IDEwOC42ODNMMTAwLjExMSAxNTcuODkyWiIgZmlsbD0iI0FDRTczMCIvPgo8cGF0aCBkPSJNMTAwLjExIDEyMi43MDJMMTM0Ljk3OCAxMDIuMDYxTDEwMC4xMSA4Ni4xODg5TDEwMC4xMSAxMjIuNzAyWiIgZmlsbD0iI0FDRTczMCIvPgo8cGF0aCBkPSJNNjUuMjQxNyAxMDIuMDYxTDEwMC4xMSAxMjIuNzAyTDEwMC4xMSA4Ni4xODg5TDY1LjI0MTcgMTAyLjA2MVoiIGZpbGw9IiNBQ0U3MzAiLz4KPC9nPgo8L2c+CjxkZWZzPgo8ZmlsdGVyIGlkPSJmaWx0ZXIwX2RkXzc3XzQzIiB4PSIyMS4yMTMxIiB5PSIwLjA5MTgwMDciIHdpZHRoPSIxNTcuODE1IiBoZWlnaHQ9IjIwMS44MjgiIGZpbHRlclVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgY29sb3ItaW50ZXJwb2xhdGlvbi1maWx0ZXJzPSJzUkdCIj4KPGZlRmxvb2QgZmxvb2Qtb3BhY2l0eT0iMCIgcmVzdWx0PSJCYWNrZ3JvdW5kSW1hZ2VGaXgiLz4KPGZlQ29sb3JNYXRyaXggaW49IlNvdXJjZUFscGhhIiB0eXBlPSJtYXRyaXgiIHZhbHVlcz0iMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMTI3IDAiIHJlc3VsdD0iaGFyZEFscGhhIi8+CjxmZU9mZnNldC8+CjxmZUdhdXNzaWFuQmx1ciBzdGREZXZpYXRpb249IjEwLjY3MjUiLz4KPGZlQ29tcG9zaXRlIGluMj0iaGFyZEFscGhhIiBvcGVyYXRvcj0ib3V0Ii8+CjxmZUNvbG9yTWF0cml4IHR5cGU9Im1hdHJpeCIgdmFsdWVzPSIwIDAgMCAwIDAuNjc0NTEgMCAwIDAgMCAwLjkwNTg4MiAwIDAgMCAwIDAuMTg4MjM1IDAgMCAwIDAuNSAwIi8+CjxmZUJsZW5kIG1vZGU9Im5vcm1hbCIgaW4yPSJCYWNrZ3JvdW5kSW1hZ2VGaXgiIHJlc3VsdD0iZWZmZWN0MV9kcm9wU2hhZG93Xzc3XzQzIi8+CjxmZUNvbG9yTWF0cml4IGluPSJTb3VyY2VBbHBoYSIgdHlwZT0ibWF0cml4IiB2YWx1ZXM9IjAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDEyNyAwIiByZXN1bHQ9ImhhcmRBbHBoYSIvPgo8ZmVPZmZzZXQvPgo8ZmVHYXVzc2lhbkJsdXIgc3RkRGV2aWF0aW9uPSIyMi4wMTQzIi8+CjxmZUNvbXBvc2l0ZSBpbjI9ImhhcmRBbHBoYSIgb3BlcmF0b3I9Im91dCIvPgo8ZmVDb2xvck1hdHJpeCB0eXBlPSJtYXRyaXgiIHZhbHVlcz0iMCAwIDAgMCAwLjY3NDUxIDAgMCAwIDAgMC45MDU4ODIgMCAwIDAgMCAwLjE4ODIzNSAwIDAgMCAxIDAiLz4KPGZlQmxlbmQgbW9kZT0ibm9ybWFsIiBpbjI9ImVmZmVjdDFfZHJvcFNoYWRvd183N180MyIgcmVzdWx0PSJlZmZlY3QyX2Ryb3BTaGFkb3dfNzdfNDMiLz4KPGZlQmxlbmQgbW9kZT0ibm9ybWFsIiBpbj0iU291cmNlR3JhcGhpYyIgaW4yPSJlZmZlY3QyX2Ryb3BTaGFkb3dfNzdfNDMiIHJlc3VsdD0ic2hhcGUiLz4KPC9maWx0ZXI+CjwvZGVmcz4KPC9zdmc+Cg==",
+      tags: ["liquidStakingToken"],
+      extensions: {},
+    },
+    {
+      chainId: 11155111,
       address: "0xFF8AFe6bb92eB9D8e80c607bbe5bbb78BF1201Df",
       decimals: 18,
       places: 2,
@@ -69,6 +75,7 @@ export const sepoliaAppConfig: AppConfig = {
   registryAddress: "0x03f6554299acf544ac646305800f57db544b837a",
   hyperdrives: [
     {
+      chainId: 11155111,
       address: "0xC7cb718D5f1c5B4839045aed2620FABc1cF13CD3",
       version: "v1.0.12",
       name: "14d Maker DSR",
@@ -108,6 +115,7 @@ export const sepoliaAppConfig: AppConfig = {
       },
     },
     {
+      chainId: 11155111,
       address: "0xfA8dB2177F1e1eE4327c9b9d1389b1173bC5A5e2",
       version: "v1.0.12",
       name: "30d Maker DSR",
@@ -147,6 +155,7 @@ export const sepoliaAppConfig: AppConfig = {
       },
     },
     {
+      chainId: 11155111,
       address: "0x54A93937EE00838d659795b9bbbe904a00DdF278",
       version: "v1.0.12",
       name: "14d Renzo ezETH",
@@ -186,6 +195,7 @@ export const sepoliaAppConfig: AppConfig = {
       },
     },
     {
+      chainId: 11155111,
       address: "0x87621c072B1967730b70F4c0536D739c2053d34c",
       version: "v1.0.12",
       name: "30d Renzo ezETH",
@@ -225,6 +235,7 @@ export const sepoliaAppConfig: AppConfig = {
       },
     },
     {
+      chainId: 11155111,
       address: "0x8DFc7c74331162FE2FCc2Ee83173d806E4Ca2CE8",
       version: "v1.0.12",
       name: "14d Rocket Pool ETH",
@@ -264,6 +275,7 @@ export const sepoliaAppConfig: AppConfig = {
       },
     },
     {
+      chainId: 11155111,
       address: "0x1F5625B9d2B1c02b06bcA6F95BEE71b9700Bf95D",
       version: "v1.0.12",
       name: "30d Rocket Pool ETH",
@@ -303,6 +315,7 @@ export const sepoliaAppConfig: AppConfig = {
       },
     },
     {
+      chainId: 11155111,
       address: "0xb59b98209e82Fc0549Bb2572809B7CD10289Bb91",
       version: "v1.0.12",
       name: "14d Lido stETH",
@@ -342,6 +355,7 @@ export const sepoliaAppConfig: AppConfig = {
       },
     },
     {
+      chainId: 11155111,
       address: "0x51C054F75b2c4b53E8E5114430C3ded4572473D8",
       version: "v1.0.12",
       name: "30d Lido stETH",
@@ -381,6 +395,7 @@ export const sepoliaAppConfig: AppConfig = {
       },
     },
     {
+      chainId: 11155111,
       address: "0xE352F4D16C7Ee4162d1aa54b77A15d4DA8f35f4b",
       version: "v1.0.15",
       name: "14d Morpho sUSDe/DAI",
@@ -420,6 +435,7 @@ export const sepoliaAppConfig: AppConfig = {
       },
     },
     {
+      chainId: 11155111,
       address: "0x0399BBA8DE5959007148a95ADaaD04eA3172513E",
       version: "v1.0.15",
       name: "14d Morpho USDe/DAI",

--- a/packages/hyperdrive-appconfig/src/hyperdrives/HyperdriveConfig.ts
+++ b/packages/hyperdrive-appconfig/src/hyperdrives/HyperdriveConfig.ts
@@ -3,6 +3,7 @@ import { yieldSources } from "src/yieldSources";
 import { Address } from "viem";
 
 export interface HyperdriveConfig {
+  chainId: number;
   address: Address;
   name: string;
   version: string;

--- a/packages/hyperdrive-appconfig/src/hyperdrives/custom/getCustomHyperdrive.ts
+++ b/packages/hyperdrive-appconfig/src/hyperdrives/custom/getCustomHyperdrive.ts
@@ -64,6 +64,7 @@ export async function getCustomHyperdrive({
   });
 
   const hyperdriveConfig: HyperdriveConfig = {
+    chainId: await hyperdrive.network.getChainId(),
     address: hyperdrive.address,
     version: version.string,
     name: hyperdriveName,

--- a/packages/hyperdrive-appconfig/src/hyperdrives/morpho/getMorphoHyperdrive.ts
+++ b/packages/hyperdrive-appconfig/src/hyperdrives/morpho/getMorphoHyperdrive.ts
@@ -42,6 +42,7 @@ export async function getMorphoHyperdrive({
   });
 
   const hyperdriveConfig: HyperdriveConfig = {
+    chainId: await hyperdrive.network.getChainId(),
     address: hyperdrive.address,
     version: version.string,
     name: hyperdriveName,

--- a/packages/hyperdrive-appconfig/src/hyperdrives/steth/getStethHyperdrive.ts
+++ b/packages/hyperdrive-appconfig/src/hyperdrives/steth/getStethHyperdrive.ts
@@ -11,15 +11,14 @@ import { yieldSources } from "src/yieldSources";
 import { sepolia } from "viem/chains";
 export async function getStethHyperdrive({
   hyperdrive,
-  chainId,
 }: {
   hyperdrive: ReadHyperdrive;
-  chainId: number;
 }): Promise<{
   sharesToken: TokenConfig<EmptyExtensions>;
   baseToken: TokenConfig<EmptyExtensions>;
   hyperdriveConfig: HyperdriveConfig;
 }> {
+  const chainId = await hyperdrive.network.getChainId();
   const version = await hyperdrive.getVersion();
   const poolConfig = await hyperdrive.getPoolConfig();
 
@@ -34,6 +33,7 @@ export async function getStethHyperdrive({
 
   const baseTokenConfig: TokenConfig<EmptyExtensions> = {
     address: poolConfig.baseToken,
+    chainId: await hyperdrive.network.getChainId(),
     name: "Ether",
     symbol: "ETH",
     decimals: 18,
@@ -49,6 +49,7 @@ export async function getStethHyperdrive({
   });
 
   const hyperdriveConfig: HyperdriveConfig = {
+    chainId,
     address: hyperdrive.address,
     version: version.string,
     name: hyperdriveName,

--- a/packages/hyperdrive-appconfig/src/tokens/getTokenConfig.ts
+++ b/packages/hyperdrive-appconfig/src/tokens/getTokenConfig.ts
@@ -7,6 +7,7 @@ export interface TokenConfig<
   Extensions = Record<string, string | number | boolean> | EmptyExtensions,
 > {
   address: Address;
+  chainId: number;
   name: string;
   symbol: string;
   decimals: number;
@@ -32,6 +33,7 @@ export async function getTokenConfig<
   extensions: Extensions;
 }): Promise<TokenConfig<Extensions>> {
   return {
+    chainId: await token.network.getChainId(),
     address: token.address,
     decimals: await token.getDecimals(),
     places,


### PR DESCRIPTION
This adds a `chainId` field on `HyperdriveConfig` and `TokenConfig`, making it possible to store multi-chain hyperdrives in a single appconfig.

Related to #1356 but going to land this in multiple parts. Closes #1355