### PR TITLE
Add `chainId` to findToken selector

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongForm/CloseLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongForm/CloseLongForm.tsx
@@ -53,6 +53,7 @@ export function CloseLongForm({
   }
 
   const sharesToken = findToken({
+    chainId: hyperdrive.chainId,
     tokenAddress: hyperdrive.poolConfig.vaultSharesToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongModalButton/CloseLongModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongModalButton/CloseLongModalButton.tsx
@@ -27,6 +27,7 @@ export function CloseLongModalButton({
     appConfig,
   });
   const sharesToken = findToken({
+    chainId: hyperdrive.chainId,
     tokenAddress: hyperdrive.poolConfig.vaultSharesToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
@@ -1,6 +1,10 @@
 import { fixed } from "@delvtech/fixed-point-wasm";
 import { adjustAmountByPercentage } from "@delvtech/hyperdrive-js-core";
-import { findBaseToken, HyperdriveConfig } from "@hyperdrive/appconfig";
+import {
+  findBaseToken,
+  findToken,
+  HyperdriveConfig,
+} from "@hyperdrive/appconfig";
 import { MouseEvent, ReactElement } from "react";
 import { isTestnetChain } from "src/chains/isTestnetChain";
 import { getIsValidTradeSize } from "src/hyperdrive/getIsValidTradeSize";
@@ -69,9 +73,11 @@ export function OpenLongForm({
     });
   }
 
-  const sharesToken = appConfig.tokens.find(
-    (token) => token.address === hyperdrive.poolConfig.vaultSharesToken,
-  );
+  const sharesToken = findToken({
+    chainId: hyperdrive.chainId,
+    tokens: appConfig.tokens,
+    tokenAddress: hyperdrive.poolConfig.vaultSharesToken,
+  });
 
   if (sharesToken && hyperdrive.depositOptions.isShareTokenDepositsEnabled) {
     tokenChoices.push({

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktopTwo.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktopTwo.tsx
@@ -7,6 +7,7 @@ import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/outline";
 import {
   AppConfig,
   findBaseToken,
+  findToken,
   HyperdriveConfig,
 } from "@hyperdrive/appconfig";
 import {
@@ -60,9 +61,11 @@ export function OpenLongsContainer(): ReactElement {
           hyperdriveAddress: hyperdrive.address,
           appConfig,
         });
-        const sharesToken = appConfig.tokens.find(
-          (token) => token.address === hyperdrive.poolConfig.vaultSharesToken,
-        );
+        const sharesToken = findToken({
+          chainId: hyperdrive.chainId,
+          tokens: appConfig.tokens,
+          tokenAddress: hyperdrive.poolConfig.vaultSharesToken,
+        });
         // Ensure this hyperdrive pool has open positions before rendering.
         if (
           openLongPositionsStatus === "success" &&

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
@@ -5,6 +5,7 @@ import {
   HyperdriveConfig,
   TokenConfig,
   findBaseToken,
+  findToken,
 } from "@hyperdrive/appconfig";
 import classNames from "classnames";
 import { MouseEvent, ReactElement } from "react";
@@ -57,9 +58,11 @@ export function AddLiquidityForm({
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });
-  const sharesToken = appConfig.tokens.find(
-    (token) => token.address === hyperdrive.poolConfig.vaultSharesToken,
-  );
+  const sharesToken = findToken({
+    chainId: hyperdrive.chainId,
+    tokens: appConfig.tokens,
+    tokenAddress: hyperdrive.poolConfig.vaultSharesToken,
+  });
 
   const { vaultRate, vaultRateStatus } = useYieldSourceRate({
     hyperdriveAddress: hyperdrive.address,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/OpenLpSharesCard/OpenLpSharesCard.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/OpenLpSharesCard/OpenLpSharesCard.tsx
@@ -1,6 +1,7 @@
 import { XMarkIcon } from "@heroicons/react/24/outline";
 import {
   findBaseToken,
+  findToken,
   HyperdriveConfig,
   TokenConfig,
 } from "@hyperdrive/appconfig";
@@ -38,9 +39,11 @@ export function OpenLpSharesCard({
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });
-  const sharesToken = appConfig.tokens.find(
-    (token) => token.address === hyperdrive.poolConfig.vaultSharesToken,
-  );
+  const sharesToken = findToken({
+    chainId: hyperdrive.chainId,
+    tokens: appConfig.tokens,
+    tokenAddress: hyperdrive.poolConfig.vaultSharesToken,
+  });
 
   const { poolInfo } = usePoolInfo({ hyperdriveAddress: hyperdrive.address });
   const { lpShares, lpSharesStatus } = useLpShares({

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
@@ -1,6 +1,10 @@
 import { fixed } from "@delvtech/fixed-point-wasm";
 import { adjustAmountByPercentage } from "@delvtech/hyperdrive-viem";
-import { findBaseToken, HyperdriveConfig } from "@hyperdrive/appconfig";
+import {
+  findBaseToken,
+  findToken,
+  HyperdriveConfig,
+} from "@hyperdrive/appconfig";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
 import { MouseEvent, ReactElement } from "react";
 import { calculateValueFromPrice } from "src/base/calculateValueFromPrice";
@@ -40,9 +44,11 @@ export function RemoveLiquidityForm({
     appConfig,
   });
 
-  const sharesToken = appConfig.tokens.find(
-    (token) => token.address === hyperdrive.poolConfig.vaultSharesToken,
-  );
+  const sharesToken = findToken({
+    chainId: hyperdrive.chainId,
+    tokens: appConfig.tokens,
+    tokenAddress: hyperdrive.poolConfig.vaultSharesToken,
+  });
 
   const { balance: baseTokenBalance } = useTokenBalance({
     account,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortForm/CloseShortForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortForm/CloseShortForm.tsx
@@ -44,6 +44,7 @@ export function CloseShortForm({
     defaultItems.push(baseToken);
   }
   const sharesToken = findToken({
+    chainId: hyperdrive.chainId,
     tokenAddress: hyperdrive.poolConfig.vaultSharesToken,
     tokens: appConfig.tokens,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortModalButton/CloseShortModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortModalButton/CloseShortModalButton.tsx
@@ -4,6 +4,7 @@ import {
   HyperdriveConfig,
   TokenConfig,
   findBaseToken,
+  findToken,
 } from "@hyperdrive/appconfig";
 import classNames from "classnames";
 import { ReactElement } from "react";
@@ -30,9 +31,11 @@ export function CloseShortModalButton({
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });
-  const sharesToken = appConfig.tokens.find(
-    (token) => token.address === hyperdrive.poolConfig.vaultSharesToken,
-  );
+  const sharesToken = findToken({
+    chainId: hyperdrive.chainId,
+    tokens: appConfig.tokens,
+    tokenAddress: hyperdrive.poolConfig.vaultSharesToken,
+  });
   const subHeading = sharesToken
     ? getSubHeadingLabel(baseToken, hyperdrive, sharesToken)
     : "";

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
@@ -1,7 +1,11 @@
 import { fixed } from "@delvtech/fixed-point-wasm";
 import { adjustAmountByPercentage } from "@delvtech/hyperdrive-js-core";
 
-import { findBaseToken, HyperdriveConfig } from "@hyperdrive/appconfig";
+import {
+  findBaseToken,
+  findToken,
+  HyperdriveConfig,
+} from "@hyperdrive/appconfig";
 import { MouseEvent, ReactElement, useState } from "react";
 import Skeleton from "react-loading-skeleton";
 import { MAX_UINT256 } from "src/base/constants";
@@ -84,9 +88,11 @@ export function OpenShortForm({
     });
   }
 
-  const sharesToken = appConfig.tokens.find(
-    (token) => token.address === hyperdrive.poolConfig.vaultSharesToken,
-  );
+  const sharesToken = findToken({
+    chainId: hyperdrive.chainId,
+    tokens: appConfig.tokens,
+    tokenAddress: hyperdrive.poolConfig.vaultSharesToken,
+  });
 
   if (sharesToken && shareTokenDepositsEnabled) {
     tokenOptions.push({

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktopTwo.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktopTwo.tsx
@@ -4,6 +4,7 @@ import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/outline";
 import {
   AppConfig,
   findBaseToken,
+  findToken,
   HyperdriveConfig,
 } from "@hyperdrive/appconfig";
 import {
@@ -44,9 +45,11 @@ export function OpenShortsContainer(): ReactElement {
           hyperdriveAddress: hyperdrive.address,
           appConfig,
         });
-        const sharesToken = appConfig.tokens.find(
-          (token) => token.address === hyperdrive.poolConfig.vaultSharesToken,
-        );
+        const sharesToken = findToken({
+          chainId: hyperdrive.chainId,
+          tokens: appConfig.tokens,
+          tokenAddress: hyperdrive.poolConfig.vaultSharesToken,
+        });
         // Ensure this hyperdrive pool has open positions before rendering.
         if (
           openShortPositionsStatus === "success" &&

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/withdrawalShares/RedeemWithdrawalSharesForm/RedeemWithdrawalSharesForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/withdrawalShares/RedeemWithdrawalSharesForm/RedeemWithdrawalSharesForm.tsx
@@ -2,6 +2,7 @@ import { fixed } from "@delvtech/fixed-point-wasm";
 import { adjustAmountByPercentage } from "@delvtech/hyperdrive-viem";
 import {
   findBaseToken,
+  findToken,
   HyperdriveConfig,
   TokenConfig,
 } from "@hyperdrive/appconfig";
@@ -36,9 +37,11 @@ export function RedeemWithdrawalSharesForm({
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });
-  const sharesToken = appConfig.tokens.find(
-    (token) => token.address === hyperdrive.poolConfig.vaultSharesToken,
-  );
+  const sharesToken = findToken({
+    chainId: hyperdrive.chainId,
+    tokens: appConfig.tokens,
+    tokenAddress: hyperdrive.poolConfig.vaultSharesToken,
+  });
   const items: TokenConfig[] = [baseToken];
   if (sharesToken) {
     items.push(sharesToken);

--- a/apps/hyperdrive-trading/src/ui/markets/AssetStack.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/AssetStack.tsx
@@ -1,4 +1,4 @@
-import { findBaseToken } from "@hyperdrive/appconfig";
+import { findBaseToken, findToken } from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { Address } from "viem";
@@ -16,9 +16,11 @@ export function AssetStack({
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });
-  const sharesToken = appConfig.tokens.find(
-    (token) => hyperdrive.poolConfig.vaultSharesToken === token.address,
-  );
+  const sharesToken = findToken({
+    chainId: hyperdrive.chainId,
+    tokens: appConfig.tokens,
+    tokenAddress: hyperdrive.poolConfig.vaultSharesToken,
+  });
   return (
     <div
       className={

--- a/apps/hyperdrive-trading/src/ui/markets/MarketDetailsBody/MarketHeader.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketDetailsBody/MarketHeader.tsx
@@ -1,5 +1,9 @@
 import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/outline";
-import { HyperdriveConfig, findBaseToken } from "@hyperdrive/appconfig";
+import {
+  HyperdriveConfig,
+  findBaseToken,
+  findToken,
+} from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
 import { getAnalyticsUrl } from "src/ui/analytics/getAnalyticsUrl";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
@@ -15,9 +19,11 @@ export function MarketHeader({
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });
-  const sharesToken = appConfig.tokens.find(
-    (token) => token.address === hyperdrive.poolConfig.vaultSharesToken,
-  );
+  const sharesToken = findToken({
+    chainId: hyperdrive.chainId,
+    tokens: appConfig.tokens,
+    tokenAddress: hyperdrive.poolConfig.vaultSharesToken,
+  });
   const analyticsUrl = getAnalyticsUrl({
     chainId: hyperdrive.chainId,
     hyperdrive: hyperdrive.address,

--- a/apps/hyperdrive-trading/src/ui/markets/YourBalanceWell/YourBalanceWell.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/YourBalanceWell/YourBalanceWell.tsx
@@ -3,6 +3,7 @@ import {
   HyperdriveConfig,
   TokenConfig,
   findBaseToken,
+  findToken,
 } from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
 import Skeleton from "react-loading-skeleton";
@@ -34,9 +35,11 @@ export function YourBalanceWell({
   });
 
   // shares token
-  const sharesToken = appConfig.tokens.find(
-    (token) => token.address === hyperdrive.poolConfig.vaultSharesToken,
-  );
+  const sharesToken = findToken({
+    chainId: hyperdrive.chainId,
+    tokens: appConfig.tokens,
+    tokenAddress: hyperdrive.poolConfig.vaultSharesToken,
+  });
 
   return (
     <Well elevation="flat">

--- a/packages/hyperdrive-appconfig/src/hyperdrives/selectors.ts
+++ b/packages/hyperdrive-appconfig/src/hyperdrives/selectors.ts
@@ -53,6 +53,7 @@ export function findBaseToken({
     hyperdriveConfig.baseTokenFallback
   ) {
     baseToken = findToken({
+      chainId: hyperdriveConfig.baseTokenFallback.chainId,
       tokenAddress: hyperdriveConfig.baseTokenFallback.address,
       tokens: appConfig.tokens,
     });
@@ -60,6 +61,7 @@ export function findBaseToken({
 
   // Otherwise, use the pool's base token
   baseToken = findToken({
+    chainId: hyperdriveConfig.chainId,
     tokenAddress: hyperdriveConfig.poolConfig.baseToken,
     tokens: appConfig.tokens,
   });

--- a/packages/hyperdrive-appconfig/src/tokens/selectors.ts
+++ b/packages/hyperdrive-appconfig/src/tokens/selectors.ts
@@ -5,13 +5,17 @@ import { Address } from "viem";
  * Returns a strongly typed TokenConfig for the token address if it exists.
  */
 export function findToken({
+  chainId,
   tokenAddress,
   tokens,
 }: {
+  chainId: number;
   tokenAddress: Address;
   tokens: TokenConfig[];
 }): TokenConfig | undefined {
-  const token = tokens.find((token) => tokenAddress === token.address);
+  const token = tokens.find(
+    (token) => token.address == tokenAddress && token.chainId === chainId,
+  );
 
   return token;
 }


### PR DESCRIPTION
Tokens can have the same address on different chains, so this selector now takes the `chainId` as a required parameter.