### PR TITLE
Use `registries` instead of `chains` for chainlog chain ids

### DIFF
--- a/apps/hyperdrive-trading/package.json
+++ b/apps/hyperdrive-trading/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@delvtech/fixed-point-wasm": "^0.0.4",
-    "@delvtech/hyperdrive-viem": "^3.0.0",
+    "@delvtech/hyperdrive-viem": "^3.0.1",
     "@heroicons/react": "^2.0.16",
     "@hyperdrive/appconfig": "*",
     "@radix-ui/react-tooltip": "^1.1.2",

--- a/apps/hyperdrive-trading/src/ui/chainlog/FactoriesTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/chainlog/FactoriesTable.tsx
@@ -165,7 +165,7 @@ interface Factory {
 
 function useFactoriesQuery(): UseQueryResult<Factory[], any> {
   const appConfig = useAppConfig();
-  const chainIds = Object.keys(appConfig.chains).map(Number);
+  const chainIds = Object.keys(appConfig.registries).map(Number);
 
   return useQuery({
     queryKey: makeQueryKey("chainlog", {

--- a/apps/hyperdrive-trading/src/ui/chainlog/PoolsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/chainlog/PoolsTable.tsx
@@ -212,7 +212,7 @@ interface Pool {
 
 function usePoolsQuery(): UseQueryResult<Pool[], any> {
   const appConfig = useAppConfig();
-  const chainIds = Object.keys(appConfig.chains).map(Number);
+  const chainIds = Object.keys(appConfig.registries).map(Number);
 
   return useQuery({
     queryKey: makeQueryKey("chainlog", {

--- a/packages/hyperdrive-appconfig/package.json
+++ b/packages/hyperdrive-appconfig/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@delvtech/hyperdrive-artifacts": "^1.0.16",
-    "@delvtech/hyperdrive-viem": "^3.0.0",
+    "@delvtech/hyperdrive-viem": "^3.0.1",
     "@hyperdrive/eslint-config": "*",
     "@hyperdrive/prettier-config": "*",
     "@hyperdrive/tsconfig": "*",


### PR DESCRIPTION
Fixes the factories tab by using all chain ids from `appConfig.registries` rather than assuming there's a registry for each chain.