### PR TITLE
Add `chainId` to anywhere that hyperdrive addresses are used

### DIFF
--- a/apps/hyperdrive-trading/src/hyperdrive/getReadHyperdrive.ts
+++ b/apps/hyperdrive-trading/src/hyperdrive/getReadHyperdrive.ts
@@ -35,8 +35,8 @@ export async function getReadHyperdrive({
 
   try {
     // steth
-
     const hyperdriveConfig = findHyperdriveConfig({
+      hyperdriveChainId: publicClient.chain?.id as number,
       hyperdriveAddress,
       hyperdrives: appConfig.hyperdrives,
     });

--- a/apps/hyperdrive-trading/src/hyperdrive/getReadWriteHyperdrive.ts
+++ b/apps/hyperdrive-trading/src/hyperdrive/getReadWriteHyperdrive.ts
@@ -39,6 +39,7 @@ export async function getReadWriteHyperdrive({
     // steth
 
     const hyperdriveConfig = findHyperdriveConfig({
+      hyperdriveChainId: publicClient.chain?.id as number,
       hyperdriveAddress,
       hyperdrives: appConfig.hyperdrives,
     });

--- a/apps/hyperdrive-trading/src/hyperdrive/getYieldSourceRate.ts
+++ b/apps/hyperdrive-trading/src/hyperdrive/getYieldSourceRate.ts
@@ -7,7 +7,9 @@ export async function getYieldSourceRate(
   readHyperdrive: ReadHyperdrive,
   appConfig: AppConfig,
 ): Promise<bigint> {
+  const hyperdriveChainId = await readHyperdrive.network.getChainId();
   const hyperdrive = findHyperdriveConfig({
+    hyperdriveChainId,
     hyperdriveAddress: readHyperdrive.address,
     hyperdrives: appConfig.hyperdrives,
   });

--- a/apps/hyperdrive-trading/src/ui/base/components/Toaster/TransactionToast.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/Toaster/TransactionToast.tsx
@@ -2,17 +2,17 @@ import { ArrowRightIcon } from "@heroicons/react/24/outline";
 import { makeTransactionURL } from "src/blockexplorer/makeTransactionUrl";
 import { SupportedChainId } from "src/chains/supportedChains";
 import { Hash } from "viem";
-import { useChainId } from "wagmi";
 
 export default function TransactionToast({
+  chainId,
   message,
   txHash,
 }: {
+  chainId: number;
   message: string;
   txHash: Hash;
 }): JSX.Element {
-  const chainId = useChainId() as SupportedChainId;
-  const link = makeTransactionURL(txHash, chainId);
+  const link = makeTransactionURL(txHash, chainId as SupportedChainId);
 
   return (
     <span className="flex flex-col">

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/TransactionTable/TransactionsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/TransactionTable/TransactionsTable.tsx
@@ -67,6 +67,7 @@ export function TransactionTable({
 }): JSX.Element {
   const { data: transactionData, isLoading } = useTransactionData({
     hyperdriveAddress: hyperdrive.address,
+    chainId: hyperdrive.chainId,
     account,
   });
   const appConfig = useAppConfig();

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/TransactionTable/TransactionsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/TransactionTable/TransactionsTable.tsx
@@ -183,6 +183,7 @@ export function TransactionTable({
 
 function getColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });
@@ -294,6 +295,7 @@ function formatTransactionTableMobileData(
   appConfig: AppConfig,
 ) {
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/TransactionTable/useTransactionData.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/TransactionTable/useTransactionData.ts
@@ -6,7 +6,7 @@ import { convertSharesToBase } from "src/hyperdrive/convertSharesToBase";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address, Hash } from "viem";
-export type TransactionData = {
+export interface TransactionData {
   assetId?: bigint;
   baseAmount: bigint;
   bondAmount?: bigint;
@@ -16,22 +16,28 @@ export type TransactionData = {
   lpSharePrice?: bigint;
   blockNumber: bigint | undefined;
   transactionHash: Hash | undefined;
-};
+}
 
 export function useTransactionData({
   hyperdriveAddress,
   account,
+  chainId,
 }: {
   account?: Address;
   hyperdriveAddress: Address;
+  chainId: number;
 }): {
   data: TransactionData[] | undefined;
   isLoading: boolean;
 } {
-  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
+  const readHyperdrive = useReadHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const appConfig = useAppConfig();
   const { decimals } = findHyperdriveConfig({
     hyperdriveAddress,
+    hyperdriveChainId: chainId,
     hyperdrives: appConfig.hyperdrives,
   });
 

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/TransactionTable/useTransactionData.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/TransactionTable/useTransactionData.ts
@@ -42,7 +42,11 @@ export function useTransactionData({
   });
 
   const { data: longs, status: longEventsStatus } = useQuery({
-    queryKey: makeQueryKey("longEvents", { hyperdriveAddress, account }),
+    queryKey: makeQueryKey("longEvents", {
+      chainId,
+      hyperdriveAddress,
+      account,
+    }),
     enabled: !!readHyperdrive,
     queryFn: !!readHyperdrive
       ? async () =>
@@ -53,7 +57,11 @@ export function useTransactionData({
   });
 
   const { data: shorts, status: shortEventsStatus } = useQuery({
-    queryKey: makeQueryKey("shortEvents", { hyperdriveAddress, account }),
+    queryKey: makeQueryKey("shortEvents", {
+      chainId,
+      hyperdriveAddress,
+      account,
+    }),
     enabled: !!readHyperdrive,
     queryFn: !!readHyperdrive
       ? async () =>
@@ -63,7 +71,7 @@ export function useTransactionData({
       : undefined,
   });
   const { data: lpEvents, status: lpEventsStatus } = useQuery({
-    queryKey: makeQueryKey("lpEvents", { hyperdriveAddress, account }),
+    queryKey: makeQueryKey("lpEvents", { chainId, hyperdriveAddress, account }),
     enabled: !!readHyperdrive,
     queryFn: !!readHyperdrive
       ? async () =>

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useAccruedYield.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useAccruedYield.ts
@@ -16,7 +16,10 @@ export function useAccruedYield({
   accruedYield: bigint | undefined;
   status: QueryStatusWithIdle;
 } {
-  const readHyperdrive = useReadHyperdrive(hyperdrive.address);
+  const readHyperdrive = useReadHyperdrive({
+    chainId: hyperdrive.chainId,
+    address: hyperdrive.address,
+  });
   const queryEnabled = !!readHyperdrive;
   const { data, status, fetchStatus } = useQuery({
     queryKey: makeQueryKey("accruedYield", {

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useAccruedYield.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useAccruedYield.ts
@@ -23,6 +23,7 @@ export function useAccruedYield({
   const queryEnabled = !!readHyperdrive;
   const { data, status, fetchStatus } = useQuery({
     queryKey: makeQueryKey("accruedYield", {
+      chainId: hyperdrive.chainId,
       hyperdriveAddress: hyperdrive.address,
       checkpointId: checkpointTime.toString(),
       bondAmount: bondAmount.toString(),

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useDevLogging.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useDevLogging.ts
@@ -15,7 +15,10 @@ export function useDevLogging(hyperdrive: HyperdriveConfig): void {
     }
   }, [hyperdrive.decimals, hyperdrive.poolConfig]);
 
-  const { poolInfo } = usePoolInfo({ hyperdriveAddress: hyperdrive.address });
+  const { poolInfo } = usePoolInfo({
+    chainId: hyperdrive.chainId,
+    hyperdriveAddress: hyperdrive.address,
+  });
   useEffect(() => {
     if (import.meta.env.DEV) {
       console.log("Pool Info:");

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useIdleLiquidity.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useIdleLiquidity.ts
@@ -5,13 +5,18 @@ import { Address } from "viem";
 
 export function useIdleLiquidity({
   hyperdriveAddress,
+  chainId,
 }: {
   hyperdriveAddress: Address;
+  chainId: number;
 }): {
   idleLiquidity: bigint | undefined;
   idleLiquidityStatus: QueryStatus;
 } {
-  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
+  const readHyperdrive = useReadHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const queryEnabled = !!readHyperdrive;
   const { data, status } = useQuery({
     queryKey: makeQueryKey("liquidity", { hyperdriveAddress }),

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useIdleLiquidity.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useIdleLiquidity.ts
@@ -19,7 +19,7 @@ export function useIdleLiquidity({
   });
   const queryEnabled = !!readHyperdrive;
   const { data, status } = useQuery({
-    queryKey: makeQueryKey("liquidity", { hyperdriveAddress }),
+    queryKey: makeQueryKey("liquidity", { chainId, hyperdriveAddress }),
     queryFn: queryEnabled ? () => readHyperdrive.getIdleLiquidity() : undefined,
     enabled: queryEnabled,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useLpApy.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useLpApy.ts
@@ -7,21 +7,33 @@ import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { usePoolInfo } from "src/ui/hyperdrive/hooks/usePoolInfo";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
-import { useBlockNumber, useChainId } from "wagmi";
+import { useBlockNumber } from "wagmi";
 
-export function useLpApy(hyperdriveAddress: Address): {
+export function useLpApy({
+  hyperdriveAddress,
+  chainId,
+}: {
+  hyperdriveAddress: Address;
+  chainId: number;
+}): {
   lpApy: number | undefined;
   lpApyStatus: "error" | "success" | "loading";
 } {
-  const chainId = useChainId();
-  const { poolInfo: currentPoolInfo } = usePoolInfo({ hyperdriveAddress });
+  const { poolInfo: currentPoolInfo } = usePoolInfo({
+    hyperdriveAddress,
+    chainId,
+  });
   const appConfig = useAppConfig();
   const hyperdrive = findHyperdriveConfig({
+    hyperdriveChainId: chainId,
     hyperdriveAddress,
     hyperdrives: appConfig.hyperdrives,
   });
-  const { data: blockNumber } = useBlockNumber({ chainId: hyperdrive.chainId });
-  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
+  const { data: blockNumber } = useBlockNumber({ chainId });
+  const readHyperdrive = useReadHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const queryEnabled = !!readHyperdrive && !!blockNumber && !!currentPoolInfo;
   const { data, status } = useQuery({
     queryKey: makeQueryKey("getLpApy", {
@@ -32,7 +44,7 @@ export function useLpApy(hyperdriveAddress: Address): {
     queryFn: queryEnabled
       ? async () => {
           const numBlocksForHistoricalRate =
-            hyperdrive.chainId === cloudChain.id
+            chainId === cloudChain.id
               ? 1000n // roughly 3 hours for cloudchain
               : DAILY_AVERAGE_BLOCK_TOTAL *
                 BigInt(

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useMarketState.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useMarketState.ts
@@ -3,16 +3,25 @@ import { QueryStatus, useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
-export function useMarketState(hyperdrive: Address): {
+export function useMarketState({
+  hyperdriveAddress,
+  chainId,
+}: {
+  hyperdriveAddress: Address;
+  chainId: number;
+}): {
   marketState:
     | Awaited<ReturnType<ReadHyperdrive["getMarketState"]>>
     | undefined;
   marketStateStatus: QueryStatus;
 } {
-  const readHyperdrive = useReadHyperdrive(hyperdrive);
+  const readHyperdrive = useReadHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const queryEnabled = !!readHyperdrive;
   const { data: marketState, status: marketStateStatus } = useQuery({
-    queryKey: makeQueryKey("marketState", { hyperdrive }),
+    queryKey: makeQueryKey("marketState", { hyperdrive: hyperdriveAddress }),
     queryFn: queryEnabled ? () => readHyperdrive.getMarketState() : undefined,
     enabled: queryEnabled,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useMarketState.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useMarketState.ts
@@ -21,7 +21,10 @@ export function useMarketState({
   });
   const queryEnabled = !!readHyperdrive;
   const { data: marketState, status: marketStateStatus } = useQuery({
-    queryKey: makeQueryKey("marketState", { hyperdrive: hyperdriveAddress }),
+    queryKey: makeQueryKey("marketState", {
+      hyperdrive: hyperdriveAddress,
+      chainId,
+    }),
     queryFn: queryEnabled ? () => readHyperdrive.getMarketState() : undefined,
     enabled: queryEnabled,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/usePoolInfo.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/usePoolInfo.ts
@@ -21,6 +21,7 @@ export function usePoolInfo({
   const queryEnabled = !!readHyperdrive && !!enabled;
   const { data: poolInfo } = useQuery({
     queryKey: makeQueryKey("poolInfo", {
+      chainId,
       hyperdriveAddress,
     }),
     queryFn: queryEnabled ? () => readHyperdrive.getPoolInfo() : undefined,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/usePoolInfo.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/usePoolInfo.ts
@@ -5,14 +5,19 @@ import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
 export function usePoolInfo({
   hyperdriveAddress,
+  chainId,
   enabled = true,
 }: {
   hyperdriveAddress: Address;
+  chainId: number;
   enabled?: boolean;
 }): {
   poolInfo: PoolInfo | undefined;
 } {
-  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
+  const readHyperdrive = useReadHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const queryEnabled = !!readHyperdrive && !!enabled;
   const { data: poolInfo } = useQuery({
     queryKey: makeQueryKey("poolInfo", {

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/usePrepareSharesIn.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/usePrepareSharesIn.ts
@@ -10,17 +10,22 @@ import { Address } from "viem";
 export function usePrepareSharesIn({
   sharesAmount,
   hyperdriveAddress,
+  chainId,
   enabled,
 }: {
   sharesAmount: bigint | undefined;
   hyperdriveAddress: Address;
+  chainId: number;
   enabled: boolean;
 }): {
   amount: bigint | undefined;
   status: QueryStatusWithIdle;
 } {
   const appConfig = useAppConfig();
-  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
+  const readHyperdrive = useReadHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
 
   const queryEnabled =
     !!readHyperdrive && sharesAmount !== undefined && enabled;
@@ -34,7 +39,7 @@ export function usePrepareSharesIn({
       ? () =>
           prepareSharesIn({
             appConfig,
-            hyperdriveAddress,
+            chainId,
             sharesAmount,
             readHyperdrive,
           })
@@ -49,18 +54,19 @@ export function usePrepareSharesIn({
 
 export async function prepareSharesIn({
   appConfig,
-  hyperdriveAddress,
+  chainId,
   sharesAmount,
   readHyperdrive,
 }: {
   appConfig: AppConfig;
-  hyperdriveAddress: Address;
+  chainId: number;
   sharesAmount: bigint;
   readHyperdrive: ReadHyperdrive;
 }): Promise<bigint> {
   const hyperdriveConfig = findHyperdriveConfig({
+    hyperdriveChainId: chainId,
     hyperdrives: appConfig.hyperdrives,
-    hyperdriveAddress: hyperdriveAddress,
+    hyperdriveAddress: readHyperdrive.address,
   });
 
   // If the shares token is pegged to its base token (e.g., stETH to ETH), then

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/usePrepareSharesIn.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/usePrepareSharesIn.ts
@@ -32,6 +32,7 @@ export function usePrepareSharesIn({
   const { data, status, fetchStatus } = useQuery({
     queryKey: makeQueryKey("prepare-shares-amount-in", {
       hyperdrive: hyperdriveAddress,
+      chainId,
       amount: sharesAmount?.toString(),
     }),
     enabled: queryEnabled,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/usePrepareSharesOut.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/usePrepareSharesOut.ts
@@ -10,9 +10,11 @@ import { Address } from "viem";
 export function usePrepareSharesOut({
   sharesAmount,
   hyperdriveAddress,
+  chainId,
   enabled = true,
 }: {
   sharesAmount: bigint | undefined;
+  chainId: number;
   hyperdriveAddress: Address;
   enabled?: boolean;
 }): {
@@ -20,7 +22,10 @@ export function usePrepareSharesOut({
   status: QueryStatusWithIdle;
 } {
   const appConfig = useAppConfig();
-  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
+  const readHyperdrive = useReadHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
 
   const queryEnabled =
     !!readHyperdrive && sharesAmount !== undefined && enabled;
@@ -34,7 +39,7 @@ export function usePrepareSharesOut({
       ? () =>
           prepareSharesOut({
             appConfig,
-            hyperdriveAddress,
+            chainId,
             sharesAmount,
             readHyperdrive,
           })
@@ -49,12 +54,12 @@ export function usePrepareSharesOut({
 
 export async function prepareSharesOut({
   appConfig,
-  hyperdriveAddress,
+  chainId,
   sharesAmount,
   readHyperdrive,
 }: {
   appConfig: AppConfig;
-  hyperdriveAddress: Address;
+  chainId: number;
   sharesAmount: bigint;
   readHyperdrive: ReadHyperdrive;
 }): Promise<bigint> {
@@ -63,8 +68,9 @@ export async function prepareSharesOut({
   }
 
   const hyperdriveConfig = findHyperdriveConfig({
+    hyperdriveChainId: chainId,
     hyperdrives: appConfig.hyperdrives,
-    hyperdriveAddress: hyperdriveAddress,
+    hyperdriveAddress: readHyperdrive.address,
   });
 
   // If the shares token is pegged to its base token (e.g., stETH to ETH), then

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/usePrepareSharesOut.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/usePrepareSharesOut.ts
@@ -31,6 +31,7 @@ export function usePrepareSharesOut({
     !!readHyperdrive && sharesAmount !== undefined && enabled;
   const { data, status, fetchStatus } = useQuery({
     queryKey: makeQueryKey("prepare-shares-amount-out", {
+      chainId,
       hyperdrive: hyperdriveAddress,
       amount: sharesAmount?.toString(),
     }),

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/usePresentValue.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/usePresentValue.ts
@@ -4,14 +4,19 @@ import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
 
 export function usePresentValue({
+  chainId,
   hyperdriveAddress,
 }: {
+  chainId: number;
   hyperdriveAddress: Address;
 }): {
   presentValue: bigint | undefined;
   presentValueStatus: QueryStatus;
 } {
-  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
+  const readHyperdrive = useReadHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const queryEnabled = !!readHyperdrive;
   const { data, status } = useQuery({
     queryKey: makeQueryKey("present-value", { hyperdriveAddress }),

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/usePresentValue.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/usePresentValue.ts
@@ -19,7 +19,7 @@ export function usePresentValue({
   });
   const queryEnabled = !!readHyperdrive;
   const { data, status } = useQuery({
-    queryKey: makeQueryKey("present-value", { hyperdriveAddress }),
+    queryKey: makeQueryKey("present-value", { chainId, hyperdriveAddress }),
     queryFn: queryEnabled ? () => readHyperdrive.getPresentValue() : undefined,
     enabled: queryEnabled,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useReadHyperdrive.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useReadHyperdrive.ts
@@ -6,14 +6,16 @@ import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { Address } from "viem";
 import { usePublicClient } from "wagmi";
 
-export function useReadHyperdrive(
-  address: Address | undefined,
-): ReadHyperdrive | undefined {
+export function useReadHyperdrive({
+  chainId,
+  address,
+}: {
+  chainId: number;
+  address: Address | undefined;
+}): ReadHyperdrive | undefined {
   const appConfig = useAppConfig();
-  const pool = appConfig.hyperdrives.find(
-    (hyperdrive) => hyperdrive.address === address,
-  );
-  const publicClient = usePublicClient({ chainId: pool?.chainId });
+
+  const publicClient = usePublicClient({ chainId });
 
   const enabled = !!address && !!publicClient;
 

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useReadHyperdrive.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useReadHyperdrive.ts
@@ -21,6 +21,7 @@ export function useReadHyperdrive({
 
   const { data } = useQuery({
     queryKey: makeQueryKey("getReadHyperdrive", {
+      chainId,
       address,
     }),
     enabled,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useReadWriteHyperdrive.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useReadWriteHyperdrive.ts
@@ -6,11 +6,15 @@ import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { Address } from "viem";
 import { usePublicClient, useWalletClient } from "wagmi";
 
-export function useReadWriteHyperdrive(
-  address: Address | undefined,
-): ReadWriteHyperdrive | undefined {
-  const publicClient = usePublicClient();
-  const { data: walletClient } = useWalletClient();
+export function useReadWriteHyperdrive({
+  address,
+  chainId,
+}: {
+  address: Address | undefined;
+  chainId: number;
+}): ReadWriteHyperdrive | undefined {
+  const publicClient = usePublicClient({ chainId });
+  const { data: walletClient } = useWalletClient({ chainId });
 
   const appConfig = useAppConfig();
 
@@ -18,6 +22,7 @@ export function useReadWriteHyperdrive(
 
   const { data } = useQuery({
     queryKey: makeQueryKey("getReadWriteHyperdrive", {
+      chainId,
       address,
     }),
     enabled,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useTradingVolume.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useTradingVolume.ts
@@ -4,6 +4,7 @@ import { makeQueryKey } from "src/base/makeQueryKey";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address, BlockTag } from "viem";
 export function useTradingVolume(
+  chainId: number,
   hyperdriveAddress: Address,
   currentBlockNumber: bigint | undefined,
 ): {
@@ -12,7 +13,10 @@ export function useTradingVolume(
   shortVolume: bigint | undefined;
   tradingVolumeStatus: "loading" | "error" | "success";
 } {
-  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
+  const readHyperdrive = useReadHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const queryEnabled = !!readHyperdrive && currentBlockNumber !== undefined;
 
   // If we have at least 1 day of blocks, go back by 1 day, otherwise

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useTradingVolume.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useTradingVolume.ts
@@ -31,6 +31,7 @@ export function useTradingVolume(
 
   const { data: volume, status } = useQuery({
     queryKey: makeQueryKey("tradingVolume", {
+      chainId,
       hyperdriveAddress,
       currentBlockNumber: currentBlockNumber?.toString(),
       fromBlock: fromBlock.toString(),

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongForm/CloseLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongForm/CloseLongForm.tsx
@@ -125,8 +125,7 @@ export function CloseLongForm({
     asBase: activeWithdrawToken.address === hyperdrive.poolConfig.baseToken,
     enabled: previewCloseLongStatus === "success",
     onSubmitted: () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any)[`${long.assetId}`].close();
+      (document.getElementById(`${long.assetId}`) as HTMLDialogElement).close();
     },
     onExecuted: () => {
       setAmount("");

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongForm/CloseLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongForm/CloseLongForm.tsx
@@ -26,7 +26,7 @@ import { TokenInputTwo } from "src/ui/token/TokenInputTwo";
 import { TokenChoice } from "src/ui/token/TokenPicker";
 import { TokenPickerTwo } from "src/ui/token/TokenPickerTwo";
 import { Address, formatUnits, parseUnits } from "viem";
-import { useAccount, useChainId } from "wagmi";
+import { useAccount } from "wagmi";
 
 interface CloseLongFormProps {
   hyperdrive: HyperdriveConfig;
@@ -41,7 +41,6 @@ export function CloseLongForm({
 }: CloseLongFormProps): ReactElement {
   const appConfig = useAppConfig();
   const { address: account } = useAccount();
-  const chainId = useChainId();
 
   const defaultItems: TokenConfig[] = [];
   const baseToken = findBaseToken({
@@ -100,6 +99,7 @@ export function CloseLongForm({
     previewCloseLongStatus,
     previewCloseLongError,
   } = usePreviewCloseLong({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     maturityTime: long.maturity,
     bondAmountIn: bondAmountAsBigInt,
@@ -116,6 +116,7 @@ export function CloseLongForm({
     });
 
   const { closeLong, closeLongStatus } = useCloseLong({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     maturityTime: long.maturity,
     bondAmountIn: bondAmountAsBigInt,
@@ -124,6 +125,7 @@ export function CloseLongForm({
     asBase: activeWithdrawToken.address === hyperdrive.poolConfig.baseToken,
     enabled: previewCloseLongStatus === "success",
     onSubmitted: () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (window as any)[`${long.assetId}`].close();
     },
     onExecuted: () => {
@@ -202,7 +204,7 @@ export function CloseLongForm({
               disabled
               bottomLeftElement={
                 // Defillama fetches the token price via {chain}:{tokenAddress}. Since the token address differs on testnet, price display is disabled there.
-                !isTestnetChain(chainId) ? (
+                !isTestnetChain(hyperdrive.chainId) ? (
                   <label className="text-sm text-neutral-content">
                     {`$${formatBalance({
                       balance:

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongForm/CloseLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongForm/CloseLongForm.tsx
@@ -46,6 +46,7 @@ export function CloseLongForm({
   const defaultItems: TokenConfig[] = [];
   const baseToken = findBaseToken({
     hyperdriveAddress: hyperdrive.address,
+    hyperdriveChainId: hyperdrive.chainId,
     appConfig,
   });
   if (hyperdrive.withdrawOptions.isBaseTokenWithdrawalEnabled) {

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongModalButton/CloseLongModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongModalButton/CloseLongModalButton.tsx
@@ -23,6 +23,7 @@ export function CloseLongModalButton({
 }: CloseLongModalButtonProps): ReactElement {
   const appConfig = useAppConfig();
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/ClosedLongsTable/ClosedLongsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/ClosedLongsTable/ClosedLongsTable.tsx
@@ -186,6 +186,7 @@ export function ClosedLongsTable({
   const isTailwindSmallScreen = useIsTailwindSmallScreen();
   const { closedLongs, closedLongsStatus } = useClosedLongs({
     account,
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
   });
   const reversedClosedLongs = useMemo(

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/ClosedLongsTable/ClosedLongsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/ClosedLongsTable/ClosedLongsTable.tsx
@@ -74,6 +74,7 @@ function formatClosedLongMobileColumnData(
 
 function getMobileColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });
@@ -119,6 +120,7 @@ function getMobileColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
 
 function getColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });
@@ -303,6 +305,7 @@ function BaseAmountReceivedCell({
 }) {
   const appConfig = useAppConfig();
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
@@ -49,6 +49,7 @@ export function OpenLongForm({
   const appConfig = useAppConfig();
   const { poolInfo } = usePoolInfo({ hyperdriveAddress: hyperdrive.address });
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
@@ -181,8 +181,7 @@ export function OpenLongForm({
     destination: account,
     enabled: openLongPreviewStatus === "success" && hasEnoughAllowance,
     onSubmitted: () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any)["open-long"].close();
+      (document.getElementById("open-long") as HTMLDialogElement).close();
     },
     onExecuted: () => {
       setAmount("");

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
@@ -47,7 +47,10 @@ export function OpenLongForm({
   const chainId = useChainId();
 
   const appConfig = useAppConfig();
-  const { poolInfo } = usePoolInfo({ hyperdriveAddress: hyperdrive.address });
+  const { poolInfo } = usePoolInfo({
+    hyperdriveAddress: hyperdrive.address,
+    chainId: hyperdrive.chainId,
+  });
   const baseToken = findBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
@@ -128,6 +131,7 @@ export function OpenLongForm({
 
   const { maxBaseIn, maxSharesIn, maxBondsOut } = useMaxLong({
     hyperdriveAddress: hyperdrive.address,
+    chainId: hyperdrive.chainId,
   });
   const activeTokenMaxTradeSize =
     activeToken.address === baseToken.address ? maxBaseIn : maxSharesIn;
@@ -143,6 +147,7 @@ export function OpenLongForm({
     curveFee,
     status: openLongPreviewStatus,
   } = usePreviewOpenLong({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     amountIn: depositAmountAsBigInt,
     asBase: activeToken.address === baseToken.address,
@@ -166,6 +171,7 @@ export function OpenLongForm({
     });
 
   const { openLong, openLongStatus } = useOpenLong({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     asBase: activeToken.address === baseToken.address,
     amount: depositAmountAsBigInt,
@@ -175,6 +181,7 @@ export function OpenLongForm({
     destination: account,
     enabled: openLongPreviewStatus === "success" && hasEnoughAllowance,
     onSubmitted: () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (window as any)["open-long"].close();
     },
     onExecuted: () => {

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongModalButton/OpenLongModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongModalButton/OpenLongModalButton.tsx
@@ -17,9 +17,13 @@ export function OpenLongModalButton({
   modalId,
   hyperdrive,
 }: OpenLongModalButtonProps): ReactElement {
-  const { marketState } = useMarketState(hyperdrive.address);
+  const { marketState } = useMarketState({
+    chainId: hyperdrive.chainId,
+    hyperdriveAddress: hyperdrive.address,
+  });
 
   function closeModal() {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window as any)[modalId].close();
   }
 

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongPreview.tsx
@@ -44,6 +44,7 @@ export function OpenLongPreview({
 }: OpenLongPreviewProps): ReactElement {
   const appConfig = useAppConfig();
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongPreview.tsx
@@ -49,7 +49,10 @@ export function OpenLongPreview({
     appConfig,
   });
   const yieldSource = appConfig.yieldSources[hyperdrive.yieldSource];
-  const { fixedApr } = useFixedRate(hyperdrive.address);
+  const { fixedApr } = useFixedRate({
+    chainId: hyperdrive.chainId,
+    hyperdriveAddress: hyperdrive.address,
+  });
 
   const isBaseAmount = asBase || yieldSource.isSharesPeggedToBase;
   const amountPaidInBase = isBaseAmount

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongStats.tsx
@@ -39,6 +39,7 @@ export function OpenLongStats({
 }: OpenLongStatsProps): JSX.Element {
   const appConfig = useAppConfig();
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongStats.tsx
@@ -18,7 +18,6 @@ import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { useFixedRate } from "src/ui/hyperdrive/longs/hooks/useFixedRate";
 import { useTokenFiatPrices } from "src/ui/token/hooks/useTokenFiatPrices";
 import { Address } from "viem";
-import { useChainId } from "wagmi";
 interface OpenLongStatsProps {
   hyperdrive: HyperdriveConfig;
   bondAmount: bigint;
@@ -43,11 +42,13 @@ export function OpenLongStats({
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });
-  const chainId = useChainId();
   const tokenPrices = useTokenFiatPrices([baseToken.address]);
   const baseTokenPrice =
     tokenPrices?.[baseToken.address.toLowerCase() as Address];
-  const { fixedApr } = useFixedRate(hyperdrive.address);
+  const { fixedApr } = useFixedRate({
+    chainId: hyperdrive.chainId,
+    hyperdriveAddress: hyperdrive.address,
+  });
 
   const isBaseAmount =
     asBase ||
@@ -127,7 +128,7 @@ export function OpenLongStats({
         subValue={
           // Defillama fetches the token price via {chain}:{tokenAddress}. Since the token address differs on testnet, term length is displayed instead.
 
-          isTestnetChain(chainId)
+          isTestnetChain(hyperdrive.chainId)
             ? `Term: ${numDays} days`
             : `$${formatBalance({
                 balance: baseTokenPrice

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/CurrentValueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/CurrentValueCell.tsx
@@ -27,13 +27,17 @@ export function CurrentValueCell({
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });
-  const { poolInfo } = usePoolInfo({ hyperdriveAddress: hyperdrive.address });
+  const { poolInfo } = usePoolInfo({
+    chainId: hyperdrive.chainId,
+    hyperdriveAddress: hyperdrive.address,
+  });
 
   const {
     amountOut: baseAmountOut,
     previewCloseLongStatus,
     previewCloseLongError,
   } = usePreviewCloseLong({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     maturityTime: row.maturity,
     bondAmountIn: row.bondAmount,
@@ -111,6 +115,7 @@ export function CurrentValueCellTwo({
 }): ReactElement {
   const appConfig = useAppConfig();
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });
@@ -120,6 +125,7 @@ export function CurrentValueCellTwo({
     previewCloseLongStatus,
     previewCloseLongError,
   } = usePreviewCloseLong({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     maturityTime: row.maturity,
     bondAmountIn: row.details?.bondAmount || 0n,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/CurrentValueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/CurrentValueCell.tsx
@@ -23,6 +23,7 @@ export function CurrentValueCell({
   const isTailwindSmallScreen = useIsTailwindSmallScreen();
   const appConfig = useAppConfig();
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/FixedRateCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/FixedRateCell.tsx
@@ -25,6 +25,7 @@ export function FixedRateCell({
   const isTailwindSmallScreen = useIsTailwindSmallScreen();
   const { poolConfig } = hyperdrive;
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
@@ -227,6 +227,7 @@ function getColumns({
   appConfig: AppConfig;
 }) {
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
@@ -189,8 +189,9 @@ export function OpenLongsTableDesktop({
                 className="daisy-hover h-24 cursor-pointer items-center border-none transition duration-300 ease-in-out"
                 onClick={() => {
                   const modalId = `${row.original.assetId}`;
-                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  (window as any)[modalId].showModal();
+                  (
+                    document.getElementById(modalId) as HTMLDialogElement
+                  ).showModal();
                 }}
               >
                 {row.getVisibleCells().map((cell, cellIndex) => (

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
@@ -42,10 +42,14 @@ export function OpenLongsTableDesktop({
 }): ReactElement {
   const { address: account } = useAccount();
   const appConfig = useAppConfig();
-  const { marketState } = useMarketState(hyperdrive.address);
+  const { marketState } = useMarketState({
+    hyperdriveAddress: hyperdrive.address,
+    chainId: hyperdrive.chainId,
+  });
   const { switchChain } = useSwitchChain();
   const { openLongs, openLongsStatus } = useOpenLongs({
     account,
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
   });
 
@@ -185,6 +189,7 @@ export function OpenLongsTableDesktop({
                 className="daisy-hover h-24 cursor-pointer items-center border-none transition duration-300 ease-in-out"
                 onClick={() => {
                   const modalId = `${row.original.assetId}`;
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
                   (window as any)[modalId].showModal();
                 }}
               >
@@ -325,6 +330,7 @@ function getColumns({
               className="daisy-btn daisy-btn-ghost rounded-full bg-gray-600 hover:bg-gray-700"
               onClick={() => {
                 const modalId = `${row.original.assetId}`;
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 (window as any)[modalId].showModal();
               }}
             >

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktopTwo.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktopTwo.tsx
@@ -372,7 +372,12 @@ function getColumns({
       id: "value",
       header: `Status`,
       cell: ({ row }) => {
-        return <StatusCell maturity={row.original.maturity} />;
+        return (
+          <StatusCell
+            maturity={row.original.maturity}
+            chainId={hyperdrive.chainId}
+          />
+        );
       },
     }),
     columnHelper.display({

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktopTwo.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktopTwo.tsx
@@ -58,6 +58,7 @@ export function OpenLongsContainer(): ReactElement {
       {appConfig.hyperdrives.map((hyperdrive) => {
         const openLongs = openLongPositions?.[hyperdrive.address];
         const baseToken = findBaseToken({
+          hyperdriveChainId: hyperdrive.chainId,
           hyperdriveAddress: hyperdrive.address,
           appConfig,
         });
@@ -290,6 +291,7 @@ function getColumns({
   appConfig: AppConfig;
 }) {
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableMobile.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableMobile.tsx
@@ -38,10 +38,14 @@ export function OpenLongsTableMobile({
   const { address: account } = useAccount();
   const { switchChain } = useSwitchChain();
   const chainId = useChainId();
-  const { marketState } = useMarketState(hyperdrive.address);
+  const { marketState } = useMarketState({
+    hyperdriveAddress: hyperdrive.address,
+    chainId: hyperdrive.chainId,
+  });
   const appConfig = useAppConfig();
   const { openLongs, openLongsStatus } = useOpenLongs({
     account,
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
   });
   const tableInstance = useReactTable({
@@ -146,6 +150,7 @@ export function OpenLongsTableMobile({
                 className="daisy-hover h-24 cursor-pointer items-center transition duration-300 ease-in-out"
                 onClick={() => {
                   const modalId = `${row.original.assetId}`;
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
                   (window as any)[modalId].showModal();
                 }}
               >

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableMobile.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableMobile.tsx
@@ -237,6 +237,7 @@ function getMobileColumns({
   appConfig: AppConfig;
 }) {
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/StatusCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/StatusCell.tsx
@@ -2,10 +2,15 @@ import { CheckCircleIcon } from "@heroicons/react/24/solid";
 import classNames from "classnames";
 import { ReactElement } from "react";
 import { getRemainingTimeLabel } from "src/ui/hyperdrive/getRemainingTimeLabel";
-import { useBlock, useChainId } from "wagmi";
+import { useBlock } from "wagmi";
 
-export function StatusCell({ maturity }: { maturity: bigint }): ReactElement {
-  const chainId = useChainId();
+export function StatusCell({
+  chainId,
+  maturity,
+}: {
+  chainId: number;
+  maturity: bigint;
+}): ReactElement {
   const { data: currentBlock } = useBlock({ chainId });
   const isTermComplete = maturity < (currentBlock?.timestamp || 0n);
   const maturityDateMS = maturity * 1000n;

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/TotalOpenLongsValue.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/TotalOpenLongsValue.tsx
@@ -28,6 +28,7 @@ export function TotalOpenLongsValue({
     hyperdrive,
   });
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/TotalOpenLongsValue.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/TotalOpenLongsValue.tsx
@@ -18,6 +18,7 @@ export function TotalOpenLongsValue({
   const appConfig = useAppConfig();
   const { openLongs, openLongsStatus } = useOpenLongs({
     account,
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
   });
 

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useCloseLong.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useCloseLong.tsx
@@ -91,7 +91,11 @@ export function useCloseLong({
         onTransactionCompleted: (txHash: Hash) => {
           queryClient.invalidateQueries();
           toast.success(
-            <TransactionToast message="Long closed" txHash={hash} />,
+            <TransactionToast
+              message="Long closed"
+              txHash={hash}
+              chainId={chainId}
+            />,
             { id: hash, duration: SUCCESS_TOAST_DURATION },
           );
           toastWarpcast();
@@ -100,7 +104,11 @@ export function useCloseLong({
       });
 
       toast.loading(
-        <TransactionToast message="Closing Long..." txHash={hash} />,
+        <TransactionToast
+          chainId={chainId}
+          message="Closing Long..."
+          txHash={hash}
+        />,
         { id: hash },
       );
       onSubmitted?.(hash);

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useCloseLong.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useCloseLong.tsx
@@ -17,6 +17,7 @@ import { usePublicClient } from "wagmi";
 
 interface UseCloseLongOptions {
   hyperdriveAddress: Address;
+  chainId: number;
   maturityTime: bigint | undefined;
   bondAmountIn: bigint | undefined;
   minAmountOut: bigint | undefined;
@@ -34,6 +35,7 @@ interface UseCloseLongResult {
 
 export function useCloseLong({
   hyperdriveAddress,
+  chainId,
   maturityTime,
   bondAmountIn,
   minAmountOut,
@@ -43,7 +45,10 @@ export function useCloseLong({
   onSubmitted,
   onExecuted,
 }: UseCloseLongOptions): UseCloseLongResult {
-  const readWriteHyperdrive = useReadWriteHyperdrive(hyperdriveAddress);
+  const readWriteHyperdrive = useReadWriteHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const publicClient = usePublicClient();
   const queryClient = useQueryClient();
   const addTransaction = useAddRecentTransaction();
@@ -70,7 +75,7 @@ export function useCloseLong({
         ? minAmountOut
         : await prepareSharesIn({
             appConfig,
-            hyperdriveAddress,
+            chainId,
             sharesAmount: minAmountOut,
             readHyperdrive: readWriteHyperdrive,
           });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useClosedLongs.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useClosedLongs.ts
@@ -27,7 +27,11 @@ export function useClosedLongs({
   });
   const queryEnabled = !!readHyperdrive && !!account && !!hyperdriveAddress;
   const { data: closedLongs, status: closedLongsStatus } = useQuery({
-    queryKey: makeQueryKey("closedLongs", { account, hyperdriveAddress }),
+    queryKey: makeQueryKey("closedLongs", {
+      chainId,
+      account,
+      hyperdriveAddress,
+    }),
     queryFn: queryEnabled
       ? () => readHyperdrive.getClosedLongs({ account })
       : undefined,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useClosedLongs.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useClosedLongs.ts
@@ -7,6 +7,7 @@ import { Address } from "viem";
 interface UseClosedLongsOptions {
   account: Address | undefined;
   hyperdriveAddress: Address | undefined;
+  chainId: number;
 }
 
 /**
@@ -15,11 +16,15 @@ interface UseClosedLongsOptions {
 export function useClosedLongs({
   account,
   hyperdriveAddress,
+  chainId,
 }: UseClosedLongsOptions): {
   closedLongs: ClosedLong[] | undefined;
   closedLongsStatus: QueryStatus;
 } {
-  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
+  const readHyperdrive = useReadHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const queryEnabled = !!readHyperdrive && !!account && !!hyperdriveAddress;
   const { data: closedLongs, status: closedLongsStatus } = useQuery({
     queryKey: makeQueryKey("closedLongs", { account, hyperdriveAddress }),

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useCurrentLongPrice.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useCurrentLongPrice.ts
@@ -20,6 +20,7 @@ export function useCurrentLongPrice({
   const queryEnabled = !!readHyperdrive;
   const { data, status } = useQuery({
     queryKey: makeQueryKey("current-long-price", {
+      chainId,
       hyperdriveAddress: hyperdriveAddress,
     }),
     queryFn: queryEnabled ? () => readHyperdrive.getLongPrice() : undefined,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useCurrentLongPrice.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useCurrentLongPrice.ts
@@ -3,11 +3,20 @@ import { makeQueryKey } from "src/base/makeQueryKey";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
 
-export function useCurrentLongPrice(hyperdriveAddress: Address): {
+export function useCurrentLongPrice({
+  hyperdriveAddress,
+  chainId,
+}: {
+  hyperdriveAddress: Address;
+  chainId: number;
+}): {
   longPrice: bigint | undefined;
   longPriceStatus: QueryStatus;
 } {
-  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
+  const readHyperdrive = useReadHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const queryEnabled = !!readHyperdrive;
   const { data, status } = useQuery({
     queryKey: makeQueryKey("current-long-price", {

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useFixedRate.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useFixedRate.ts
@@ -35,7 +35,7 @@ export function useFixedRate({
 
   const queryEnabled = !!readHyperdrive;
   const { data, status, fetchStatus } = useQuery({
-    queryKey: makeQueryKey("fixedApr", { address: hyperdriveAddress }),
+    queryKey: makeQueryKey("fixedApr", { chainId, address: hyperdriveAddress }),
     queryFn: queryEnabled
       ? async () => {
           const fixedApr = await readHyperdrive.getFixedApr({ blockNumber });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useFixedRate.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useFixedRate.ts
@@ -9,17 +9,29 @@ import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
 
-export function useFixedRate(
-  hyperdriveAddress: Address,
-  blockNumber?: bigint,
-): {
+export function useFixedRate({
+  chainId,
+  hyperdriveAddress,
+  blockNumber,
+}: {
+  chainId: number;
+  hyperdriveAddress: Address;
+  blockNumber?: bigint;
+}): {
   fixedApr: { apr: bigint; formatted: string } | undefined;
   fixedRoi: { roi: bigint; formatted: string } | undefined;
   fixedRateStatus: QueryStatusWithIdle;
 } {
   const { hyperdrives } = useAppConfig();
-  const hyperdrive = findHyperdriveConfig({ hyperdrives, hyperdriveAddress });
-  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
+  const hyperdrive = findHyperdriveConfig({
+    hyperdriveChainId: chainId,
+    hyperdrives,
+    hyperdriveAddress,
+  });
+  const readHyperdrive = useReadHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
 
   const queryEnabled = !!readHyperdrive;
   const { data, status, fetchStatus } = useQuery({

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useMaxLong.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useMaxLong.ts
@@ -27,7 +27,8 @@ export function useMaxLong({
 
   const { data, status, fetchStatus } = useQuery({
     queryKey: makeQueryKey("maxLong", {
-      market: hyperdriveAddress,
+      hyperdriveAddress,
+      chainId,
     }),
     enabled: queryEnabled,
     queryFn: queryEnabled

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useMaxLong.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useMaxLong.ts
@@ -7,8 +7,10 @@ import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
 
 export function useMaxLong({
+  chainId,
   hyperdriveAddress,
 }: {
+  chainId: number;
   hyperdriveAddress: Address;
 }): {
   maxBaseIn: bigint | undefined;
@@ -16,7 +18,10 @@ export function useMaxLong({
   maxBondsOut: bigint | undefined;
   status: QueryStatusWithIdle;
 } {
-  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
+  const readHyperdrive = useReadHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const queryEnabled = !!readHyperdrive;
   const appConfig = useAppConfig();
 
@@ -33,7 +38,7 @@ export function useMaxLong({
           const finalMaxSharesIn = await prepareSharesOut({
             sharesAmount: result.maxSharesIn,
             appConfig,
-            hyperdriveAddress,
+            chainId,
             readHyperdrive,
           });
 

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useOpenLong.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useOpenLong.tsx
@@ -93,7 +93,11 @@ export function useOpenLong({
         onTransactionCompleted: (txHash) => {
           queryClient.invalidateQueries();
           toast.success(
-            <TransactionToast message="Long opened" txHash={txHash} />,
+            <TransactionToast
+              chainId={chainId}
+              message="Long opened"
+              txHash={txHash}
+            />,
             { id: txHash, duration: SUCCESS_TOAST_DURATION },
           );
           setTimeout(() => {
@@ -104,7 +108,11 @@ export function useOpenLong({
       });
 
       toast.loading(
-        <TransactionToast txHash={hash} message="Opening a Long..." />,
+        <TransactionToast
+          chainId={chainId}
+          txHash={hash}
+          message="Opening a Long..."
+        />,
         { id: hash },
       );
 

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useOpenLong.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useOpenLong.tsx
@@ -14,6 +14,7 @@ import { usePublicClient } from "wagmi";
 
 interface UseOpenLongOptions {
   hyperdriveAddress: Address;
+  chainId: number;
   destination: Address | undefined;
   minSharePrice: bigint | undefined;
   minBondsOut: bigint | undefined;
@@ -32,6 +33,7 @@ interface UseOpenLongResult {
 
 export function useOpenLong({
   hyperdriveAddress,
+  chainId,
   destination,
   amount,
   minBondsOut,
@@ -46,7 +48,10 @@ export function useOpenLong({
   const publicClient = usePublicClient();
   const appConfig = useAppConfig();
   const queryClient = useQueryClient();
-  const readWriteHyperdrive = useReadWriteHyperdrive(hyperdriveAddress);
+  const readWriteHyperdrive = useReadWriteHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
 
   const mutationEnabled =
     !!amount &&
@@ -69,7 +74,7 @@ export function useOpenLong({
         ? amount
         : await prepareSharesIn({
             appConfig,
-            hyperdriveAddress,
+            chainId,
             sharesAmount: amount,
             readHyperdrive: readWriteHyperdrive,
           });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useOpenLongs.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useOpenLongs.ts
@@ -7,6 +7,7 @@ import { Address } from "viem";
 interface UseOpenLongsOptions {
   account: Address | undefined;
   hyperdriveAddress: Address | undefined;
+  chainId: number;
 }
 
 /**
@@ -15,12 +16,16 @@ interface UseOpenLongsOptions {
  */
 export function useOpenLongs({
   account,
+  chainId,
   hyperdriveAddress,
 }: UseOpenLongsOptions): {
   openLongs: Long[] | undefined;
   openLongsStatus: "error" | "success" | "loading";
 } {
-  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
+  const readHyperdrive = useReadHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const queryEnabled = !!readHyperdrive && !!account;
   const { data: openLongs, status: openLongsStatus } = useQuery({
     enabled: queryEnabled,
@@ -39,12 +44,16 @@ export function useOpenLongs({
  */
 export function useOpenLongPositions({
   account,
+  chainId,
   hyperdriveAddress,
 }: UseOpenLongsOptions): {
   openLongPositionsReceived: OpenLongPositionReceived[] | undefined;
   openLongPositionsReceivedStatus: "error" | "success" | "loading";
 } {
-  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
+  const readHyperdrive = useReadHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const queryEnabled = !!readHyperdrive && !!account && !!hyperdriveAddress;
   const {
     data: openLongPositionsReceived,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useOpenLongs.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useOpenLongs.ts
@@ -29,7 +29,11 @@ export function useOpenLongs({
   const queryEnabled = !!readHyperdrive && !!account;
   const { data: openLongs, status: openLongsStatus } = useQuery({
     enabled: queryEnabled,
-    queryKey: makeQueryKey("openLongs", { account, hyperdriveAddress }),
+    queryKey: makeQueryKey("openLongs", {
+      account,
+      hyperdriveAddress,
+      chainId,
+    }),
     queryFn: queryEnabled
       ? () => readHyperdrive.getOpenLongs({ account })
       : undefined,
@@ -60,7 +64,11 @@ export function useOpenLongPositions({
     status: openLongPositionsReceivedStatus,
   } = useQuery({
     enabled: queryEnabled,
-    queryKey: makeQueryKey("allOpenLongs", { account, hyperdriveAddress }),
+    queryKey: makeQueryKey("allOpenLongs", {
+      account,
+      hyperdriveAddress,
+      chainId,
+    }),
     queryFn: queryEnabled
       ? async () => {
           const allLongs = await readHyperdrive.getOpenLongPositions({

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/usePreviewCloseLong.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/usePreviewCloseLong.ts
@@ -49,6 +49,7 @@ export function usePreviewCloseLong({
 
   const { data, status, fetchStatus, error } = useQuery({
     queryKey: makeQueryKey("previewCloseLong", {
+      chainId,
       hyperdriveAddress,
       maturityTime: maturityTime?.toString(),
       bondAmountIn: bondAmountIn?.toString(),

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/usePreviewCloseLong.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/usePreviewCloseLong.ts
@@ -7,6 +7,7 @@ import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
 
 interface UsePreviewCloseLongOptions {
+  chainId: number;
   hyperdriveAddress: Address | undefined;
   /**
    * Time in seconds, as the contracts require
@@ -26,13 +27,17 @@ interface UsePreviewCloseLongResult {
 
 export function usePreviewCloseLong({
   hyperdriveAddress,
+  chainId,
   maturityTime,
   bondAmountIn,
   asBase = true,
   enabled = true,
 }: UsePreviewCloseLongOptions): UsePreviewCloseLongResult {
   const appConfig = useAppConfig();
-  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
+  const readHyperdrive = useReadHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
 
   const queryEnabled =
     !!hyperdriveAddress &&
@@ -63,7 +68,7 @@ export function usePreviewCloseLong({
               ...result,
               amountOut: await prepareSharesOut({
                 appConfig,
-                hyperdriveAddress,
+                chainId,
                 sharesAmount: result.amountOut,
                 readHyperdrive,
               }),

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/usePreviewOpenLong.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/usePreviewOpenLong.ts
@@ -5,8 +5,9 @@ import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { prepareSharesIn } from "src/ui/hyperdrive/hooks/usePrepareSharesIn";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
-import { useBlockNumber, useChainId } from "wagmi";
+import { useBlockNumber } from "wagmi";
 interface UsePreviewOpenLongOptions {
+  chainId: number;
   hyperdriveAddress: Address;
   amountIn: bigint | undefined;
   asBase: boolean;
@@ -23,11 +24,15 @@ interface UsePreviewOpenLongResult {
 
 export function usePreviewOpenLong({
   hyperdriveAddress,
+  chainId,
   amountIn,
   asBase,
 }: UsePreviewOpenLongOptions): UsePreviewOpenLongResult {
-  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
-  const chainId = useChainId();
+  const readHyperdrive = useReadHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
+
   const appConfig = useAppConfig();
   const queryEnabled = amountIn !== undefined && !!readHyperdrive;
   const { data: blockNumber } = useBlockNumber({
@@ -37,6 +42,7 @@ export function usePreviewOpenLong({
   });
   const { data, status, fetchStatus } = useQuery({
     queryKey: makeQueryKey("previewOpenLong", {
+      chainId,
       hyperdrive: hyperdriveAddress,
       amountIn: amountIn?.toString(),
       asBase,
@@ -49,8 +55,8 @@ export function usePreviewOpenLong({
             amountIn: asBase
               ? amountIn
               : await prepareSharesIn({
+                  chainId,
                   appConfig,
-                  hyperdriveAddress,
                   readHyperdrive,
                   sharesAmount: amountIn,
                 }),

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useTotalClosedLongsValue.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useTotalClosedLongsValue.ts
@@ -28,6 +28,7 @@ export function useTotalClosedLongsValue({
 
   const { data: totalClosedLongsValue, isLoading } = useQuery({
     queryKey: makeQueryKey("totalClosedLongsValue", {
+      chainId: hyperdrive.chainId,
       hyperdriveAddress: hyperdrive.address,
       account,
       activeOpenOrClosedTab,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useTotalClosedLongsValue.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useTotalClosedLongsValue.ts
@@ -17,7 +17,10 @@ export function useTotalClosedLongsValue({
   closedLongs: ClosedLong[] | undefined;
   enabled: boolean;
 }): { totalClosedLongsValue: bigint | undefined; isLoading: boolean } {
-  const readHyperdrive = useReadHyperdrive(hyperdrive.address);
+  const readHyperdrive = useReadHyperdrive({
+    chainId: hyperdrive.chainId,
+    address: hyperdrive.address,
+  });
   const activeOpenOrClosedTab = useOpenOrClosedSearchParam();
 
   const queryEnabled =

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useTotalOpenLongsValue.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useTotalOpenLongsValue.ts
@@ -40,6 +40,7 @@ export function useTotalOpenLongsValue({
     error: totalOpenLongsValueError,
   } = useQuery({
     queryKey: makeQueryKey("totalLongsValue", {
+      chainId: hyperdrive.chainId,
       hyperdriveAddress: hyperdrive.address,
       account,
       activeOpenOrClosedTab,
@@ -106,6 +107,7 @@ export function useTotalOpenLongsValueTwo({
     error: totalOpenLongsValueError,
   } = useQuery({
     queryKey: makeQueryKey("totalLongsValue", {
+      chainId: hyperdrive.chainId,
       hyperdriveAddress: hyperdrive.address,
       account,
     }),

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useTotalOpenLongsValue.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useTotalOpenLongsValue.ts
@@ -22,8 +22,14 @@ export function useTotalOpenLongsValue({
   isLoading: boolean;
   totalOpenLongsValueError: Error;
 } {
-  const readHyperdrive = useReadHyperdrive(hyperdrive.address);
-  const { poolInfo } = usePoolInfo({ hyperdriveAddress: hyperdrive.address });
+  const readHyperdrive = useReadHyperdrive({
+    chainId: hyperdrive.chainId,
+    address: hyperdrive.address,
+  });
+  const { poolInfo } = usePoolInfo({
+    hyperdriveAddress: hyperdrive.address,
+    chainId: hyperdrive.chainId,
+  });
   const activeOpenOrClosedTab = useOpenOrClosedSearchParam();
   const queryEnabled =
     !!account && !!longs && !!readHyperdrive && !!poolInfo && enabled;
@@ -83,8 +89,14 @@ export function useTotalOpenLongsValueTwo({
   isLoading: boolean;
   totalOpenLongsValueError: Error;
 } {
-  const readHyperdrive = useReadHyperdrive(hyperdrive.address);
-  const { poolInfo } = usePoolInfo({ hyperdriveAddress: hyperdrive.address });
+  const readHyperdrive = useReadHyperdrive({
+    chainId: hyperdrive.chainId,
+    address: hyperdrive.address,
+  });
+  const { poolInfo } = usePoolInfo({
+    chainId: hyperdrive.chainId,
+    hyperdriveAddress: hyperdrive.address,
+  });
   const queryEnabled =
     !!account && !!longs && !!readHyperdrive && !!poolInfo && enabled;
 

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
@@ -55,6 +55,7 @@ export function AddLiquidityForm({
   const { poolInfo } = usePoolInfo({ hyperdriveAddress: hyperdrive.address });
   const appConfig = useAppConfig();
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityModalButton/AddLiquidityModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityModalButton/AddLiquidityModalButton.tsx
@@ -15,7 +15,10 @@ export function AddLiquidityModalButton({
   modalId: string;
   hyperdrive: HyperdriveConfig;
 }): ReactElement {
-  const { marketState } = useMarketState(hyperdrive.address);
+  const { marketState } = useMarketState({
+    hyperdriveAddress: hyperdrive.address,
+    chainId: hyperdrive.chainId,
+  });
   const appConfig = useAppConfig();
 
   const yieldSource = appConfig.yieldSources[hyperdrive.yieldSource];

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/ClosedLpTable/ClosedLpTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/ClosedLpTable/ClosedLpTable.tsx
@@ -214,11 +214,13 @@ export function ClosedLpTable({
   const appConfig = useAppConfig();
   const isTailwindSmallScreen = useIsTailwindSmallScreen();
   const { closedLpShares, closedLpSharesStatus } = useClosedLpShares({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     account,
   });
 
   const { redeemedWithdrawalShares } = useRedeemedWithdrawalShares({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     account,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/ClosedLpTable/ClosedLpTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/ClosedLpTable/ClosedLpTable.tsx
@@ -42,6 +42,7 @@ function formatClosedLpMobileColumnData(
   appConfig: AppConfig,
 ) {
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });
@@ -127,6 +128,7 @@ function getMobileColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
 }
 function getColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/OpenLpSharesCard/OpenLpSharesCard.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/OpenLpSharesCard/OpenLpSharesCard.tsx
@@ -46,12 +46,17 @@ export function OpenLpSharesCard({
     tokenAddress: hyperdrive.poolConfig.vaultSharesToken,
   });
 
-  const { poolInfo } = usePoolInfo({ hyperdriveAddress: hyperdrive.address });
+  const { poolInfo } = usePoolInfo({
+    hyperdriveAddress: hyperdrive.address,
+    chainId: hyperdrive.chainId,
+  });
   const { lpShares, lpSharesStatus } = useLpShares({
     hyperdriveAddress: hyperdrive.address,
+    chainId: hyperdrive.chainId,
     account,
   });
   const { lpSharesTotalSupply } = useLpSharesTotalSupply({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
   });
 
@@ -221,6 +226,7 @@ export function OpenLpSharesCard({
                     <button
                       className="daisy-btn daisy-btn-circle daisy-btn-ghost daisy-btn-sm absolute right-4 top-4"
                       onClick={() =>
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
                         (window as any)["withdrawalLpModal"].close()
                       }
                     >

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/OpenLpSharesCard/OpenLpSharesCard.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/OpenLpSharesCard/OpenLpSharesCard.tsx
@@ -36,6 +36,7 @@ export function OpenLpSharesCard({
   const { address: account } = useAccount();
   const appConfig = useAppConfig();
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });
@@ -59,6 +60,7 @@ export function OpenLpSharesCard({
     : "";
   const { baseAmountPaid, baseValue, openLpPositionStatus } = useOpenLpPosition(
     {
+      chainId: hyperdrive.chainId,
       hyperdriveAddress: hyperdrive.address,
       account,
     },

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
@@ -40,6 +40,7 @@ export function RemoveLiquidityForm({
   const { address: account } = useAccount();
   const appConfig = useAppConfig();
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
@@ -90,7 +90,10 @@ export function RemoveLiquidityForm({
       ? baseToken.address
       : hyperdrive.poolConfig.vaultSharesToken,
   });
-  const { poolInfo } = usePoolInfo({ hyperdriveAddress: hyperdrive.address });
+  const { poolInfo } = usePoolInfo({
+    hyperdriveAddress: hyperdrive.address,
+    chainId: hyperdrive.chainId,
+  });
 
   // Let users type in an amount of lp shares they want to remove
   const {
@@ -135,6 +138,7 @@ export function RemoveLiquidityForm({
   } = usePreviewRemoveLiquidity({
     destination: account,
     lpSharesIn,
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     minOutputPerShare,
     asBase:
@@ -142,6 +146,7 @@ export function RemoveLiquidityForm({
       activeWithdrawToken.address === baseToken.address,
   });
   const { removeLiquidity, removeLiquidityStatus } = useRemoveLiquidity({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     lpSharesIn,
     minOutputPerShare,
@@ -151,6 +156,7 @@ export function RemoveLiquidityForm({
       hyperdrive.withdrawOptions.isBaseTokenWithdrawalEnabled &&
       activeWithdrawToken.address === baseToken.address,
     onSubmitted: () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (window as any)["withdrawalLpModal"].close();
     },
     onExecuted: () => {

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useAddLiquidity.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useAddLiquidity.tsx
@@ -13,8 +13,8 @@ import { prepareSharesIn } from "src/ui/hyperdrive/hooks/usePrepareSharesIn";
 import { useReadWriteHyperdrive } from "src/ui/hyperdrive/hooks/useReadWriteHyperdrive";
 import { toastWarpcast } from "src/ui/social/WarpcastToast";
 import { Address, Hash } from "viem";
-import { usePublicClient } from "wagmi";
 interface UseAddLiquidityOptions {
+  chainId: number;
   hyperdriveAddress: Address;
   destination: Address | undefined;
   contribution: bigint | undefined;
@@ -36,6 +36,7 @@ interface UseAddLiquidityResult {
 }
 
 export function useAddLiquidity({
+  chainId,
   hyperdriveAddress,
   destination,
   contribution,
@@ -48,10 +49,12 @@ export function useAddLiquidity({
   onExecuted,
   ethValue,
 }: UseAddLiquidityOptions): UseAddLiquidityResult {
-  const readWriteHyperdrive = useReadWriteHyperdrive(hyperdriveAddress);
+  const readWriteHyperdrive = useReadWriteHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
 
   const appConfig = useAppConfig();
-  const publicClient = usePublicClient();
   const queryClient = useQueryClient();
   const addTransaction = useAddRecentTransaction();
 
@@ -62,7 +65,6 @@ export function useAddLiquidity({
     maxApr !== undefined &&
     !!destination &&
     enabled &&
-    !!publicClient &&
     !!readWriteHyperdrive;
 
   const { mutate: addLiquidity, status } = useMutation({
@@ -77,7 +79,7 @@ export function useAddLiquidity({
         ? contribution
         : await prepareSharesIn({
             appConfig,
-            hyperdriveAddress,
+            chainId,
             readHyperdrive: readWriteHyperdrive,
             sharesAmount: contribution,
           });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useAddLiquidity.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useAddLiquidity.tsx
@@ -97,7 +97,11 @@ export function useAddLiquidity({
         onTransactionCompleted: (txHash: Hash) => {
           queryClient.invalidateQueries();
           toast.success(
-            <TransactionToast message="Liquidity added" txHash={txHash} />,
+            <TransactionToast
+              chainId={chainId}
+              message="Liquidity added"
+              txHash={txHash}
+            />,
             { id: txHash, duration: SUCCESS_TOAST_DURATION },
           );
           toastWarpcast();
@@ -106,7 +110,11 @@ export function useAddLiquidity({
       });
 
       toast.loading(
-        <TransactionToast message="Adding liquidity..." txHash={hash} />,
+        <TransactionToast
+          chainId={chainId}
+          message="Adding liquidity..."
+          txHash={hash}
+        />,
         { id: hash },
       );
       onSubmitted(hash);

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useClosedLpShares.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useClosedLpShares.ts
@@ -22,7 +22,11 @@ export function useClosedLpShares({
   });
   const queryEnabled = !!readHyperdrive && !!account;
   const { data: closedLpShares, status: closedLpSharesStatus } = useQuery({
-    queryKey: makeQueryKey("closedLpShares", { account, hyperdriveAddress }),
+    queryKey: makeQueryKey("closedLpShares", {
+      chainId,
+      account,
+      hyperdriveAddress,
+    }),
     queryFn: queryEnabled
       ? () => readHyperdrive.getClosedLpShares({ account })
       : undefined,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useClosedLpShares.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useClosedLpShares.ts
@@ -5,16 +5,21 @@ import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
 interface UseClosedLpSharesOptions {
   account: Address | undefined;
+  chainId: number;
   hyperdriveAddress: Address | undefined;
 }
 export function useClosedLpShares({
   account,
+  chainId,
   hyperdriveAddress,
 }: UseClosedLpSharesOptions): {
   closedLpShares: ClosedLpShares[] | undefined;
   closedLpSharesStatus: QueryStatus;
 } {
-  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
+  const readHyperdrive = useReadHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const queryEnabled = !!readHyperdrive && !!account;
   const { data: closedLpShares, status: closedLpSharesStatus } = useQuery({
     queryKey: makeQueryKey("closedLpShares", { account, hyperdriveAddress }),

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useLpShares.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useLpShares.ts
@@ -5,18 +5,23 @@ import { Address } from "viem";
 interface UseLpSharesOptions {
   account: Address | undefined;
   hyperdriveAddress: Address | undefined;
+  chainId: number;
 }
 export function useLpShares({
   account,
   hyperdriveAddress,
+  chainId,
 }: UseLpSharesOptions): {
   lpShares: bigint | undefined;
   lpSharesStatus: QueryStatus;
 } {
-  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
+  const readHyperdrive = useReadHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const queryEnabled = !!readHyperdrive && !!account;
   const { data: lpShares, status: lpSharesStatus } = useQuery({
-    queryKey: makeQueryKey("lpShares", { account, hyperdriveAddress }),
+    queryKey: makeQueryKey("lpShares", { account, hyperdriveAddress, chainId }),
     queryFn: queryEnabled
       ? () => readHyperdrive.getLpShares({ account })
       : undefined,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useLpSharesTotalSupply.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useLpSharesTotalSupply.ts
@@ -18,7 +18,10 @@ export function useLpSharesTotalSupply({
   });
   const queryEnabled = !!readHyperdrive;
   const { data: lpSharesTotalSupply } = useQuery({
-    queryKey: makeQueryKey("lpSharesTotalSupply", { hyperdriveAddress }),
+    queryKey: makeQueryKey("lpSharesTotalSupply", {
+      chainId,
+      hyperdriveAddress,
+    }),
     queryFn: queryEnabled
       ? () => readHyperdrive.getLpSharesTotalSupply()
       : undefined,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useLpSharesTotalSupply.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useLpSharesTotalSupply.ts
@@ -3,14 +3,19 @@ import { makeQueryKey } from "src/base/makeQueryKey";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
 interface UseLpSharesTotalSupplyOptions {
+  chainId: number;
   hyperdriveAddress: Address | undefined;
 }
 export function useLpSharesTotalSupply({
+  chainId,
   hyperdriveAddress,
 }: UseLpSharesTotalSupplyOptions): {
   lpSharesTotalSupply: bigint | undefined;
 } {
-  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
+  const readHyperdrive = useReadHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const queryEnabled = !!readHyperdrive;
   const { data: lpSharesTotalSupply } = useQuery({
     queryKey: makeQueryKey("lpSharesTotalSupply", { hyperdriveAddress }),

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useOpenLpPosition.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useOpenLpPosition.ts
@@ -4,14 +4,15 @@ import { makeQueryKey } from "src/base/makeQueryKey";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
-interface UseOpenLpPositionOptions {
-  account: Address | undefined;
-  hyperdriveAddress: Address | undefined;
-}
 export function useOpenLpPosition({
   account,
+  chainId,
   hyperdriveAddress,
-}: UseOpenLpPositionOptions): {
+}: {
+  account: Address | undefined;
+  chainId: number;
+  hyperdriveAddress: Address | undefined;
+}): {
   lpShareBalance: bigint;
   baseAmountPaid: bigint;
   baseValue: bigint;
@@ -26,6 +27,7 @@ export function useOpenLpPosition({
     queryFn: queryEnabled
       ? () => {
           const hyperdriveConfig = findHyperdriveConfig({
+            hyperdriveChainId: chainId,
             hyperdrives: appConfig.hyperdrives,
             hyperdriveAddress,
           });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useOpenLpPosition.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useOpenLpPosition.ts
@@ -19,11 +19,18 @@ export function useOpenLpPosition({
   sharesValue: bigint;
   openLpPositionStatus: "loading" | "error" | "success";
 } {
-  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
+  const readHyperdrive = useReadHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const appConfig = useAppConfig();
   const queryEnabled = !!hyperdriveAddress && !!readHyperdrive && !!account;
   const { data, status: openLpPositionStatus } = useQuery({
-    queryKey: makeQueryKey("openLpPosition", { account, hyperdriveAddress }),
+    queryKey: makeQueryKey("openLpPosition", {
+      account,
+      hyperdriveAddress,
+      chainId,
+    }),
     queryFn: queryEnabled
       ? () => {
           const hyperdriveConfig = findHyperdriveConfig({

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/usePreviewAddLiquidity.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/usePreviewAddLiquidity.ts
@@ -8,6 +8,7 @@ import { Address } from "viem";
 import { useAccount, useBlockNumber, usePublicClient } from "wagmi";
 
 interface UsePreviewAddLiquidityOptions {
+  chainId: number;
   hyperdriveAddress: Address;
   destination: Address | undefined;
   contribution: bigint | undefined;
@@ -26,6 +27,7 @@ interface UsePreviewAddLiquidityResult {
 }
 
 export function usePreviewAddLiquidity({
+  chainId,
   hyperdriveAddress,
   destination,
   contribution,
@@ -39,10 +41,10 @@ export function usePreviewAddLiquidity({
   const publicClient = usePublicClient();
   const appConfig = useAppConfig();
   const { address: account } = useAccount();
-  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
-  const hyperdrive = appConfig.hyperdrives.find(
-    (hyperdrive) => hyperdrive.address === hyperdriveAddress,
-  );
+  const readHyperdrive = useReadHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const queryEnabled =
     minApr !== undefined &&
     minLpSharePrice !== undefined &&
@@ -54,7 +56,7 @@ export function usePreviewAddLiquidity({
     enabled &&
     !!readHyperdrive;
   const { data: blockNumber } = useBlockNumber({
-    chainId: hyperdrive?.chainId,
+    chainId,
     watch: true,
     query: { enabled: queryEnabled },
   });
@@ -62,6 +64,7 @@ export function usePreviewAddLiquidity({
   const { data, status, fetchStatus, error } = useQuery({
     queryKey: makeQueryKey("previewAddLiquidity", {
       hyperdrive: hyperdriveAddress,
+      chainId,
       destination,
       contribution: contribution?.toString(),
       minApr: minApr?.toString(),
@@ -78,8 +81,8 @@ export function usePreviewAddLiquidity({
           const finalContribution = asBase
             ? contribution
             : await prepareSharesIn({
+                chainId,
                 appConfig,
-                hyperdriveAddress,
                 readHyperdrive,
                 sharesAmount: contribution,
               });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/usePreviewRedeemWithdrawalShares.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/usePreviewRedeemWithdrawalShares.ts
@@ -7,6 +7,7 @@ import { useReadWriteHyperdrive } from "src/ui/hyperdrive/hooks/useReadWriteHype
 import { Address } from "viem";
 
 interface UsePreviewRedeemWithdrawalSharesOptions {
+  chainId: number;
   hyperdriveAddress: Address;
   withdrawalSharesIn: bigint | undefined;
   minOutputPerShare: bigint | undefined;
@@ -23,15 +24,20 @@ interface UsePreviewRedeemWithdrawalSharesResult {
 }
 
 export function usePreviewRedeemWithdrawalShares({
+  chainId,
   hyperdriveAddress,
   withdrawalSharesIn,
   minOutputPerShare,
   destination,
   enabled = true,
 }: UsePreviewRedeemWithdrawalSharesOptions): UsePreviewRedeemWithdrawalSharesResult {
-  const readWriteHyperdrive = useReadWriteHyperdrive(hyperdriveAddress);
+  const readWriteHyperdrive = useReadWriteHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const appConfig = useAppConfig();
   const hyperdriveConfig = findHyperdriveConfig({
+    hyperdriveChainId: chainId,
     hyperdrives: appConfig.hyperdrives,
     hyperdriveAddress,
   });
@@ -66,7 +72,7 @@ export function usePreviewRedeemWithdrawalShares({
             // The shares output need to be prepared before being returned
             sharesProceeds: await prepareSharesOut({
               appConfig,
-              hyperdriveAddress,
+              chainId,
               readHyperdrive: readWriteHyperdrive,
               sharesAmount: result.sharesProceeds,
             }),

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/usePreviewRedeemWithdrawalShares.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/usePreviewRedeemWithdrawalShares.ts
@@ -50,6 +50,7 @@ export function usePreviewRedeemWithdrawalShares({
 
   const { data, status } = useQuery({
     queryKey: makeQueryKey("previewRedeemWithdrawalShares", {
+      chainId,
       hyperdriveAddress,
       withdrawalSharesIn: withdrawalSharesIn?.toString(),
       minBaseAmountOutPerShare: minOutputPerShare?.toString(),

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/usePreviewRemoveLiquidity.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/usePreviewRemoveLiquidity.ts
@@ -46,6 +46,7 @@ export function usePreviewRemoveLiquidity({
 
   const { data, status } = useQuery({
     queryKey: makeQueryKey("previewRemoveLiquidity", {
+      chainId,
       market: hyperdriveAddress,
       lpSharesIn: lpSharesIn?.toString(),
       minOutputPerShare: minOutputPerShare?.toString(),

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/usePreviewRemoveLiquidity.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/usePreviewRemoveLiquidity.ts
@@ -7,6 +7,7 @@ import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
 
 interface UsePreviewRemoveLiquidityOptions {
+  chainId: number;
   hyperdriveAddress: Address;
   lpSharesIn: bigint | undefined;
   minOutputPerShare: bigint | undefined;
@@ -22,6 +23,7 @@ interface UsePreviewRemoveLiquidityResult {
 }
 
 export function usePreviewRemoveLiquidity({
+  chainId,
   hyperdriveAddress,
   lpSharesIn,
   minOutputPerShare,
@@ -29,7 +31,10 @@ export function usePreviewRemoveLiquidity({
   asBase = true,
   enabled = true,
 }: UsePreviewRemoveLiquidityOptions): UsePreviewRemoveLiquidityResult {
-  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
+  const readHyperdrive = useReadHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const appConfig = useAppConfig();
 
   const queryEnabled =
@@ -55,7 +60,7 @@ export function usePreviewRemoveLiquidity({
             ? minOutputPerShare
             : await prepareSharesIn({
                 appConfig,
-                hyperdriveAddress,
+                chainId,
                 readHyperdrive,
                 sharesAmount: minOutputPerShare,
               });
@@ -73,7 +78,7 @@ export function usePreviewRemoveLiquidity({
             ? result.proceeds
             : await prepareSharesOut({
                 appConfig,
-                hyperdriveAddress,
+                chainId,
                 readHyperdrive,
                 sharesAmount: result.proceeds,
               });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useRedeemWithdrawalShares.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useRedeemWithdrawalShares.ts
@@ -14,6 +14,7 @@ import { Address } from "viem";
 import { usePublicClient } from "wagmi";
 
 interface UseRedeemWithdrawalSharesOptions {
+  chainId: number;
   hyperdriveAddress: Address;
   withdrawalSharesIn: bigint | undefined;
   minOutputPerShare: bigint | undefined;
@@ -28,6 +29,7 @@ interface UseRedeemWithdrawalSharesResult {
 }
 
 export function useRedeemWithdrawalShares({
+  chainId,
   hyperdriveAddress,
   withdrawalSharesIn,
   minOutputPerShare,
@@ -35,7 +37,10 @@ export function useRedeemWithdrawalShares({
   asBase = true,
   enabled,
 }: UseRedeemWithdrawalSharesOptions): UseRedeemWithdrawalSharesResult {
-  const readWriteHyperdrive = useReadWriteHyperdrive(hyperdriveAddress);
+  const readWriteHyperdrive = useReadWriteHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const publicClient = usePublicClient();
   const queryClient = useQueryClient();
   const appConfig = useAppConfig();
@@ -60,7 +65,7 @@ export function useRedeemWithdrawalShares({
         ? minOutputPerShare
         : await prepareSharesIn({
             appConfig,
-            hyperdriveAddress,
+            chainId,
             readHyperdrive: readWriteHyperdrive,
             sharesAmount: minOutputPerShare,
           });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useRedeemedWithdrawalShares.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useRedeemedWithdrawalShares.ts
@@ -5,16 +5,21 @@ import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
 interface UseRedeemedWithdrawalSharesOptions {
   account: Address | undefined;
+  chainId: number;
   hyperdriveAddress: Address | undefined;
 }
 export function useRedeemedWithdrawalShares({
   account,
+  chainId,
   hyperdriveAddress,
 }: UseRedeemedWithdrawalSharesOptions): {
   redeemedWithdrawalShares: RedeemedWithdrawalShares[] | undefined;
   redeemedWithdrawlSharesStatus: QueryStatus;
 } {
-  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
+  const readHyperdrive = useReadHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const queryEnabled = !!readHyperdrive && !!account;
   const {
     data: redeemedWithdrawalShares,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useRedeemedWithdrawalShares.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useRedeemedWithdrawalShares.ts
@@ -26,6 +26,7 @@ export function useRedeemedWithdrawalShares({
     status: redeemedWithdrawlSharesStatus,
   } = useQuery({
     queryKey: makeQueryKey("redeemedWithdrawalShares", {
+      chainId,
       account,
       hyperdriveAddress,
     }),

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useRemoveLiquidity.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useRemoveLiquidity.tsx
@@ -83,7 +83,11 @@ export function useRemoveLiquidity({
         onTransactionCompleted: (txHash: Hash) => {
           queryClient.invalidateQueries();
           toast.success(
-            <TransactionToast message="Liquidity removed" txHash={txHash} />,
+            <TransactionToast
+              chainId={chainId}
+              message="Liquidity removed"
+              txHash={txHash}
+            />,
             { id: txHash, duration: SUCCESS_TOAST_DURATION },
           );
           toastWarpcast();
@@ -92,7 +96,11 @@ export function useRemoveLiquidity({
       });
 
       toast.loading(
-        <TransactionToast message="Removing liquidity..." txHash={hash} />,
+        <TransactionToast
+          chainId={chainId}
+          message="Removing liquidity..."
+          txHash={hash}
+        />,
         { id: hash },
       );
       onSubmitted?.(hash);

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useRemoveLiquidity.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useRemoveLiquidity.tsx
@@ -13,9 +13,9 @@ import { prepareSharesIn } from "src/ui/hyperdrive/hooks/usePrepareSharesIn";
 import { useReadWriteHyperdrive } from "src/ui/hyperdrive/hooks/useReadWriteHyperdrive";
 import { toastWarpcast } from "src/ui/social/WarpcastToast";
 import { Address, Hash } from "viem";
-import { usePublicClient } from "wagmi";
 
 interface UseRemoveLiquidityOptions {
+  chainId: number;
   hyperdriveAddress: Address;
   lpSharesIn: bigint | undefined;
   minOutputPerShare: bigint | undefined;
@@ -33,6 +33,7 @@ interface UseRemoveLiquidityResult {
 
 export function useRemoveLiquidity({
   hyperdriveAddress,
+  chainId,
   lpSharesIn,
   minOutputPerShare,
   destination,
@@ -41,9 +42,11 @@ export function useRemoveLiquidity({
   onSubmitted,
   onExecuted,
 }: UseRemoveLiquidityOptions): UseRemoveLiquidityResult {
-  const readWriteHyperdrive = useReadWriteHyperdrive(hyperdriveAddress);
+  const readWriteHyperdrive = useReadWriteHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const appConfig = useAppConfig();
-  const publicClient = usePublicClient();
   const queryClient = useQueryClient();
   const addTransaction = useAddRecentTransaction();
   const mutationEnabled =
@@ -51,8 +54,7 @@ export function useRemoveLiquidity({
     !!lpSharesIn &&
     minOutputPerShare !== undefined &&
     !!destination &&
-    !!readWriteHyperdrive &&
-    !!publicClient;
+    !!readWriteHyperdrive;
 
   const { mutate: removeLiquidity, status } = useMutation({
     mutationFn: async () => {
@@ -66,7 +68,7 @@ export function useRemoveLiquidity({
         ? minOutputPerShare
         : await prepareSharesIn({
             appConfig,
-            hyperdriveAddress,
+            chainId,
             readHyperdrive: readWriteHyperdrive,
             sharesAmount: minOutputPerShare,
           });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useUtilizationRatio.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useUtilizationRatio.ts
@@ -12,10 +12,12 @@ export function useUtilizationRatio({
   account: Address | undefined;
 }): bigint | undefined {
   const { lpShares } = useLpShares({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     account,
   });
   const { withdrawalShares } = usePreviewRemoveLiquidity({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     lpSharesIn: lpShares,
     minOutputPerShare: 1n,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useWithdrawalShares.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useWithdrawalShares.ts
@@ -3,20 +3,29 @@ import { makeQueryKey } from "src/base/makeQueryKey";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
 interface UseWithdrawalSharesOptions {
+  chainId: number;
   account: Address | undefined;
   hyperdriveAddress: Address | undefined;
 }
 export function useWithdrawalShares({
   account,
+  chainId,
   hyperdriveAddress,
 }: UseWithdrawalSharesOptions): {
   withdrawalShares: bigint | undefined;
   withdrawalSharesStatus: QueryStatus;
 } {
-  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
+  const readHyperdrive = useReadHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const queryEnabled = !!readHyperdrive && !!account;
   const { data: withdrawalShares, status: withdrawalSharesStatus } = useQuery({
-    queryKey: makeQueryKey("withdrawalShares", { account, hyperdriveAddress }),
+    queryKey: makeQueryKey("withdrawalShares", {
+      account,
+      hyperdriveAddress,
+      chainId,
+    }),
     queryFn: queryEnabled
       ? () => readHyperdrive.getWithdrawalShares({ account })
       : undefined,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortForm/CloseShortForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortForm/CloseShortForm.tsx
@@ -80,6 +80,7 @@ export function CloseShortForm({
   );
   const { amountOut, flatPlusCurveFee, previewCloseShortStatus } =
     usePreviewCloseShort({
+      chainId: hyperdrive.chainId,
       hyperdriveAddress: hyperdrive.address,
       maturityTime: short.maturity,
       shortAmountIn: amountAsBigInt,
@@ -97,6 +98,7 @@ export function CloseShortForm({
     });
 
   const { closeShort, closeShortStatus } = useCloseShort({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     maturityTime: short.maturity,
     bondAmountIn: amountAsBigInt,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortForm/CloseShortForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortForm/CloseShortForm.tsx
@@ -37,6 +37,7 @@ export function CloseShortForm({
   const { address: account } = useAccount();
   const defaultItems = [];
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortModalButton/CloseShortModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortModalButton/CloseShortModalButton.tsx
@@ -28,6 +28,7 @@ export function CloseShortModalButton({
 }: CloseShortModalButtonProps): ReactElement {
   const appConfig = useAppConfig();
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/ClosedShortsTable/ClosedShortsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/ClosedShortsTable/ClosedShortsTable.tsx
@@ -174,6 +174,7 @@ export function ClosedShortsTable({
   const appConfig = useAppConfig();
   const isTailwindSmallScreen = useIsTailwindSmallScreen();
   const { closedShorts, closedShortsStatus } = useClosedShorts({
+    chainId: hyperdrive.chainId,
     account,
     hyperdriveAddress: hyperdrive.address,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/ClosedShortsTable/ClosedShortsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/ClosedShortsTable/ClosedShortsTable.tsx
@@ -36,6 +36,7 @@ function formatClosedShortMobileColumnData(
   appConfig: AppConfig,
 ) {
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });
@@ -112,6 +113,7 @@ function getMobileColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
 
 function getColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
@@ -38,7 +38,7 @@ import { useTokenBalance } from "src/ui/token/hooks/useTokenBalance";
 import { useTokenFiatPrices } from "src/ui/token/hooks/useTokenFiatPrices";
 import { useYieldSourceRate } from "src/ui/vaults/useYieldSourceRate";
 import { Address, formatUnits } from "viem";
-import { useAccount, useChainId } from "wagmi";
+import { useAccount } from "wagmi";
 
 (window as any).fixed = fixed;
 
@@ -53,14 +53,17 @@ export function OpenShortForm({
 }: OpenShortPositionFormProps): ReactElement {
   const { address: account } = useAccount();
   const appConfig = useAppConfig();
-  const chainId = useChainId();
-  const { poolInfo } = usePoolInfo({ hyperdriveAddress: hyperdrive.address });
+  const { poolInfo } = usePoolInfo({
+    chainId: hyperdrive.chainId,
+    hyperdriveAddress: hyperdrive.address,
+  });
   const baseToken = findBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });
   const { vaultRate, vaultRateStatus } = useYieldSourceRate({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
   });
   const { balance: baseTokenBalance } = useTokenBalance({
@@ -68,7 +71,10 @@ export function OpenShortForm({
     tokenAddress: baseToken.address,
     decimals: baseToken.decimals,
   });
-  const { longPrice } = useCurrentLongPrice(hyperdrive.address);
+  const { longPrice } = useCurrentLongPrice({
+    chainId: hyperdrive.chainId,
+    hyperdriveAddress: hyperdrive.address,
+  });
 
   const { balance: sharesTokenBalance } = useTokenBalance({
     account,
@@ -157,6 +163,7 @@ export function OpenShortForm({
     fixedRatePaid,
     status: openShortPreviewStatus,
   } = usePreviewOpenShort({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     amountOfBondsToShort: amountOfBondsToShortAsBigInt,
     asBase: activeToken.address === baseToken.address,
@@ -186,11 +193,13 @@ export function OpenShortForm({
   });
 
   const { maxBondsOut } = useMaxShort({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     budget: MAX_UINT256,
   });
 
   const { maxBondsOut: maxBondsOutFromPayment } = useMaxShort({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     budget: amountToPayAsBigInt || 0n,
   });
@@ -218,6 +227,7 @@ export function OpenShortForm({
     });
 
   const { openShort, openShortStatus } = useOpenShort({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     amountBondShorts: amountOfBondsToShortAsBigInt,
     minVaultSharePrice: poolInfo?.vaultSharePrice,
@@ -302,7 +312,7 @@ export function OpenShortForm({
             }}
             bottomLeftElement={
               // Defillama fetches the token price via {chain}:{tokenAddress}. Since the token address differs on testnet, price display is disabled there.
-              !isTestnetChain(chainId) ? (
+              !isTestnetChain(hyperdrive.chainId) ? (
                 <label className="text-sm text-neutral-content">
                   {`$${formatBalance({
                     balance:
@@ -346,7 +356,7 @@ export function OpenShortForm({
             }}
             bottomLeftElement={
               // Defillama fetches the token price via {chain}:{tokenAddress}. Since the token address differs on testnet, price display is disabled there.
-              !isTestnetChain(chainId) ? (
+              !isTestnetChain(hyperdrive.chainId) ? (
                 <label className="text-sm text-neutral-content">
                   {`$${formatBalance({
                     balance:

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
@@ -56,6 +56,7 @@ export function OpenShortForm({
   const chainId = useChainId();
   const { poolInfo } = usePoolInfo({ hyperdriveAddress: hyperdrive.address });
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortModalButton/OpenShortModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortModalButton/OpenShortModalButton.tsx
@@ -17,7 +17,10 @@ export function OpenShortModalButton({
   modalId,
   hyperdrive,
 }: OpenShortModalButtonProps): ReactElement {
-  const { marketState } = useMarketState(hyperdrive.address);
+  const { marketState } = useMarketState({
+    chainId: hyperdrive.chainId,
+    hyperdriveAddress: hyperdrive.address,
+  });
 
   const appConfig = useAppConfig();
   const termLengthMS = Number(hyperdrive.poolConfig.positionDuration * 1000n);

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
@@ -46,13 +46,18 @@ export function OpenShortPreview({
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });
-  const { fixedApr } = useFixedRate(hyperdrive.address);
+  const { fixedApr } = useFixedRate({
+    chainId: hyperdrive.chainId,
+    hyperdriveAddress: hyperdrive.address,
+  });
   const { vaultRate } = useYieldSourceRate({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
   });
   const defaultBondAmount =
     hyperdrive.decimals > 6 ? BigInt(1e15) : BigInt(1e6);
   const { shortApr, shortRateStatus } = useShortRate({
+    chainId: hyperdrive.chainId,
     // show the market short rate (aka bond amount of 1) if the user hasn't
     // already entered a short size
     bondAmount: shortSize || defaultBondAmount,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
@@ -42,6 +42,7 @@ export function OpenShortPreview({
   const [detailsOpen, setDetailsOpen] = useState(false);
   const appConfig = useAppConfig();
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/AccruedYieldCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/AccruedYieldCell.tsx
@@ -18,6 +18,7 @@ export function AccruedYieldCell({
   const isTailwindSmallScreen = useIsTailwindSmallScreen();
   const appConfig = useAppConfig();
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/CurrentShortsValueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/CurrentShortsValueCell.tsx
@@ -31,12 +31,14 @@ export function CurrentShortsValueCell({
     previewCloseShortError,
   } = usePreviewCloseShort({
     hyperdriveAddress: hyperdrive.address,
+    chainId: hyperdrive.chainId,
     maturityTime: openShort.maturity,
     shortAmountIn: openShort.bondAmount,
   });
 
   const { marketEstimate } = useEstimateShortMarketValue({
     hyperdriveAddress: hyperdrive.address,
+    chainId: hyperdrive.chainId,
     maturityTime: openShort.maturity,
     shortAmountIn: openShort.bondAmount,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/CurrentShortsValueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/CurrentShortsValueCell.tsx
@@ -20,6 +20,7 @@ export function CurrentShortsValueCell({
   const isTailwindSmallScreen = useIsTailwindSmallScreen();
   const appConfig = useAppConfig();
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/CurrentValueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/CurrentValueCell.tsx
@@ -31,12 +31,14 @@ export function CurrentValueCell({
     previewCloseShortError,
   } = usePreviewCloseShort({
     hyperdriveAddress: hyperdrive.address,
+    chainId: hyperdrive.chainId,
     maturityTime: openShort.maturity,
     shortAmountIn: openShort.bondAmount,
   });
 
   const { marketEstimate } = useEstimateShortMarketValue({
     hyperdriveAddress: hyperdrive.address,
+    chainId: hyperdrive.chainId,
     maturityTime: openShort.maturity,
     shortAmountIn: openShort.bondAmount,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/CurrentValueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/CurrentValueCell.tsx
@@ -20,6 +20,7 @@ export function CurrentValueCell({
   const isTailwindSmallScreen = useIsTailwindSmallScreen();
   const appConfig = useAppConfig();
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTable.tsx
@@ -20,12 +20,16 @@ export function OpenShortsTable({
 }): ReactElement {
   const { address: account } = useAccount();
   const { switchChain } = useSwitchChain();
-  const chainId = useChainId();
-  const { marketState } = useMarketState(hyperdrive.address);
+  const connectedChainId = useChainId();
+  const { marketState } = useMarketState({
+    chainId: hyperdrive.chainId,
+    hyperdriveAddress: hyperdrive.address,
+  });
   const isTailwindSmallScreen = useIsTailwindSmallScreen();
   const { openShorts, openShortsStatus } = useOpenShorts({
     account,
     hyperdriveAddress: hyperdrive.address,
+    chainId: hyperdrive.chainId,
   });
   if (!account) {
     return (
@@ -38,7 +42,7 @@ export function OpenShortsTable({
       </div>
     );
   }
-  if (chainId !== hyperdrive.chainId) {
+  if (connectedChainId !== hyperdrive.chainId) {
     return (
       <div className="my-28">
         <NonIdealState

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktop.tsx
@@ -37,6 +37,7 @@ export function OpenShortsTableDesktop({
 }): ReactElement {
   const appConfig = useAppConfig();
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktopTwo.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktopTwo.tsx
@@ -42,6 +42,7 @@ export function OpenShortsContainer(): ReactElement {
     <div className="mt-10 flex w-[1036px] flex-col gap-10">
       {appConfig.hyperdrives.map((hyperdrive) => {
         const baseToken = findBaseToken({
+          hyperdriveChainId: hyperdrive.chainId,
           hyperdriveAddress: hyperdrive.address,
           appConfig,
         });
@@ -284,6 +285,7 @@ function getColumns({
   appConfig: AppConfig;
 }) {
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktopTwo.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktopTwo.tsx
@@ -105,9 +105,13 @@ export function OpenShortsTableDesktopTwo({
 }): ReactElement {
   const { address: account } = useAccount();
   const appConfig = useAppConfig();
-  const { marketState } = useMarketState(hyperdrive.address);
+  const { marketState } = useMarketState({
+    hyperdriveAddress: hyperdrive.address,
+    chainId: hyperdrive.chainId,
+  });
   const { openShorts, openShortsStatus } = useOpenShorts({
     account,
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
   });
   const tableInstance = useReactTable({

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktopTwo.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktopTwo.tsx
@@ -338,7 +338,12 @@ function getColumns({
       id: "value",
       header: `Status`,
       cell: ({ row }) => {
-        return <StatusCell maturity={row.original.maturity} />;
+        return (
+          <StatusCell
+            chainId={hyperdrive.chainId}
+            maturity={row.original.maturity}
+          />
+        );
       },
     }),
     columnHelper.display({

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableMobile.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableMobile.tsx
@@ -157,6 +157,7 @@ function formatOpenShortMobileColumnData(
   appConfig: AppConfig,
 ) {
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/ShortRateAndSizeCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/ShortRateAndSizeCell.tsx
@@ -18,6 +18,7 @@ export function ShortRateAndSizeCell({
   const appConfig = useAppConfig();
   const chainId = useChainId();
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/ShortRateAndSizeCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/ShortRateAndSizeCell.tsx
@@ -6,7 +6,7 @@ import { formatRate } from "src/base/formatRate";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { useFixedRate } from "src/ui/hyperdrive/longs/hooks/useFixedRate";
-import { useBlock, useChainId } from "wagmi";
+import { useBlock } from "wagmi";
 
 export function ShortRateAndSizeCell({
   hyperdrive,
@@ -16,7 +16,6 @@ export function ShortRateAndSizeCell({
   short: OpenShort;
 }): ReactElement {
   const appConfig = useAppConfig();
-  const chainId = useChainId();
   const baseToken = findBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
@@ -24,12 +23,16 @@ export function ShortRateAndSizeCell({
   });
   const { data: maturityBlock } = useBlock({
     blockNumber: short.maturity,
-    chainId,
+    chainId: hyperdrive.chainId,
   });
 
   // NOTE: Maturity block will be undefined if the term in incomplete,
   // defaulting to latest.
-  const { fixedApr } = useFixedRate(hyperdrive.address, maturityBlock?.number);
+  const { fixedApr } = useFixedRate({
+    chainId: hyperdrive.chainId,
+    hyperdriveAddress: hyperdrive.address,
+    blockNumber: maturityBlock?.number,
+  });
 
   const rateDifference = (fixedApr?.apr || 0n) - short.fixedRatePaid;
   const isPositiveChangeInValue = rateDifference > 0;

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/TotalOpenShortsValue.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/TotalOpenShortsValue.tsx
@@ -28,6 +28,7 @@ export function TotalOpenShortValue({
       enabled: openShortsStatus === "success",
     });
     const baseToken = findBaseToken({
+      hyperdriveChainId: hyperdrive.chainId,
       hyperdriveAddress: hyperdrive.address,
       appConfig,
     });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/TotalOpenShortsValue.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/TotalOpenShortsValue.tsx
@@ -19,6 +19,7 @@ export function TotalOpenShortValue({
     const appConfig = useAppConfig();
     const { openShorts, openShortsStatus } = useOpenShorts({
       account,
+      chainId: hyperdrive.chainId,
       hyperdriveAddress: hyperdrive.address,
     });
     const { totalOpenShortsValue, isLoading } = useTotalOpenShortsValue({

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useCloseShort.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useCloseShort.tsx
@@ -86,7 +86,11 @@ export function useCloseShort({
         onTransactionCompleted: (txHash: Hash) => {
           queryClient.invalidateQueries();
           toast.success(
-            <TransactionToast message="Short closed" txHash={txHash} />,
+            <TransactionToast
+              chainId={chainId}
+              message="Short closed"
+              txHash={txHash}
+            />,
             { id: txHash, duration: SUCCESS_TOAST_DURATION },
           );
           toastWarpcast();
@@ -95,7 +99,11 @@ export function useCloseShort({
       });
 
       toast.loading(
-        <TransactionToast message="Closing Short..." txHash={hash} />,
+        <TransactionToast
+          chainId={chainId}
+          message="Closing Short..."
+          txHash={hash}
+        />,
         { id: hash },
       );
       onSubmitted?.(hash);

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useCloseShort.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useCloseShort.tsx
@@ -13,9 +13,9 @@ import { prepareSharesIn } from "src/ui/hyperdrive/hooks/usePrepareSharesIn";
 import { useReadWriteHyperdrive } from "src/ui/hyperdrive/hooks/useReadWriteHyperdrive";
 import { toastWarpcast } from "src/ui/social/WarpcastToast";
 import { Address, Hash } from "viem";
-import { usePublicClient } from "wagmi";
 
 interface UseCloseShortOptions {
+  chainId: number;
   hyperdriveAddress: Address;
   maturityTime: bigint | undefined;
   bondAmountIn: bigint | undefined;
@@ -33,6 +33,7 @@ interface UseCloseShortResult {
 }
 
 export function useCloseShort({
+  chainId,
   hyperdriveAddress,
   maturityTime,
   bondAmountIn,
@@ -43,8 +44,10 @@ export function useCloseShort({
   onSubmitted,
   onExecuted,
 }: UseCloseShortOptions): UseCloseShortResult {
-  const readWriteHyperdrive = useReadWriteHyperdrive(hyperdriveAddress);
-  const publicClient = usePublicClient();
+  const readWriteHyperdrive = useReadWriteHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const appConfig = useAppConfig();
   const queryClient = useQueryClient();
   const addTransaction = useAddRecentTransaction();
@@ -54,8 +57,7 @@ export function useCloseShort({
     !!bondAmountIn &&
     minAmountOut !== undefined && // check undefined since 0 is valid
     !!destination &&
-    !!readWriteHyperdrive &&
-    !!publicClient;
+    !!readWriteHyperdrive;
 
   const { mutate: closeShort, status } = useMutation({
     mutationFn: async () => {
@@ -68,7 +70,7 @@ export function useCloseShort({
         ? minAmountOut
         : await prepareSharesIn({
             appConfig,
-            hyperdriveAddress,
+            chainId,
             readHyperdrive: readWriteHyperdrive,
             sharesAmount: minAmountOut,
           });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useClosedShorts.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useClosedShorts.ts
@@ -5,6 +5,7 @@ import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
 
 interface UseClosedShortsOptions {
+  chainId: number;
   account: Address | undefined;
   hyperdriveAddress: Address | undefined;
 }
@@ -14,15 +15,23 @@ interface UseClosedShortsOptions {
  */
 export function useClosedShorts({
   account,
+  chainId,
   hyperdriveAddress,
 }: UseClosedShortsOptions): {
   closedShorts: ClosedShort[] | undefined;
   closedShortsStatus: QueryStatus;
 } {
-  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
+  const readHyperdrive = useReadHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const queryEnabled = !!readHyperdrive && !!account;
   const { data: closedShorts, status: closedShortsStatus } = useQuery({
-    queryKey: makeQueryKey("closedShorts", { account, hyperdriveAddress }),
+    queryKey: makeQueryKey("closedShorts", {
+      account,
+      hyperdriveAddress,
+      chainId,
+    }),
     queryFn: queryEnabled
       ? async () => await readHyperdrive.getClosedShorts({ account })
       : undefined,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useEstimateShortMarketValue.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useEstimateShortMarketValue.ts
@@ -7,6 +7,7 @@ import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
 
 interface UseEstimateShortMarketValue {
+  chainId: number;
   hyperdriveAddress: Address;
   maturityTime: bigint | undefined;
   shortAmountIn: bigint | undefined;
@@ -20,19 +21,24 @@ interface UseEstimateShortMarketValueResult {
 }
 
 export function useEstimateShortMarketValue({
+  chainId,
   hyperdriveAddress,
   maturityTime,
   shortAmountIn,
   asBase = true,
   enabled = true,
 }: UseEstimateShortMarketValue): UseEstimateShortMarketValueResult {
-  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
+  const readHyperdrive = useReadHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const appConfig = useAppConfig();
   const queryEnabled =
     !!readHyperdrive && !!maturityTime && !!shortAmountIn && enabled;
 
   const { data, status, fetchStatus } = useQuery({
     queryKey: makeQueryKey("estimateShortMarketValue", {
+      chainId,
       hyperdriveAddress,
       maturityTime: maturityTime?.toString(),
       shortAmountIn: shortAmountIn?.toString(),
@@ -53,7 +59,7 @@ export function useEstimateShortMarketValue({
             ? result
             : await prepareSharesOut({
                 appConfig,
-                hyperdriveAddress,
+                chainId,
                 readHyperdrive,
                 sharesAmount: result,
               });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useMaxShort.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useMaxShort.ts
@@ -14,19 +14,25 @@ interface UseMaxShortResult {
 }
 
 export function useMaxShort({
+  chainId,
   hyperdriveAddress,
   budget,
 }: {
   hyperdriveAddress: Address;
+  chainId: number;
   budget: bigint;
 }): UseMaxShortResult {
-  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
+  const readHyperdrive = useReadHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const appConfig = useAppConfig();
   const queryEnabled = !!readHyperdrive && !!budget;
 
   const { data, status } = useQuery({
     queryKey: makeQueryKey("maxShort", {
-      market: hyperdriveAddress,
+      chainId,
+      hyperdriveAddress,
       budget: budget.toString(),
     }),
     enabled: queryEnabled,
@@ -37,7 +43,7 @@ export function useMaxShort({
           // All shares coming from the sdk need to be prepared for the UI
           const finalMaxSharesIn = await prepareSharesOut({
             appConfig,
-            hyperdriveAddress,
+            chainId,
             readHyperdrive,
             sharesAmount: result.maxSharesIn,
           });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useOpenShort.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useOpenShort.tsx
@@ -17,6 +17,7 @@ import { Address, Hash, parseUnits } from "viem";
 import { usePublicClient } from "wagmi";
 
 interface UseOpenShortOptions {
+  chainId: number;
   hyperdriveAddress: Address;
   amountBondShorts: bigint | undefined;
   maxDeposit: bigint | undefined;
@@ -37,6 +38,7 @@ interface UseOpenShortResult {
 
 export function useOpenShort({
   hyperdriveAddress,
+  chainId,
   amountBondShorts,
   maxDeposit,
   minVaultSharePrice,
@@ -47,7 +49,10 @@ export function useOpenShort({
   onSubmitted,
   onExecuted,
 }: UseOpenShortOptions): UseOpenShortResult {
-  const readWriteHyperdrive = useReadWriteHyperdrive(hyperdriveAddress);
+  const readWriteHyperdrive = useReadWriteHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const publicClient = usePublicClient();
   const queryClient = useQueryClient();
   const appConfig = useAppConfig();
@@ -85,7 +90,7 @@ export function useOpenShort({
         ? maxDeposit
         : await prepareSharesIn({
             appConfig,
-            hyperdriveAddress,
+            chainId,
             readHyperdrive: readWriteHyperdrive,
             sharesAmount: maxDeposit,
           });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useOpenShort.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useOpenShort.tsx
@@ -107,7 +107,11 @@ export function useOpenShort({
         onTransactionCompleted: (txHash: `0x${string}`) => {
           queryClient.invalidateQueries();
           toast.success(
-            <TransactionToast message="Short opened" txHash={txHash} />,
+            <TransactionToast
+              chainId={chainId}
+              message="Short opened"
+              txHash={txHash}
+            />,
             { id: txHash, duration: SUCCESS_TOAST_DURATION },
           );
           toastWarpcast();
@@ -116,7 +120,11 @@ export function useOpenShort({
       });
 
       toast.loading(
-        <TransactionToast message="Opening Short" txHash={hash} />,
+        <TransactionToast
+          chainId={chainId}
+          message="Opening Short"
+          txHash={hash}
+        />,
         { id: hash },
       );
       onSubmitted?.(hash);

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useOpenShorts.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useOpenShorts.ts
@@ -4,6 +4,7 @@ import { makeQueryKey } from "src/base/makeQueryKey";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
 interface UseOpenShortsOptions {
+  chainId: number;
   account: Address | undefined;
   hyperdriveAddress: Address | undefined;
 }
@@ -13,15 +14,23 @@ interface UseOpenShortsOptions {
  */
 export function useOpenShorts({
   account,
+  chainId,
   hyperdriveAddress,
 }: UseOpenShortsOptions): {
   openShorts: OpenShort[] | undefined;
   openShortsStatus: "error" | "success" | "loading";
 } {
-  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
+  const readHyperdrive = useReadHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const queryEnabled = !!readHyperdrive && !!account;
   const { data: openShorts, status: openShortsStatus } = useQuery({
-    queryKey: makeQueryKey("openShorts", { account, hyperdriveAddress }),
+    queryKey: makeQueryKey("openShorts", {
+      chainId,
+      account,
+      hyperdriveAddress,
+    }),
     queryFn: queryEnabled
       ? async () => await readHyperdrive.getOpenShorts({ account })
       : undefined,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/usePreviewCloseShort.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/usePreviewCloseShort.ts
@@ -7,6 +7,7 @@ import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
 
 interface UsePreviewCloseShortOptions {
+  chainId: number;
   hyperdriveAddress: Address;
   maturityTime: bigint | undefined;
   shortAmountIn: bigint | undefined;
@@ -23,12 +24,16 @@ interface UsePreviewCloseShortResult {
 
 export function usePreviewCloseShort({
   hyperdriveAddress,
+  chainId,
   maturityTime,
   shortAmountIn,
   asBase = true,
   enabled = true,
 }: UsePreviewCloseShortOptions): UsePreviewCloseShortResult {
-  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
+  const readHyperdrive = useReadHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const appConfig = useAppConfig();
   const queryEnabled =
     !!readHyperdrive && !!maturityTime && !!shortAmountIn && enabled;
@@ -36,6 +41,7 @@ export function usePreviewCloseShort({
   const { data, status, fetchStatus, error } = useQuery({
     queryKey: makeQueryKey("previewCloseShort", {
       hyperdriveAddress,
+      chainId,
       maturityTime: maturityTime?.toString(),
       shortAmountIn: shortAmountIn?.toString(),
       asBase,
@@ -56,13 +62,13 @@ export function usePreviewCloseShort({
             : await Promise.all([
                 prepareSharesOut({
                   appConfig,
-                  hyperdriveAddress,
+                  chainId,
                   readHyperdrive,
                   sharesAmount: result.amountOut,
                 }),
                 prepareSharesOut({
                   appConfig,
-                  hyperdriveAddress,
+                  chainId,
                   readHyperdrive,
                   sharesAmount: result.flatPlusCurveFee,
                 }),

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/usePreviewOpenShort.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/usePreviewOpenShort.ts
@@ -5,9 +5,10 @@ import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { prepareSharesOut } from "src/ui/hyperdrive/hooks/usePrepareSharesOut";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
-import { useBlockNumber, useChainId } from "wagmi";
+import { useBlockNumber } from "wagmi";
 
 interface UsePreviewOpenShortOptions {
+  chainId: number;
   hyperdriveAddress: Address;
   amountOfBondsToShort: bigint | undefined;
   asBase: boolean;
@@ -23,23 +24,27 @@ interface UsePreviewOpenShortResult {
 }
 
 export function usePreviewOpenShort({
+  chainId,
   hyperdriveAddress,
   amountOfBondsToShort,
   asBase,
 }: UsePreviewOpenShortOptions): UsePreviewOpenShortResult {
-  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
+  const readHyperdrive = useReadHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const appConfig = useAppConfig();
-  const chainId = useChainId();
   const queryEnabled = !!readHyperdrive && !!amountOfBondsToShort;
   const { data: blockNumber } = useBlockNumber({
     watch: true,
     query: { enabled: queryEnabled },
-    chainId: chainId,
+    chainId,
   });
 
   const { data, status, fetchStatus } = useQuery({
     queryKey: makeQueryKey("previewOpenShort", {
-      hyperdrive: hyperdriveAddress,
+      chainId,
+      hyperdriveAddress,
       amountBondShorts: amountOfBondsToShort?.toString(),
       asBase,
       blockNumber: blockNumber?.toString(),
@@ -57,7 +62,7 @@ export function usePreviewOpenShort({
             ? result.traderDeposit
             : await prepareSharesOut({
                 appConfig,
-                hyperdriveAddress,
+                chainId,
                 readHyperdrive,
                 sharesAmount: result.traderDeposit,
               });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useTotalClosedShortsValue.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useTotalClosedShortsValue.ts
@@ -36,6 +36,7 @@ export function useTotalClosedShortsValue({
     error: totalClosedShortsValueError,
   } = useQuery({
     queryKey: makeQueryKey("totalClosedShortsValue", {
+      chainId: hyperdrive.chainId,
       hyperdriveAddress: hyperdrive.address,
       account,
       activeOpenOrClosedTab,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useTotalClosedShortsValue.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useTotalClosedShortsValue.ts
@@ -21,7 +21,10 @@ export function useTotalClosedShortsValue({
   isLoading: boolean;
   totalClosedShortsValueError: Error;
 } {
-  const readHyperdrive = useReadHyperdrive(hyperdrive.address);
+  const readHyperdrive = useReadHyperdrive({
+    chainId: hyperdrive.chainId,
+    address: hyperdrive.address,
+  });
   const activeOpenOrClosedTab = useOpenOrClosedSearchParam();
 
   const queryEnabled =

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useTotalOpenShortsValue.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useTotalOpenShortsValue.ts
@@ -17,8 +17,14 @@ export function useTotalOpenShortsValue({
   shorts: Short[] | undefined;
   enabled: boolean;
 }): { totalOpenShortsValue: bigint | undefined; isLoading: boolean } {
-  const readHyperdrive = useReadHyperdrive(hyperdrive.address);
-  const { poolInfo } = usePoolInfo({ hyperdriveAddress: hyperdrive.address });
+  const readHyperdrive = useReadHyperdrive({
+    chainId: hyperdrive.chainId,
+    address: hyperdrive.address,
+  });
+  const { poolInfo } = usePoolInfo({
+    hyperdriveAddress: hyperdrive.address,
+    chainId: hyperdrive.chainId,
+  });
 
   const queryEnabled =
     !!account && !!shorts && !!readHyperdrive && !!poolInfo && enabled;

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useTotalOpenShortsValue.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useTotalOpenShortsValue.ts
@@ -31,6 +31,7 @@ export function useTotalOpenShortsValue({
 
   const { data: totalOpenShortsValue, isLoading } = useQuery({
     queryKey: makeQueryKey("totalOpenShortsValue", {
+      chainId: hyperdrive.chainId,
       hyperdriveAddress: hyperdrive.address,
       account,
     }),

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/withdrawalShares/OpenWithdrawalSharesCard/OpenWithdrawalSharesCard.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/withdrawalShares/OpenWithdrawalSharesCard/OpenWithdrawalSharesCard.tsx
@@ -29,8 +29,12 @@ export function OpenWithdrawalSharesCard({
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });
-  const { poolInfo } = usePoolInfo({ hyperdriveAddress: hyperdrive.address });
+  const { poolInfo } = usePoolInfo({
+    hyperdriveAddress: hyperdrive.address,
+    chainId: hyperdrive.chainId,
+  });
   const { withdrawalShares: balanceOfWithdrawalShares } = useWithdrawalShares({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     account,
   });
@@ -39,6 +43,7 @@ export function OpenWithdrawalSharesCard({
     baseProceeds: baseProceedsFromPreview,
     withdrawalSharesRedeemed: withdrawalSharesRedeemedFromPreview,
   } = usePreviewRedeemWithdrawalShares({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     withdrawalSharesIn: balanceOfWithdrawalShares,
     minOutputPerShare: 1n, // TODO: slippage,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/withdrawalShares/OpenWithdrawalSharesCard/OpenWithdrawalSharesCard.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/withdrawalShares/OpenWithdrawalSharesCard/OpenWithdrawalSharesCard.tsx
@@ -25,6 +25,7 @@ export function OpenWithdrawalSharesCard({
   const { address: account } = useAccount();
   const appConfig = useAppConfig();
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/withdrawalShares/RedeemWithdrawalSharesForm/RedeemWithdrawalSharesForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/withdrawalShares/RedeemWithdrawalSharesForm/RedeemWithdrawalSharesForm.tsx
@@ -76,6 +76,7 @@ export function RedeemWithdrawalSharesForm({
   // The max button is wired up to this
   const { withdrawalShares } = useWithdrawalShares({
     account,
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
   });
   const {
@@ -83,6 +84,7 @@ export function RedeemWithdrawalSharesForm({
     baseProceeds: maxRedeemableBaseProceeds,
     sharesProceeds: maxRedeemableSharesProceeds,
   } = usePreviewRedeemWithdrawalShares({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     withdrawalSharesIn: withdrawalShares,
     minOutputPerShare: 0n,
@@ -91,7 +93,10 @@ export function RedeemWithdrawalSharesForm({
 
   // Whatever amount of base or shares they type in, we convert it to withdrawal
   // shares, since that's what the smart contract method requires
-  const { poolInfo } = usePoolInfo({ hyperdriveAddress: hyperdrive.address });
+  const { poolInfo } = usePoolInfo({
+    chainId: hyperdrive.chainId,
+    hyperdriveAddress: hyperdrive.address,
+  });
   const isBaseTokenWithdrawal =
     activeWithdrawToken.address === baseToken.address;
   const convertedAmountToWithdrawalShares = convertAmountToWithdrawalShares({
@@ -121,6 +126,7 @@ export function RedeemWithdrawalSharesForm({
 
   const { baseProceeds, sharesProceeds, previewRedeemWithdrawalSharesStatus } =
     usePreviewRedeemWithdrawalShares({
+      chainId: hyperdrive.chainId,
       hyperdriveAddress: hyperdrive.address,
       withdrawalSharesIn: convertedAmountToWithdrawalShares,
       minOutputPerShare,
@@ -129,6 +135,7 @@ export function RedeemWithdrawalSharesForm({
 
   const { redeemWithdrawalShares, redeemWithdrawalSharesStatus } =
     useRedeemWithdrawalShares({
+      chainId: hyperdrive.chainId,
       hyperdriveAddress: hyperdrive.address,
       withdrawalSharesIn: convertedAmountToWithdrawalShares,
       minOutputPerShare,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/withdrawalShares/RedeemWithdrawalSharesForm/RedeemWithdrawalSharesForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/withdrawalShares/RedeemWithdrawalSharesForm/RedeemWithdrawalSharesForm.tsx
@@ -34,6 +34,7 @@ export function RedeemWithdrawalSharesForm({
 }: RedeemWithdrawalSharesFormProps): ReactElement {
   const appConfig = useAppConfig();
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/landing/Landing.tsx
+++ b/apps/hyperdrive-trading/src/ui/landing/Landing.tsx
@@ -77,16 +77,24 @@ function PoolRow({ hyperdrive }: { hyperdrive: HyperdriveConfig }) {
   const { yieldSources, chains } = appConfig;
 
   const chainInfo = chains[hyperdrive.chainId];
-  const { fixedApr, fixedRateStatus } = useFixedRate(hyperdrive.address);
-  const { vaultRate, vaultRateStatus } = useYieldSourceRate({
+  const { fixedApr, fixedRateStatus } = useFixedRate({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
   });
-  const { lpApy, lpApyStatus } = useLpApy(hyperdrive.address);
+  const { vaultRate, vaultRateStatus } = useYieldSourceRate({
+    chainId: hyperdrive.chainId,
+    hyperdriveAddress: hyperdrive.address,
+  });
+  const { lpApy, lpApyStatus } = useLpApy({
+    hyperdriveAddress: hyperdrive.address,
+    chainId: hyperdrive.chainId,
+  });
   const isLpApyNew = lpApyStatus !== "loading" && lpApy === undefined;
 
   // Display TVL as base value on testnet due to lack of reliable fiat pricing.
   // On mainnet and others, use DeFiLlama's fiat price.
   const { presentValue } = usePresentValue({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
   });
   const isFiatPriceEnabled = !isTestnetChain(chainInfo.id);
@@ -200,6 +208,7 @@ function PoolRow({ hyperdrive }: { hyperdrive: HyperdriveConfig }) {
               vaultRate ? (
                 <RewardsTooltip
                   hyperdriveAddress={hyperdrive.address}
+                  chainId={hyperdrive.chainId}
                   positionType="short"
                 >
                   <PercentLabel
@@ -237,6 +246,7 @@ function PoolRow({ hyperdrive }: { hyperdrive: HyperdriveConfig }) {
               lpApy && !isLpApyNew ? (
                 <RewardsTooltip
                   positionType="lp"
+                  chainId={hyperdrive.chainId}
                   hyperdriveAddress={hyperdrive.address}
                 >
                   <PercentLabel value={`${(lpApy * 100).toFixed(2)}`} />

--- a/apps/hyperdrive-trading/src/ui/landing/Landing.tsx
+++ b/apps/hyperdrive-trading/src/ui/landing/Landing.tsx
@@ -96,8 +96,9 @@ function PoolRow({ hyperdrive }: { hyperdrive: HyperdriveConfig }) {
       : undefined,
   });
   const baseToken = findBaseToken({
-    appConfig,
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
+    appConfig,
   });
   let tvlLabel = `${formatCompact({
     value: presentValue || 0n,

--- a/apps/hyperdrive-trading/src/ui/markets/AssetStack.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/AssetStack.tsx
@@ -13,6 +13,7 @@ export function AssetStack({
     (hyperdrive) => hyperdrive.address === hyperdriveAddress,
   )!;
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/markets/LongsTab/LongsTab.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/LongsTab/LongsTab.tsx
@@ -55,6 +55,7 @@ export function LongsTab({
       : isTotalClosedValueLoading;
 
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/markets/LongsTab/LongsTab.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/LongsTab/LongsTab.tsx
@@ -25,10 +25,12 @@ export function LongsTab({
   const appConfig = useAppConfig();
   const { address: account } = useAccount();
   const { openLongs } = useOpenLongs({
+    chainId: hyperdrive.chainId,
     account,
     hyperdriveAddress: hyperdrive.address,
   });
   const { closedLongs } = useClosedLongs({
+    chainId: hyperdrive.chainId,
     account,
     hyperdriveAddress: hyperdrive.address,
   });

--- a/apps/hyperdrive-trading/src/ui/markets/LpTab/LpTab.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/LpTab/LpTab.tsx
@@ -23,15 +23,20 @@ export function LpTab({
   const { address: account } = useAccount();
   const { switchChain } = useSwitchChain();
   const chainId = useChainId();
-  const { marketState } = useMarketState(hyperdrive.address);
+  const { marketState } = useMarketState({
+    chainId: hyperdrive.chainId,
+    hyperdriveAddress: hyperdrive.address,
+  });
   const activeOpenOrClosedTab = useOpenOrClosedSearchParam();
 
   const { lpShares, lpSharesStatus } = useLpShares({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     account,
   });
 
   const { withdrawalShares, withdrawalSharesStatus } = useWithdrawalShares({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     account,
   });

--- a/apps/hyperdrive-trading/src/ui/markets/MarketDetailsBody/MarketDetailsBody.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketDetailsBody/MarketDetailsBody.tsx
@@ -17,7 +17,10 @@ interface PositionsTableProps {
 export function MarketDetailsBody({
   hyperdrive,
 }: PositionsTableProps): ReactElement {
-  const { marketState } = useMarketState(hyperdrive.address);
+  const { marketState } = useMarketState({
+    chainId: hyperdrive.chainId,
+    hyperdriveAddress: hyperdrive.address,
+  });
   const { address: account } = useAccount();
   return (
     <div className="flex flex-col gap-12 xl:w-[1200px]">

--- a/apps/hyperdrive-trading/src/ui/markets/MarketDetailsBody/MarketHeader.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketDetailsBody/MarketHeader.tsx
@@ -16,6 +16,7 @@ export function MarketHeader({
 }): ReactElement {
   const appConfig = useAppConfig();
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/markets/MarketDetailsBody/PriceBadges.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketDetailsBody/PriceBadges.tsx
@@ -13,9 +13,10 @@ export function PriceBadges({
   hyperdrive: HyperdriveConfig;
 }): ReactElement {
   const appConfig = useAppConfig();
-  const { longPrice, longPriceStatus } = useCurrentLongPrice(
-    hyperdrive.address,
-  );
+  const { longPrice, longPriceStatus } = useCurrentLongPrice({
+    chainId: hyperdrive.chainId,
+    hyperdriveAddress: hyperdrive.address,
+  });
   const baseToken = findBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,

--- a/apps/hyperdrive-trading/src/ui/markets/MarketDetailsBody/PriceBadges.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketDetailsBody/PriceBadges.tsx
@@ -17,6 +17,7 @@ export function PriceBadges({
     hyperdrive.address,
   );
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/FixedRateStat.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/FixedRateStat.tsx
@@ -19,7 +19,10 @@ export function FixedRateStat({
     fixedApr,
     fixedRoi,
     fixedRateStatus: fixedAprStatus,
-  } = useFixedRate(hyperdrive.address);
+  } = useFixedRate({
+    chainId: hyperdrive.chainId,
+    hyperdriveAddress: hyperdrive.address,
+  });
   const [rateType, setRateType] = useLocalStorage<"fixedApr" | "fixedRoi">(
     "yield-stats-long-rate-type",
     "fixedApr",

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/LiquidityStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/LiquidityStats.tsx
@@ -25,6 +25,7 @@ export function LiquidityStats({
   });
   const appConfig = useAppConfig();
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/LiquidityStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/LiquidityStats.tsx
@@ -31,20 +31,28 @@ export function LiquidityStats({
   });
 
   const { totalVolume, longVolume, shortVolume, tradingVolumeStatus } =
-    useTradingVolume(hyperdrive.address, currentBlockNumber);
+    useTradingVolume(
+      hyperdrive.chainId,
+      hyperdrive.address,
+      currentBlockNumber,
+    );
 
   const { presentValue, presentValueStatus } = usePresentValue({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
   });
   const { maxBondsOut: maxLong } = useMaxLong({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
   });
   const { maxBondsOut: maxShort } = useMaxShort({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     budget: MAX_UINT256,
   });
 
   const { idleLiquidity, idleLiquidityStatus } = useIdleLiquidity({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
   });
 

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/ShortRateStat.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/ShortRateStat.tsx
@@ -20,10 +20,12 @@ export function ShortRateStat({
     "shortApr",
   );
   const { vaultRate } = useYieldSourceRate({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
   });
 
   const { shortApr, shortRoi, shortRateStatus } = useShortRate({
+    chainId: hyperdrive.chainId,
     bondAmount: hyperdrive.decimals > 6 ? BigInt(1e15) : BigInt(1e6),
     hyperdriveAddress: hyperdrive.address,
     variableApy: vaultRate?.vaultRate ? vaultRate.vaultRate : undefined,
@@ -56,6 +58,7 @@ export function ShortRateStat({
             <Skeleton className="w-20" />
           ) : (
             <RewardsTooltip
+              chainId={hyperdrive.chainId}
               hyperdriveAddress={hyperdrive.address}
               positionType="short"
             >
@@ -75,6 +78,7 @@ export function ShortRateStat({
             <Skeleton className="w-20" />
           ) : (
             <RewardsTooltip
+              chainId={hyperdrive.chainId}
               hyperdriveAddress={hyperdrive.address}
               positionType="short"
             >

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/YieldStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/YieldStats.tsx
@@ -25,7 +25,10 @@ export function YieldStats({
   const appConfig = useAppConfig();
   const yieldSource = appConfig.yieldSources[hyperdrive.yieldSource];
 
-  const { lpApy, lpApyStatus } = useLpApy(hyperdrive.address);
+  const { lpApy, lpApyStatus } = useLpApy({
+    chainId: hyperdrive.chainId,
+    hyperdriveAddress: hyperdrive.address,
+  });
 
   return (
     <Well transparent block>
@@ -34,6 +37,7 @@ export function YieldStats({
           <h5 className="flex text-neutral-content">Yield</h5>
           <div className="font-dmMono text-neutral-content">
             <YieldSourceRateBadge
+              chainId={hyperdrive.chainId}
               hyperdriveAddress={hyperdrive.address}
               labelRenderer={(vaultRate) =>
                 `${yieldSource?.shortName} @ ${vaultRate.formatted || 0} APY`
@@ -59,6 +63,7 @@ export function YieldStats({
               label={`LP APY (${yieldSource.historicalRatePeriod}d)`}
               value={
                 <RewardsTooltip
+                  chainId={hyperdrive.chainId}
                   hyperdriveAddress={hyperdrive.address}
                   positionType="lp"
                 >

--- a/apps/hyperdrive-trading/src/ui/markets/OpenClosedFilter/OpenClosedFilter.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/OpenClosedFilter/OpenClosedFilter.tsx
@@ -2,14 +2,13 @@ import { Link, useParams, useSearch } from "@tanstack/react-router";
 import classNames from "classnames";
 import { ReactElement } from "react";
 import { MARKET_DETAILS_ROUTE } from "src/ui/markets/routes";
-import { useAccount, useChainId } from "wagmi";
+import { useAccount } from "wagmi";
 
 export function OpenClosedFilter(): ReactElement {
   const { openOrClosed = "open", position } = useSearch({
     from: MARKET_DETAILS_ROUTE,
   });
-  const chainId = useChainId();
-  const { address } = useParams({ from: MARKET_DETAILS_ROUTE });
+  const { address, chainId } = useParams({ from: MARKET_DETAILS_ROUTE });
   const { isConnected } = useAccount();
 
   return (
@@ -25,7 +24,7 @@ export function OpenClosedFilter(): ReactElement {
           "daisy-link-secondary daisy-tab-disabled cursor-not-allowed":
             !isConnected,
         })}
-        params={{ address, chainId: chainId.toString() }}
+        params={{ address, chainId }}
         search={{ openOrClosed: "open", position }}
         to={MARKET_DETAILS_ROUTE}
         disabled={!isConnected}
@@ -40,7 +39,7 @@ export function OpenClosedFilter(): ReactElement {
           "daisy-link-secondary daisy-tab-disabled cursor-not-allowed":
             !isConnected,
         })}
-        params={{ address, chainId: chainId.toString() }}
+        params={{ address, chainId }}
         search={{ openOrClosed: "closed", position }}
         to={MARKET_DETAILS_ROUTE}
         disabled={!isConnected}

--- a/apps/hyperdrive-trading/src/ui/markets/ShortsTab/ShortsTab.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/ShortsTab/ShortsTab.tsx
@@ -56,6 +56,7 @@ export function ShortsTab({
       : isTotalClosedValueLoading;
 
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/markets/ShortsTab/ShortsTab.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/ShortsTab/ShortsTab.tsx
@@ -26,10 +26,12 @@ export function ShortsTab({
   const appConfig = useAppConfig();
   const { openShorts } = useOpenShorts({
     account,
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
   });
   const { closedShorts } = useClosedShorts({
     account,
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
   });
   const { totalOpenShortsValue, isLoading: isTotalOpenValueLoading } =

--- a/apps/hyperdrive-trading/src/ui/markets/YourBalanceWell/YourBalanceWell.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/YourBalanceWell/YourBalanceWell.tsx
@@ -29,6 +29,7 @@ export function YourBalanceWell({
 
   // base token
   const baseToken = findBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });

--- a/apps/hyperdrive-trading/src/ui/portfolio/usePortfolioLongsData.ts
+++ b/apps/hyperdrive-trading/src/ui/portfolio/usePortfolioLongsData.ts
@@ -15,6 +15,8 @@ export function usePortfolioLongsData(): {
   openLongPositionsStatus: "error" | "success" | "loading";
 } {
   const { address: account } = useAccount();
+  // TODO: We should be getting a specific public client for the chain the
+  // hyperdrive is on
   const publicClient = usePublicClient();
   const appConfig = useAppConfig();
   const queryEnabled = !!account && !!appConfig && !!publicClient;

--- a/apps/hyperdrive-trading/src/ui/portfolio/usePortfolioShortsData.ts
+++ b/apps/hyperdrive-trading/src/ui/portfolio/usePortfolioShortsData.ts
@@ -13,6 +13,8 @@ export function usePortfolioShortsData(): {
   openShortPositionsStatus: "error" | "success" | "loading";
 } {
   const { address: account } = useAccount();
+  // TODO: We should be getting a specific public client for the chain the
+  // hyperdrive is on
   const publicClient = usePublicClient();
   const appConfig = useAppConfig();
   const queryEnabled = !!account && !!appConfig && !!publicClient;

--- a/apps/hyperdrive-trading/src/ui/rewards/RewardsTooltip.tsx
+++ b/apps/hyperdrive-trading/src/ui/rewards/RewardsTooltip.tsx
@@ -5,29 +5,34 @@ import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { useRewards } from "src/ui/rewards/useRewards";
 import { Address } from "viem";
 
-interface RewardsTooltipProps extends PropsWithChildren {
+export function RewardsTooltip({
+  hyperdriveAddress,
+  chainId,
+  positionType,
+  children,
+}: PropsWithChildren<{
   hyperdriveAddress: Address;
+  chainId: number;
   positionType: "lp" | "short";
-}
-
-export function RewardsTooltip(props: RewardsTooltipProps): ReactNode {
+}>): ReactNode {
   const { hyperdrives } = useAppConfig();
   const hyperdrive = findHyperdriveConfig({
     hyperdrives,
-    hyperdriveAddress: props.hyperdriveAddress,
+    hyperdriveAddress: hyperdriveAddress,
+    hyperdriveChainId: chainId,
   });
 
-  const rewards = useRewards(hyperdrive, props.positionType);
+  const rewards = useRewards(hyperdrive, positionType);
 
   if (!rewards || (rewards && rewards.length === 0)) {
-    return props.children;
+    return children;
   }
 
   return (
     <Tooltip.Provider>
       <Tooltip.Root>
         <Tooltip.Trigger className="flex items-center gap-1 whitespace-nowrap">
-          {props.children}⚡
+          {children}⚡
         </Tooltip.Trigger>
         <Tooltip.Portal>
           <Tooltip.Content

--- a/apps/hyperdrive-trading/src/ui/rewards/useRewards.ts
+++ b/apps/hyperdrive-trading/src/ui/rewards/useRewards.ts
@@ -56,9 +56,11 @@ export function useRewards(
   const chainId = useChainId();
 
   const { poolInfo } = usePoolInfo({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
   });
   const { presentValue } = usePresentValue({
+    chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
   });
 

--- a/apps/hyperdrive-trading/src/ui/token/hooks/useApproveToken.tsx
+++ b/apps/hyperdrive-trading/src/ui/token/hooks/useApproveToken.tsx
@@ -35,7 +35,7 @@ export function useApproveToken({
   const appConfig = useAppConfig();
   const { writeContract, status } = useWriteContract();
   const addRecentTransaction = useAddRecentTransaction();
-  const publicClient = usePublicClient();
+  const publicClient = usePublicClient({ chainId: tokenChainId });
   const [isTransactionMined, setIsTransactionMined] = useState(false);
   const queryEnabled = !!spender && !!enabled && !!publicClient;
   const token = findToken({
@@ -70,7 +70,11 @@ export function useApproveToken({
               const loadingDescription =
                 finalAmount === 0n ? "Revoking approval..." : "Approving...";
               toast.loading(
-                <TransactionToast message={loadingDescription} txHash={hash} />,
+                <TransactionToast
+                  chainId={tokenChainId}
+                  message={loadingDescription}
+                  txHash={hash}
+                />,
                 { id: hash },
               );
 
@@ -84,7 +88,11 @@ export function useApproveToken({
               const loadedDescription =
                 finalAmount === 0n ? "Approval revoked" : "Token approved";
               toast.success(
-                <TransactionToast message={loadedDescription} txHash={hash} />,
+                <TransactionToast
+                  chainId={tokenChainId}
+                  message={loadedDescription}
+                  txHash={hash}
+                />,
                 { id: hash, duration: SUCCESS_TOAST_DURATION },
               );
             },

--- a/apps/hyperdrive-trading/src/ui/token/hooks/useMintToken.tsx
+++ b/apps/hyperdrive-trading/src/ui/token/hooks/useMintToken.tsx
@@ -20,7 +20,7 @@ export function useMintToken({
   amount: bigint;
 }): { mint: (() => void) | undefined } {
   const addRecentTransaction = useAddRecentTransaction();
-  const publicClient = usePublicClient();
+  const publicClient = usePublicClient({ chainId: token.chainId });
   const { data: maxMintAmount } = useReadContract({
     abi: [
       {
@@ -70,6 +70,7 @@ export function useMintToken({
             onSuccess: async (hash) => {
               toast.loading(
                 <TransactionToast
+                  chainId={token.chainId}
                   message={`Minting ${token.symbol}`}
                   txHash={hash}
                 />,
@@ -86,6 +87,7 @@ export function useMintToken({
               });
               toast.success(
                 <TransactionToast
+                  chainId={token.chainId}
                   message={`Minted ${token.symbol}`}
                   txHash={hash}
                 />,

--- a/apps/hyperdrive-trading/src/ui/vaults/YieldSourceRateBadge.tsx
+++ b/apps/hyperdrive-trading/src/ui/vaults/YieldSourceRateBadge.tsx
@@ -5,9 +5,11 @@ import { useYieldSourceRate } from "src/ui/vaults/useYieldSourceRate";
 import { Address } from "viem";
 
 export function YieldSourceRateBadge({
+  chainId,
   hyperdriveAddress,
   labelRenderer,
 }: {
+  chainId: number;
   hyperdriveAddress: Address;
   labelRenderer?: (vaultRate: {
     vaultRate: bigint;
@@ -16,6 +18,7 @@ export function YieldSourceRateBadge({
 }): ReactElement {
   const { vaultRate, vaultRateStatus } = useYieldSourceRate({
     hyperdriveAddress,
+    chainId,
   });
 
   if (vaultRateStatus === "loading" && !vaultRate) {

--- a/apps/hyperdrive-trading/src/ui/vaults/useYieldSourceRate.ts
+++ b/apps/hyperdrive-trading/src/ui/vaults/useYieldSourceRate.ts
@@ -25,6 +25,7 @@ export function useYieldSourceRate({
   const { data: vaultRate, status: vaultRateStatus } = useQuery({
     enabled: queryEnabled,
     queryKey: makeQueryKey("vaultRate", {
+      chainId,
       hyperdriveAddress,
     }),
     queryFn: queryEnabled

--- a/apps/hyperdrive-trading/src/ui/vaults/useYieldSourceRate.ts
+++ b/apps/hyperdrive-trading/src/ui/vaults/useYieldSourceRate.ts
@@ -6,17 +6,20 @@ import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
 
-interface UseVaultRateOptions {
-  hyperdriveAddress: Address | undefined;
-}
-
 export function useYieldSourceRate({
+  chainId,
   hyperdriveAddress,
-}: UseVaultRateOptions): {
+}: {
+  chainId: number;
+  hyperdriveAddress: Address | undefined;
+}): {
   vaultRate: { vaultRate: bigint; formatted: string } | undefined;
   vaultRateStatus: "error" | "success" | "loading";
 } {
-  const readHyperdrive = useReadHyperdrive(hyperdriveAddress);
+  const readHyperdrive = useReadHyperdrive({
+    chainId,
+    address: hyperdriveAddress,
+  });
   const appConfig = useAppConfig();
   const queryEnabled = !!hyperdriveAddress && !!readHyperdrive;
   const { data: vaultRate, status: vaultRateStatus } = useQuery({

--- a/packages/hyperdrive-appconfig/README.md
+++ b/packages/hyperdrive-appconfig/README.md
@@ -12,6 +12,7 @@ const firstHyperdrive = appConfig.hyperdrives[0];
 
 // 2. Lookup its base token
 const baseToken = findBaseToken({
+  hyperdriveChainId: firstHyperdrive.chainId,
   hyperdriveAddress: firstHyperdrive.address,
   appConfig,
 });

--- a/packages/hyperdrive-appconfig/src/hyperdrives/selectors.ts
+++ b/packages/hyperdrive-appconfig/src/hyperdrives/selectors.ts
@@ -5,17 +5,22 @@ import { findToken } from "src/tokens/selectors";
 import { Address, zeroAddress } from "viem";
 
 /**
- * Returns a strongly typed TokenConfig for the yield source token.
+ * Returns a strongly typed HyperdriveConfig for the hyperdrive address and
+ * chain id
  */
 export function findHyperdriveConfig({
-  hyperdrives,
+  hyperdriveChainId,
   hyperdriveAddress,
+  hyperdrives,
 }: {
-  hyperdrives: HyperdriveConfig[];
+  hyperdriveChainId: number;
   hyperdriveAddress: Address;
+  hyperdrives: HyperdriveConfig[];
 }): HyperdriveConfig {
   const hyperdriveConfig = hyperdrives.find(
-    (hyperdriveConfig) => hyperdriveConfig.address === hyperdriveAddress,
+    (hyperdriveConfig) =>
+      hyperdriveConfig.address === hyperdriveAddress &&
+      hyperdriveConfig.chainId === hyperdriveChainId,
   );
 
   if (!hyperdriveConfig) {
@@ -34,13 +39,16 @@ export function findHyperdriveConfig({
  * zero address), the function will attempt to return a fallback base token.
  */
 export function findBaseToken({
+  hyperdriveChainId,
   hyperdriveAddress,
   appConfig,
 }: {
+  hyperdriveChainId: number;
   hyperdriveAddress: Address;
   appConfig: AppConfig;
 }): TokenConfig {
   const hyperdriveConfig = findHyperdriveConfig({
+    hyperdriveChainId: hyperdriveChainId,
     hyperdriveAddress,
     hyperdrives: appConfig.hyperdrives,
   });


### PR DESCRIPTION
Hyperdrive addresses are no longer sufficient to properly identify a pool. Instead, callers must now provide the chain id and the hyperdrive address.