### PR TITLE
Show variable apy instead of short rate in Yield stats

### DIFF
--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/VariableRateStat.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/VariableRateStat.tsx
@@ -1,0 +1,52 @@
+import { HyperdriveConfig } from "@hyperdrive/appconfig";
+import classNames from "classnames";
+import { ReactElement } from "react";
+import Skeleton from "react-loading-skeleton";
+import { useAppConfig } from "src/ui/appconfig/useAppConfig";
+import { Stat } from "src/ui/base/components/Stat";
+import { RewardsTooltip } from "src/ui/rewards/RewardsTooltip";
+import { useYieldSourceRate } from "src/ui/vaults/useYieldSourceRate";
+
+export function VariableRateStat({
+  isActive,
+  hyperdrive,
+}: {
+  isActive: boolean;
+  hyperdrive: HyperdriveConfig;
+}): ReactElement {
+  const appConfig = useAppConfig();
+  const { vaultRate, vaultRateStatus } = useYieldSourceRate({
+    chainId: hyperdrive.chainId,
+    hyperdriveAddress: hyperdrive.address,
+  });
+
+  const yieldSource = appConfig.yieldSources[hyperdrive.yieldSource];
+
+  const isLoadingVaultRate =
+    vaultRateStatus === "loading" && vaultRate === undefined;
+
+  const rateClassName = classNames("flex items-center gap-1.5", {
+    "gradient-text": isActive && vaultRateStatus === "success",
+  });
+
+  return (
+    <Stat
+      label={`Variable APY (${yieldSource.historicalRatePeriod}d)`}
+      description={`The yield rate earned on deposits into ${yieldSource.shortName} in the last ${yieldSource.historicalRatePeriod} days.`}
+      tooltipPosition="bottom"
+      value={
+        isLoadingVaultRate ? (
+          <Skeleton className="w-20" />
+        ) : (
+          <RewardsTooltip
+            chainId={hyperdrive.chainId}
+            hyperdriveAddress={hyperdrive.address}
+            positionType="short"
+          >
+            <span className={rateClassName}>{vaultRate?.formatted || "-"}</span>
+          </RewardsTooltip>
+        )
+      }
+    />
+  );
+}

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/YieldStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/YieldStats.tsx
@@ -10,10 +10,9 @@ import { Well } from "src/ui/base/components/Well/Well";
 import { useIsTailwindSmallScreen } from "src/ui/base/mediaBreakpoints";
 import { useLpApy } from "src/ui/hyperdrive/hooks/useLpApy";
 import { FixedRateStat } from "src/ui/markets/MarketStats/FixedRateStat";
-import { ShortRateStat } from "src/ui/markets/MarketStats/ShortRateStat";
+import { VariableRateStat } from "src/ui/markets/MarketStats/VariableRateStat";
 import { MARKET_DETAILS_ROUTE } from "src/ui/markets/routes";
 import { RewardsTooltip } from "src/ui/rewards/RewardsTooltip";
-import { YieldSourceRateBadge } from "src/ui/vaults/YieldSourceRateBadge";
 
 export function YieldStats({
   hyperdrive,
@@ -33,18 +32,7 @@ export function YieldStats({
   return (
     <Well transparent block>
       <div className="space-y-8">
-        <div className="flex justify-between">
-          <h5 className="flex text-neutral-content">Yield</h5>
-          <div className="font-dmMono text-neutral-content">
-            <YieldSourceRateBadge
-              chainId={hyperdrive.chainId}
-              hyperdriveAddress={hyperdrive.address}
-              labelRenderer={(vaultRate) =>
-                `${yieldSource?.shortName} @ ${vaultRate.formatted || 0} APY`
-              }
-            />
-          </div>
-        </div>
+        <h5 className="flex text-neutral-content">Yield</h5>
         <div className="flex flex-wrap gap-8 lg:gap-16">
           <Animated isActive={position === "longs"}>
             <FixedRateStat
@@ -53,7 +41,7 @@ export function YieldStats({
             />
           </Animated>
           <Animated isActive={position === "shorts"}>
-            <ShortRateStat
+            <VariableRateStat
               isActive={position === "shorts"}
               hyperdrive={hyperdrive}
             />


### PR DESCRIPTION
Yield stats now show the Variable APY instead of the short rate.

<img width="679" alt="image" src="https://github.com/user-attachments/assets/726ece81-a329-4f0d-af9f-4191849236fe">
