### PR TITLE
Rename findBaseToken to findToken

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/TransactionTable/TransactionsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/TransactionTable/TransactionsTable.tsx
@@ -1,10 +1,6 @@
 import { fixed } from "@delvtech/fixed-point-wasm";
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/outline";
-import {
-  AppConfig,
-  HyperdriveConfig,
-  findBaseToken,
-} from "@hyperdrive/appconfig";
+import { AppConfig, HyperdriveConfig, findToken } from "@hyperdrive/appconfig";
 import {
   ColumnFiltersState,
   Header,
@@ -182,7 +178,7 @@ export function TransactionTable({
 }
 
 function getColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
@@ -293,7 +289,7 @@ function formatTransactionTableMobileData(
   hyperdrive: HyperdriveConfig,
   appConfig: AppConfig,
 ) {
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/TransactionTable/TransactionsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/TransactionTable/TransactionsTable.tsx
@@ -179,7 +179,7 @@ export function TransactionTable({
 
 function getColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
   return [
@@ -290,7 +290,7 @@ function formatTransactionTableMobileData(
   appConfig: AppConfig,
 ) {
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
   const size = dnum.format(

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useDevLogging.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useDevLogging.ts
@@ -7,7 +7,7 @@ import { formatUnits } from "viem";
 export function useDevLogging(market: HyperdriveConfig): void {
   const appConfig = useAppConfig();
   const baseToken = findToken({
-    baseTokenAddress: market.poolConfig.baseToken,
+    tokenAddress: market.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
   useEffect(() => {

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useDevLogging.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useDevLogging.ts
@@ -1,4 +1,4 @@
-import { HyperdriveConfig, findBaseToken } from "@hyperdrive/appconfig";
+import { HyperdriveConfig, findToken } from "@hyperdrive/appconfig";
 import { useEffect } from "react";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { usePoolInfo } from "src/ui/hyperdrive/hooks/usePoolInfo";
@@ -6,7 +6,7 @@ import { formatUnits } from "viem";
 
 export function useDevLogging(market: HyperdriveConfig): void {
   const appConfig = useAppConfig();
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: market.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongModalButton/CloseLongModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongModalButton/CloseLongModalButton.tsx
@@ -22,7 +22,7 @@ export function CloseLongModalButton({
 }: CloseLongModalButtonProps): ReactElement {
   const appConfig = useAppConfig();
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
   const sharesToken = appConfig.tokens.find(

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongModalButton/CloseLongModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongModalButton/CloseLongModalButton.tsx
@@ -2,7 +2,7 @@ import { Long } from "@delvtech/hyperdrive-viem";
 import {
   HyperdriveConfig,
   TokenConfig,
-  findBaseToken,
+  findToken,
 } from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
@@ -21,7 +21,7 @@ export function CloseLongModalButton({
   hyperdrive,
 }: CloseLongModalButtonProps): ReactElement {
   const appConfig = useAppConfig();
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/ClosedLongsTable/ClosedLongsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/ClosedLongsTable/ClosedLongsTable.tsx
@@ -4,7 +4,7 @@ import {
   AppConfig,
   HyperdriveConfig,
   TokenConfig,
-  findBaseToken,
+  findToken,
 } from "@hyperdrive/appconfig";
 import {
   createColumnHelper,
@@ -73,7 +73,7 @@ function formatClosedLongMobileColumnData(
 }
 
 function getMobileColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
@@ -118,7 +118,7 @@ function getMobileColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
 }
 
 function getColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
@@ -302,7 +302,7 @@ function BaseAmountReceivedCell({
   hyperdrive: HyperdriveConfig;
 }) {
   const appConfig = useAppConfig();
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/ClosedLongsTable/ClosedLongsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/ClosedLongsTable/ClosedLongsTable.tsx
@@ -74,7 +74,7 @@ function formatClosedLongMobileColumnData(
 
 function getMobileColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
   return [
@@ -119,7 +119,7 @@ function getMobileColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
 
 function getColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
   return [
@@ -303,7 +303,7 @@ function BaseAmountReceivedCell({
 }) {
   const appConfig = useAppConfig();
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
   const currentValueLabel = formatBalance({

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
@@ -45,7 +45,7 @@ export function OpenLongForm({
   const appConfig = useAppConfig();
   const { poolInfo } = usePoolInfo({ hyperdriveAddress: hyperdrive.address });
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
 

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
@@ -1,6 +1,6 @@
 import { fixed } from "@delvtech/fixed-point-wasm";
 import { adjustAmountByPercentage } from "@delvtech/hyperdrive-js-core";
-import { findBaseToken, HyperdriveConfig } from "@hyperdrive/appconfig";
+import { findToken, HyperdriveConfig } from "@hyperdrive/appconfig";
 import { MouseEvent, ReactElement } from "react";
 import { isTestnetChain } from "src/chains/isTestnetChain";
 import { getIsValidTradeSize } from "src/hyperdrive/getIsValidTradeSize";
@@ -44,7 +44,7 @@ export function OpenLongForm({
 
   const appConfig = useAppConfig();
   const { poolInfo } = usePoolInfo({ hyperdriveAddress: hyperdrive.address });
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongPreview.tsx
@@ -44,7 +44,7 @@ export function OpenLongPreview({
 }: OpenLongPreviewProps): ReactElement {
   const appConfig = useAppConfig();
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
   const yieldSource = appConfig.yieldSources[hyperdrive.yieldSource];

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongPreview.tsx
@@ -5,7 +5,7 @@ import { ClockIcon } from "@heroicons/react/24/outline";
 import {
   HyperdriveConfig,
   TokenConfig,
-  findBaseToken,
+  findToken,
 } from "@hyperdrive/appconfig";
 import classNames from "classnames";
 import { ReactElement } from "react";
@@ -43,7 +43,7 @@ export function OpenLongPreview({
   vaultSharePrice,
 }: OpenLongPreviewProps): ReactElement {
   const appConfig = useAppConfig();
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongStats.tsx
@@ -1,7 +1,7 @@
 import { fixed } from "@delvtech/fixed-point-wasm";
 import { calculateAprFromPrice } from "@delvtech/hyperdrive-viem";
 import {
-  findBaseToken,
+  findToken,
   HyperdriveConfig,
   TokenConfig,
 } from "@hyperdrive/appconfig";
@@ -38,7 +38,7 @@ export function OpenLongStats({
   vaultSharePrice,
 }: OpenLongStatsProps): JSX.Element {
   const appConfig = useAppConfig();
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongStats.tsx
@@ -39,7 +39,7 @@ export function OpenLongStats({
 }: OpenLongStatsProps): JSX.Element {
   const appConfig = useAppConfig();
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
   const chainId = useChainId();

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/CurrentValueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/CurrentValueCell.tsx
@@ -23,7 +23,7 @@ export function CurrentValueCell({
   const isTailwindSmallScreen = useIsTailwindSmallScreen();
   const appConfig = useAppConfig();
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
   const { poolInfo } = usePoolInfo({ hyperdriveAddress: hyperdrive.address });
@@ -110,7 +110,7 @@ export function CurrentValueCellTwo({
 }): ReactElement {
   const appConfig = useAppConfig();
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
 

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/CurrentValueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/CurrentValueCell.tsx
@@ -1,6 +1,6 @@
 import { Long, OpenLongPositionReceived } from "@delvtech/hyperdrive-viem";
 import { ExclamationTriangleIcon } from "@heroicons/react/20/solid";
-import { HyperdriveConfig, findBaseToken } from "@hyperdrive/appconfig";
+import { HyperdriveConfig, findToken } from "@hyperdrive/appconfig";
 import classNames from "classnames";
 import { ReactElement } from "react";
 import Skeleton from "react-loading-skeleton";
@@ -22,7 +22,7 @@ export function CurrentValueCell({
 }): ReactElement {
   const isTailwindSmallScreen = useIsTailwindSmallScreen();
   const appConfig = useAppConfig();
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
@@ -109,7 +109,7 @@ export function CurrentValueCellTwo({
   hyperdrive: HyperdriveConfig;
 }): ReactElement {
   const appConfig = useAppConfig();
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/FixedRateCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/FixedRateCell.tsx
@@ -2,7 +2,7 @@ import {
   calculateAprFromPrice,
   calculateMatureLongYieldAfterFees,
 } from "@delvtech/hyperdrive-viem";
-import { HyperdriveConfig, findBaseToken } from "@hyperdrive/appconfig";
+import { HyperdriveConfig, findToken } from "@hyperdrive/appconfig";
 import classNames from "classnames";
 import { ReactElement } from "react";
 import { formatRate } from "src/base/formatRate";
@@ -24,7 +24,7 @@ export function FixedRateCell({
   const appConfig = useAppConfig();
   const isTailwindSmallScreen = useIsTailwindSmallScreen();
   const { poolConfig } = hyperdrive;
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/FixedRateCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/FixedRateCell.tsx
@@ -25,7 +25,7 @@ export function FixedRateCell({
   const isTailwindSmallScreen = useIsTailwindSmallScreen();
   const { poolConfig } = hyperdrive;
   const baseToken = findToken({
-    baseTokenAddress: poolConfig.baseToken,
+    tokenAddress: poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
 

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
@@ -1,11 +1,7 @@
 import { Long } from "@delvtech/hyperdrive-viem";
 import { EllipsisVerticalIcon } from "@heroicons/react/16/solid";
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/outline";
-import {
-  AppConfig,
-  HyperdriveConfig,
-  findBaseToken,
-} from "@hyperdrive/appconfig";
+import { AppConfig, HyperdriveConfig, findToken } from "@hyperdrive/appconfig";
 import {
   createColumnHelper,
   flexRender,
@@ -203,7 +199,7 @@ function getColumns({
   hyperdrive: HyperdriveConfig;
   appConfig: AppConfig;
 }) {
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
@@ -200,7 +200,7 @@ function getColumns({
   appConfig: AppConfig;
 }) {
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
   return [

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktopTwo.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktopTwo.tsx
@@ -283,7 +283,7 @@ function getColumns({
   appConfig: AppConfig;
 }) {
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
   return [

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktopTwo.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktopTwo.tsx
@@ -4,11 +4,7 @@ import {
 } from "@delvtech/hyperdrive-viem";
 import { Cog8ToothIcon } from "@heroicons/react/20/solid";
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/outline";
-import {
-  AppConfig,
-  findBaseToken,
-  HyperdriveConfig,
-} from "@hyperdrive/appconfig";
+import { AppConfig, findToken, HyperdriveConfig } from "@hyperdrive/appconfig";
 import {
   createColumnHelper,
   flexRender,
@@ -286,7 +282,7 @@ function getColumns({
   hyperdrive: HyperdriveConfig;
   appConfig: AppConfig;
 }) {
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableMobile.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableMobile.tsx
@@ -217,7 +217,7 @@ function getMobileColumns({
   appConfig: AppConfig;
 }) {
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
   return [

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableMobile.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableMobile.tsx
@@ -3,7 +3,7 @@ import {
   AppConfig,
   HyperdriveConfig,
   TokenConfig,
-  findBaseToken,
+  findToken,
 } from "@hyperdrive/appconfig";
 import {
   createColumnHelper,
@@ -216,7 +216,7 @@ function getMobileColumns({
   hyperdrive: HyperdriveConfig;
   appConfig: AppConfig;
 }) {
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
@@ -54,7 +54,7 @@ export function AddLiquidityForm({
   const { poolInfo } = usePoolInfo({ hyperdriveAddress: hyperdrive.address });
   const appConfig = useAppConfig();
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
   const sharesToken = appConfig.tokens.find(

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
@@ -4,7 +4,7 @@ import { SparklesIcon } from "@heroicons/react/16/solid";
 import {
   HyperdriveConfig,
   TokenConfig,
-  findBaseToken,
+  findToken,
 } from "@hyperdrive/appconfig";
 import classNames from "classnames";
 import { MouseEvent, ReactElement } from "react";
@@ -53,7 +53,7 @@ export function AddLiquidityForm({
   const chainId = useChainId();
   const { poolInfo } = usePoolInfo({ hyperdriveAddress: hyperdrive.address });
   const appConfig = useAppConfig();
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/ClosedLpTable/ClosedLpTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/ClosedLpTable/ClosedLpTable.tsx
@@ -38,7 +38,7 @@ function formatClosedLpMobileColumnData(
   appConfig: AppConfig,
 ) {
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
   const isWithdrawalShare = closedLpShares.redeemedTimestamp;
@@ -123,7 +123,7 @@ function getMobileColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
 }
 function getColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
   return [

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/ClosedLpTable/ClosedLpTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/ClosedLpTable/ClosedLpTable.tsx
@@ -3,11 +3,7 @@ import {
   RedeemedWithdrawalShares,
 } from "@delvtech/hyperdrive-viem";
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/16/solid";
-import {
-  AppConfig,
-  HyperdriveConfig,
-  findBaseToken,
-} from "@hyperdrive/appconfig";
+import { AppConfig, HyperdriveConfig, findToken } from "@hyperdrive/appconfig";
 import {
   createColumnHelper,
   flexRender,
@@ -41,7 +37,7 @@ function formatClosedLpMobileColumnData(
   hyperdrive: HyperdriveConfig,
   appConfig: AppConfig,
 ) {
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
@@ -126,7 +122,7 @@ function getMobileColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
   ];
 }
 function getColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/OpenLpSharesCard/OpenLpSharesCard.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/OpenLpSharesCard/OpenLpSharesCard.tsx
@@ -35,7 +35,7 @@ export function OpenLpSharesCard({
   const { address: account } = useAccount();
   const appConfig = useAppConfig();
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
   const sharesToken = appConfig.tokens.find(

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/OpenLpSharesCard/OpenLpSharesCard.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/OpenLpSharesCard/OpenLpSharesCard.tsx
@@ -1,6 +1,6 @@
 import { XMarkIcon } from "@heroicons/react/24/outline";
 import {
-  findBaseToken,
+  findToken,
   HyperdriveConfig,
   TokenConfig,
 } from "@hyperdrive/appconfig";
@@ -34,7 +34,7 @@ export function OpenLpSharesCard({
 }: OpenLpSharesCardProps): ReactElement {
   const { address: account } = useAccount();
   const appConfig = useAppConfig();
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
@@ -1,6 +1,6 @@
 import { fixed } from "@delvtech/fixed-point-wasm";
 import { adjustAmountByPercentage } from "@delvtech/hyperdrive-viem";
-import { findBaseToken, HyperdriveConfig } from "@hyperdrive/appconfig";
+import { findToken, HyperdriveConfig } from "@hyperdrive/appconfig";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
 import { MouseEvent, ReactElement } from "react";
 import { calculateValueFromPrice } from "src/base/calculateValueFromPrice";
@@ -35,7 +35,7 @@ export function RemoveLiquidityForm({
 }: RemoveLiquidityFormProps): ReactElement {
   const { address: account } = useAccount();
   const appConfig = useAppConfig();
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
@@ -36,7 +36,7 @@ export function RemoveLiquidityForm({
   const { address: account } = useAccount();
   const appConfig = useAppConfig();
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
 

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortModalButton/CloseShortModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortModalButton/CloseShortModalButton.tsx
@@ -3,7 +3,7 @@ import { CheckIcon, XMarkIcon } from "@heroicons/react/24/solid";
 import {
   HyperdriveConfig,
   TokenConfig,
-  findBaseToken,
+  findToken,
 } from "@hyperdrive/appconfig";
 import classNames from "classnames";
 import { ReactElement } from "react";
@@ -26,7 +26,7 @@ export function CloseShortModalButton({
   hyperdrive,
 }: CloseShortModalButtonProps): ReactElement {
   const appConfig = useAppConfig();
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortModalButton/CloseShortModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortModalButton/CloseShortModalButton.tsx
@@ -27,7 +27,7 @@ export function CloseShortModalButton({
 }: CloseShortModalButtonProps): ReactElement {
   const appConfig = useAppConfig();
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
   const sharesToken = appConfig.tokens.find(

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/ClosedShortsTable/ClosedShortsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/ClosedShortsTable/ClosedShortsTable.tsx
@@ -32,7 +32,7 @@ function formatClosedShortMobileColumnData(
   appConfig: AppConfig,
 ) {
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
   return [
@@ -108,7 +108,7 @@ function getMobileColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
 
 function getColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
 

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/ClosedShortsTable/ClosedShortsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/ClosedShortsTable/ClosedShortsTable.tsx
@@ -1,10 +1,6 @@
 import { ClosedShort } from "@delvtech/hyperdrive-viem";
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/16/solid";
-import {
-  AppConfig,
-  HyperdriveConfig,
-  findBaseToken,
-} from "@hyperdrive/appconfig";
+import { AppConfig, HyperdriveConfig, findToken } from "@hyperdrive/appconfig";
 import {
   createColumnHelper,
   flexRender,
@@ -35,7 +31,7 @@ function formatClosedShortMobileColumnData(
   hyperdrive: HyperdriveConfig,
   appConfig: AppConfig,
 ) {
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
@@ -111,7 +107,7 @@ function getMobileColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
 }
 
 function getColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
@@ -1,7 +1,7 @@
 import { fixed } from "@delvtech/fixed-point-wasm";
 import { adjustAmountByPercentage } from "@delvtech/hyperdrive-js-core";
 
-import { findBaseToken, HyperdriveConfig } from "@hyperdrive/appconfig";
+import { findToken, HyperdriveConfig } from "@hyperdrive/appconfig";
 import { MouseEvent, ReactElement, useState } from "react";
 import Skeleton from "react-loading-skeleton";
 import { MAX_UINT256 } from "src/base/constants";
@@ -51,7 +51,7 @@ export function OpenShortForm({
   const appConfig = useAppConfig();
   const chainId = useChainId();
   const { poolInfo } = usePoolInfo({ hyperdriveAddress: hyperdrive.address });
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
@@ -52,7 +52,7 @@ export function OpenShortForm({
   const chainId = useChainId();
   const { poolInfo } = usePoolInfo({ hyperdriveAddress: hyperdrive.address });
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
   const { vaultRate, vaultRateStatus } = useYieldSourceRate({

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
@@ -5,7 +5,7 @@ import { ClockIcon } from "@heroicons/react/24/outline";
 import {
   HyperdriveConfig,
   TokenConfig,
-  findBaseToken,
+  findToken,
 } from "@hyperdrive/appconfig";
 import classNames from "classnames";
 import { ReactElement, useState } from "react";
@@ -41,7 +41,7 @@ export function OpenShortPreview({
 }: OpenShortPreviewProps): ReactElement {
   const [detailsOpen, setDetailsOpen] = useState(false);
   const appConfig = useAppConfig();
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
@@ -42,7 +42,7 @@ export function OpenShortPreview({
   const [detailsOpen, setDetailsOpen] = useState(false);
   const appConfig = useAppConfig();
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
   const { fixedApr } = useFixedRate(hyperdrive.address);

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/AccruedYieldCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/AccruedYieldCell.tsx
@@ -1,5 +1,5 @@
 import { OpenShort } from "@delvtech/hyperdrive-viem";
-import { HyperdriveConfig, findBaseToken } from "@hyperdrive/appconfig";
+import { HyperdriveConfig, findToken } from "@hyperdrive/appconfig";
 import classNames from "classnames";
 import { ReactElement } from "react";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
@@ -17,7 +17,7 @@ export function AccruedYieldCell({
   const { bondAmount, checkpointTime } = openShort;
   const isTailwindSmallScreen = useIsTailwindSmallScreen();
   const appConfig = useAppConfig();
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/AccruedYieldCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/AccruedYieldCell.tsx
@@ -18,7 +18,7 @@ export function AccruedYieldCell({
   const isTailwindSmallScreen = useIsTailwindSmallScreen();
   const appConfig = useAppConfig();
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
   const { accruedYield } = useAccruedYield({

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/CurrentValueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/CurrentValueCell.tsx
@@ -1,6 +1,6 @@
 import { OpenShort } from "@delvtech/hyperdrive-viem";
 import { ExclamationTriangleIcon } from "@heroicons/react/20/solid";
-import { HyperdriveConfig, findBaseToken } from "@hyperdrive/appconfig";
+import { HyperdriveConfig, findToken } from "@hyperdrive/appconfig";
 import classNames from "classnames";
 import { ReactElement } from "react";
 import Skeleton from "react-loading-skeleton";
@@ -19,7 +19,7 @@ export function CurrentValueCell({
 }): ReactElement {
   const isTailwindSmallScreen = useIsTailwindSmallScreen();
   const appConfig = useAppConfig();
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/CurrentValueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/CurrentValueCell.tsx
@@ -20,7 +20,7 @@ export function CurrentValueCell({
   const isTailwindSmallScreen = useIsTailwindSmallScreen();
   const appConfig = useAppConfig();
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
 

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktop.tsx
@@ -5,7 +5,7 @@ import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/outline";
 import {
   HyperdriveConfig,
   TokenConfig,
-  findBaseToken,
+  findToken,
 } from "@hyperdrive/appconfig";
 import {
   createColumnHelper,
@@ -36,7 +36,7 @@ export function OpenShortsTableDesktop({
   openShorts: OpenShort[];
 }): ReactElement {
   const appConfig = useAppConfig();
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktop.tsx
@@ -37,7 +37,7 @@ export function OpenShortsTableDesktop({
 }): ReactElement {
   const appConfig = useAppConfig();
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
 

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktopTwo.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktopTwo.tsx
@@ -1,11 +1,7 @@
 import { OpenShort } from "@delvtech/hyperdrive-viem";
 import { Cog8ToothIcon } from "@heroicons/react/20/solid";
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/outline";
-import {
-  AppConfig,
-  findBaseToken,
-  HyperdriveConfig,
-} from "@hyperdrive/appconfig";
+import { AppConfig, findToken, HyperdriveConfig } from "@hyperdrive/appconfig";
 import {
   createColumnHelper,
   flexRender,
@@ -280,7 +276,7 @@ function getColumns({
   hyperdrive: HyperdriveConfig;
   appConfig: AppConfig;
 }) {
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktopTwo.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktopTwo.tsx
@@ -277,7 +277,7 @@ function getColumns({
   appConfig: AppConfig;
 }) {
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
   return [

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableMobile.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableMobile.tsx
@@ -153,7 +153,7 @@ function formatOpenShortMobileColumnData(
   appConfig: AppConfig,
 ) {
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
   return [

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableMobile.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableMobile.tsx
@@ -1,10 +1,6 @@
 /* eslint-disable react/jsx-key */
 import { OpenShort } from "@delvtech/hyperdrive-viem";
-import {
-  AppConfig,
-  HyperdriveConfig,
-  findBaseToken,
-} from "@hyperdrive/appconfig";
+import { AppConfig, HyperdriveConfig, findToken } from "@hyperdrive/appconfig";
 import {
   createColumnHelper,
   flexRender,
@@ -156,7 +152,7 @@ function formatOpenShortMobileColumnData(
   hyperdrive: HyperdriveConfig,
   appConfig: AppConfig,
 ) {
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/withdrawalShares/OpenWithdrawalSharesCard/OpenWithdrawalSharesCard.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/withdrawalShares/OpenWithdrawalSharesCard/OpenWithdrawalSharesCard.tsx
@@ -1,4 +1,4 @@
-import { HyperdriveConfig, findBaseToken } from "@hyperdrive/appconfig";
+import { HyperdriveConfig, findToken } from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
 import Skeleton from "react-loading-skeleton";
 import { calculateValueFromPrice } from "src/base/calculateValueFromPrice";
@@ -24,7 +24,7 @@ export function OpenWithdrawalSharesCard({
 }: LpPortfolioCardProps): ReactElement {
   const { address: account } = useAccount();
   const appConfig = useAppConfig();
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/withdrawalShares/OpenWithdrawalSharesCard/OpenWithdrawalSharesCard.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/withdrawalShares/OpenWithdrawalSharesCard/OpenWithdrawalSharesCard.tsx
@@ -25,7 +25,7 @@ export function OpenWithdrawalSharesCard({
   const { address: account } = useAccount();
   const appConfig = useAppConfig();
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
   const { poolInfo } = usePoolInfo({ hyperdriveAddress: hyperdrive.address });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/withdrawalShares/RedeemWithdrawalSharesForm/RedeemWithdrawalSharesForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/withdrawalShares/RedeemWithdrawalSharesForm/RedeemWithdrawalSharesForm.tsx
@@ -33,7 +33,7 @@ export function RedeemWithdrawalSharesForm({
 }: RedeemWithdrawalSharesFormProps): ReactElement {
   const appConfig = useAppConfig();
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
   const sharesToken = appConfig.tokens.find(

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/withdrawalShares/RedeemWithdrawalSharesForm/RedeemWithdrawalSharesForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/withdrawalShares/RedeemWithdrawalSharesForm/RedeemWithdrawalSharesForm.tsx
@@ -1,7 +1,7 @@
 import { fixed } from "@delvtech/fixed-point-wasm";
 import { adjustAmountByPercentage } from "@delvtech/hyperdrive-viem";
 import {
-  findBaseToken,
+  findToken,
   HyperdriveConfig,
   TokenConfig,
 } from "@hyperdrive/appconfig";
@@ -32,7 +32,7 @@ export function RedeemWithdrawalSharesForm({
   hyperdrive,
 }: RedeemWithdrawalSharesFormProps): ReactElement {
   const appConfig = useAppConfig();
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/markets/AllMarketsTable/useMarketRowData.ts
+++ b/apps/hyperdrive-trading/src/ui/markets/AllMarketsTable/useMarketRowData.ts
@@ -3,7 +3,7 @@ import {
   HyperdriveConfig,
   Protocol,
   TokenConfig,
-  findBaseToken,
+  findToken,
 } from "@hyperdrive/appconfig";
 import { UseQueryResult, useQuery } from "@tanstack/react-query";
 import { formatRate } from "src/base/formatRate";
@@ -42,7 +42,7 @@ export function useMarketRowData(): UseQueryResult<MarketTableRowData[]> {
                   publicClient,
                   cache: sdkCache,
                 });
-                const baseToken = findBaseToken({
+                const baseToken = findToken({
                   baseTokenAddress: hyperdrive.poolConfig.baseToken,
                   tokens: appConfig.tokens,
                 });

--- a/apps/hyperdrive-trading/src/ui/markets/AllMarketsTable/useMarketRowData.ts
+++ b/apps/hyperdrive-trading/src/ui/markets/AllMarketsTable/useMarketRowData.ts
@@ -43,7 +43,7 @@ export function useMarketRowData(): UseQueryResult<MarketTableRowData[]> {
                   cache: sdkCache,
                 });
                 const baseToken = findToken({
-                  baseTokenAddress: hyperdrive.poolConfig.baseToken,
+                  tokenAddress: hyperdrive.poolConfig.baseToken,
                   tokens: appConfig.tokens,
                 });
                 const liquidity = await readHyperdrive.getPresentValue();

--- a/apps/hyperdrive-trading/src/ui/markets/LongsTab/LongsTab.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/LongsTab/LongsTab.tsx
@@ -55,7 +55,7 @@ export function LongsTab({
       : isTotalClosedValueLoading;
 
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
 

--- a/apps/hyperdrive-trading/src/ui/markets/LongsTab/LongsTab.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/LongsTab/LongsTab.tsx
@@ -1,5 +1,5 @@
 import { ExclamationTriangleIcon } from "@heroicons/react/16/solid";
-import { HyperdriveConfig, findBaseToken } from "@hyperdrive/appconfig";
+import { HyperdriveConfig, findToken } from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
 import Skeleton from "react-loading-skeleton";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
@@ -54,7 +54,7 @@ export function LongsTab({
       ? isTotalOpenValueLoading
       : isTotalClosedValueLoading;
 
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/markets/MarketDetailsBody/MarketHeader.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketDetailsBody/MarketHeader.tsx
@@ -1,5 +1,5 @@
 import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/outline";
-import { HyperdriveConfig, findBaseToken } from "@hyperdrive/appconfig";
+import { HyperdriveConfig, findToken } from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
 import { getAnalyticsUrl } from "src/ui/analytics/getAnalyticsUrl";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
@@ -11,7 +11,7 @@ export function MarketHeader({
   hyperdrive: HyperdriveConfig;
 }): ReactElement {
   const appConfig = useAppConfig();
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/markets/MarketDetailsBody/MarketHeader.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketDetailsBody/MarketHeader.tsx
@@ -12,7 +12,7 @@ export function MarketHeader({
 }): ReactElement {
   const appConfig = useAppConfig();
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
   const sharesToken = appConfig.tokens.find(

--- a/apps/hyperdrive-trading/src/ui/markets/MarketDetailsBody/PriceBadges.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketDetailsBody/PriceBadges.tsx
@@ -1,5 +1,5 @@
 import { parseFixed } from "@delvtech/fixed-point-wasm";
-import { findBaseToken, HyperdriveConfig } from "@hyperdrive/appconfig";
+import { findToken, HyperdriveConfig } from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
 import Skeleton from "react-loading-skeleton";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
@@ -16,7 +16,7 @@ export function PriceBadges({
   const { longPrice, longPriceStatus } = useCurrentLongPrice(
     hyperdrive.address,
   );
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/markets/MarketDetailsBody/PriceBadges.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketDetailsBody/PriceBadges.tsx
@@ -17,7 +17,7 @@ export function PriceBadges({
     hyperdrive.address,
   );
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
   if (longPriceStatus !== "success") {

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/LiquidityStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/LiquidityStats.tsx
@@ -23,7 +23,7 @@ export function LiquidityStats({
   const { data: currentBlockNumber } = useBlockNumber();
   const appConfig = useAppConfig();
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
 

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/LiquidityStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/LiquidityStats.tsx
@@ -1,4 +1,4 @@
-import { HyperdriveConfig, findBaseToken } from "@hyperdrive/appconfig";
+import { HyperdriveConfig, findToken } from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
 import Skeleton from "react-loading-skeleton";
 import { MAX_UINT256 } from "src/base/constants";
@@ -22,7 +22,7 @@ export function LiquidityStats({
   const isTailwindSmallScreen = useIsTailwindSmallScreen();
   const { data: currentBlockNumber } = useBlockNumber();
   const appConfig = useAppConfig();
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/markets/ShortsTab/ShortsTab.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/ShortsTab/ShortsTab.tsx
@@ -1,5 +1,5 @@
 import { ExclamationTriangleIcon } from "@heroicons/react/16/solid";
-import { findBaseToken, HyperdriveConfig } from "@hyperdrive/appconfig";
+import { findToken, HyperdriveConfig } from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
 import Skeleton from "react-loading-skeleton";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
@@ -55,7 +55,7 @@ export function ShortsTab({
       ? isTotalOpenValueLoading
       : isTotalClosedValueLoading;
 
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/markets/ShortsTab/ShortsTab.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/ShortsTab/ShortsTab.tsx
@@ -56,7 +56,7 @@ export function ShortsTab({
       : isTotalClosedValueLoading;
 
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
 

--- a/apps/hyperdrive-trading/src/ui/markets/YourBalanceWell/YourBalanceWell.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/YourBalanceWell/YourBalanceWell.tsx
@@ -30,7 +30,7 @@ export function YourBalanceWell({
 
   // base token
   const baseToken = findToken({
-    baseTokenAddress: hyperdrive.poolConfig.baseToken,
+    tokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });
 

--- a/apps/hyperdrive-trading/src/ui/markets/YourBalanceWell/YourBalanceWell.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/YourBalanceWell/YourBalanceWell.tsx
@@ -2,7 +2,7 @@ import { EllipsisVerticalIcon } from "@heroicons/react/24/outline";
 import {
   HyperdriveConfig,
   TokenConfig,
-  findBaseToken,
+  findToken,
 } from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
 import Skeleton from "react-loading-skeleton";
@@ -29,7 +29,7 @@ export function YourBalanceWell({
   const appConfig = useAppConfig();
 
   // base token
-  const baseToken = findBaseToken({
+  const baseToken = findToken({
     baseTokenAddress: hyperdrive.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/packages/hyperdrive-appconfig/src/index.ts
+++ b/packages/hyperdrive-appconfig/src/index.ts
@@ -7,7 +7,7 @@ export { appConfig } from "src/generated/all.appconfig";
 
 // appconfig selectors
 export { findHyperdriveConfig } from "src/hyperdrives/selectors";
-export { findBaseToken } from "src/tokens/selectors";
+export { findToken } from "src/tokens/selectors";
 
 // hyperdrive
 export type { HyperdriveConfig } from "src/hyperdrives/HyperdriveConfig";

--- a/packages/hyperdrive-appconfig/src/tokens/selectors.ts
+++ b/packages/hyperdrive-appconfig/src/tokens/selectors.ts
@@ -3,11 +3,6 @@ import { Address } from "viem";
 
 /**
  * Returns a strongly typed TokenConfig for the token address
- * @deprecated This method is too shallow to be useful, use this instead:
- * ```
- * // Find the yield source token
- * appConfig.tokens.find(token => token.address === baseTokenAddress);
- * ```
  */
 export function findToken({
   tokenAddress,

--- a/packages/hyperdrive-appconfig/src/tokens/selectors.ts
+++ b/packages/hyperdrive-appconfig/src/tokens/selectors.ts
@@ -16,13 +16,13 @@ export function findToken({
   tokenAddress: Address;
   tokens: TokenConfig[];
 }): TokenConfig {
-  const baseToken = tokens.find((token) => tokenAddress === token.address);
+  const token = tokens.find((token) => tokenAddress === token.address);
 
-  if (!baseToken) {
+  if (!token) {
     throw new Error(
       `Missing token ${tokenAddress}. Make sure your appconfig's "tokens" property is properly constructed.`,
     );
   }
 
-  return baseToken;
+  return token;
 }

--- a/packages/hyperdrive-appconfig/src/tokens/selectors.ts
+++ b/packages/hyperdrive-appconfig/src/tokens/selectors.ts
@@ -2,25 +2,25 @@ import { TokenConfig } from "src/tokens/getTokenConfig";
 import { Address } from "viem";
 
 /**
- * Returns a strongly typed TokenConfig for the baseToken
+ * Returns a strongly typed TokenConfig for the token address
  * @deprecated This method is too shallow to be useful, use this instead:
  * ```
  * // Find the yield source token
  * appConfig.tokens.find(token => token.address === baseTokenAddress);
  * ```
  */
-export function findBaseToken({
-  baseTokenAddress,
+export function findToken({
+  tokenAddress,
   tokens,
 }: {
-  baseTokenAddress: Address;
+  tokenAddress: Address;
   tokens: TokenConfig[];
 }): TokenConfig {
-  const baseToken = tokens.find((token) => baseTokenAddress === token.address);
+  const baseToken = tokens.find((token) => tokenAddress === token.address);
 
   if (!baseToken) {
     throw new Error(
-      `Missing token ${baseTokenAddress}. Make sure your appconfig's "tokens" property is properly constructed.`,
+      `Missing token ${tokenAddress}. Make sure your appconfig's "tokens" property is properly constructed.`,
     );
   }
 


### PR DESCRIPTION
All tokens share the same interface, so you only need one selector, not multiple for different token types. 

Very mechanical, but does touch a lot of files.

