### PR TITLE
Simplifies Loading State, adds APR Label

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/CurrentValueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/CurrentValueCell.tsx
@@ -1,4 +1,4 @@
-import { Long } from "@delvtech/hyperdrive-viem";
+import { Long, OpenLongPositionReceived } from "@delvtech/hyperdrive-viem";
 import { ExclamationTriangleIcon } from "@heroicons/react/20/solid";
 import { HyperdriveConfig, findBaseToken } from "@hyperdrive/appconfig";
 import classNames from "classnames";
@@ -105,7 +105,7 @@ export function CurrentValueCellTwo({
   row,
   hyperdrive,
 }: {
-  row: Long;
+  row: OpenLongPositionReceived;
   hyperdrive: HyperdriveConfig;
 }): ReactElement {
   const appConfig = useAppConfig();
@@ -121,7 +121,7 @@ export function CurrentValueCellTwo({
   } = usePreviewCloseLong({
     hyperdriveAddress: hyperdrive.address,
     maturityTime: row.maturity,
-    bondAmountIn: row.bondAmount,
+    bondAmountIn: row.details?.bondAmount || 0n,
   });
 
   const currentValueLabel = formatBalance({
@@ -131,13 +131,13 @@ export function CurrentValueCellTwo({
   });
 
   const profitLoss = formatBalance({
-    balance: (baseAmountOut || 0n) - row.baseAmountPaid,
+    balance: (baseAmountOut || 0n) - (row.details?.baseAmountPaid || 0n),
     decimals: baseToken.decimals,
     places: baseToken.places,
   });
 
   const isPositiveChangeInValue =
-    baseAmountOut && baseAmountOut > row.baseAmountPaid;
+    baseAmountOut && baseAmountOut > (row.details?.baseAmountPaid || 0n);
 
   if (previewCloseLongStatus === "loading") {
     return (

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktopTwo.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktopTwo.tsx
@@ -309,7 +309,7 @@ function getColumns({
 
         return (
           <div className="flex flex-col">
-            <div>{formatRate(fixedRate)}</div>
+            <div>{formatRate(fixedRate)} APR</div>
             <span className="flex font-dmMono text-neutral-content">
               {formatBalance({
                 balance: row.original.bondAmount,


### PR DESCRIPTION
This PR adds an APR label to the longs table. It also simplifies the loading state on the portfolio longs table. Before we were using the deprecated `useOpenLongs` on each table to fetch data we had already fetched at the top level using `usePortfolioLongsData`. Now we just wait for the one `openLongPositionsStatus` and then render all the tables.  See below for before and after:
Before:

https://github.com/user-attachments/assets/a566ab42-bfee-4620-aa6b-5cf4a3f49ab5


After:



https://github.com/user-attachments/assets/91dc8b37-1c41-4b87-9815-da30f2c87cc4

