### PR TITLE
Omit Rainbowkit options for capsule if no .env for it

### DIFF
--- a/apps/hyperdrive-trading/src/network/wagmiClient.ts
+++ b/apps/hyperdrive-trading/src/network/wagmiClient.ts
@@ -1,4 +1,4 @@
-import { getDefaultConfig } from "@rainbow-me/rainbowkit";
+import { getDefaultConfig, type WalletList } from "@rainbow-me/rainbowkit";
 import {
   injectedWallet,
   metaMaskWallet,
@@ -88,6 +88,20 @@ if (VITE_MAINNET_RPC_URL) {
   }
 }
 
+const wallets: WalletList = [
+  {
+    groupName: "Other",
+    wallets: recommendedWallets,
+  },
+];
+// If Capsule is not configured in your .env, then don't include it in the
+// custom wallets
+if (customWallets.length) {
+  wallets.push({
+    groupName: "Log In or Sign Up with Capsule",
+    wallets: customWallets,
+  });
+}
 export const wagmiConfig = getDefaultConfig({
   appName: "Hyperdrive",
   projectId: VITE_WALLET_CONNECT_PROJECT_ID || "0",
@@ -95,14 +109,5 @@ export const wagmiConfig = getDefaultConfig({
   // Viem's type for `chains` requires at least one item in the array, but since
   // we build the list up programmatically we must cast.
   chains: chains as [Chain, ...restChains: Chain[]],
-  wallets: [
-    {
-      groupName: "Other",
-      wallets: recommendedWallets,
-    },
-    {
-      groupName: "Log In or Sign Up with Capsule",
-      wallets: customWallets,
-    },
-  ],
+  wallets,
 });

--- a/apps/hyperdrive-trading/src/wallets/capsule.ts
+++ b/apps/hyperdrive-trading/src/wallets/capsule.ts
@@ -7,8 +7,6 @@ import { CreateWalletFn } from "src/wallets/CreateWalletFn";
 
 const { VITE_CAPSULE_API_KEY, VITE_CAPSULE_ENV } = import.meta.env;
 
-const hasRequiredEnvVars = !!VITE_CAPSULE_API_KEY && !!VITE_CAPSULE_ENV;
-
 export const getCapsuleWalletOpts: GetCapsuleOpts = {
   capsule: {
     environment: VITE_CAPSULE_ENV, // Environment.PROD for Production
@@ -43,16 +41,17 @@ export const getCapsuleWalletOpts: GetCapsuleOpts = {
   ],
 };
 
-export const capsuleWallet: CreateWalletFn | undefined = hasRequiredEnvVars
-  ? ({ projectId }) => {
-      const capsuleWallet = getCapsuleWallet(getCapsuleWalletOpts);
-      const wallet = capsuleWallet({ projectId });
-      return {
-        ...wallet,
+export const capsuleWallet: CreateWalletFn | undefined =
+  !!VITE_CAPSULE_API_KEY && !!VITE_CAPSULE_ENV
+    ? ({ projectId }) => {
+        const capsuleWallet = getCapsuleWallet(getCapsuleWalletOpts);
+        const wallet = capsuleWallet({ projectId });
+        return {
+          ...wallet,
 
-        // override the rainbowkit name and icon options
-        name: "Capsule",
-        iconUrl: "/capsule-logo.png",
-      };
-    }
-  : undefined;
+          // override the rainbowkit name and icon options
+          name: "Capsule",
+          iconUrl: "/capsule-logo.png",
+        };
+      }
+    : undefined;


### PR DESCRIPTION
This makes it so you don't have to configure env variables for Capsule to run the frontend.