### PR TITLE
Fix rounding icons

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktopTwo.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktopTwo.tsx
@@ -84,7 +84,7 @@ export function OpenLongsContainer(): ReactElement {
                       className="daisy-avatar daisy-tooltip daisy-tooltip-bottom w-12 scale-75 overflow-visible sm:scale-100"
                       data-tip={baseToken.symbol}
                     >
-                      <img src={baseToken.iconUrl} />
+                      <img src={baseToken.iconUrl} className="rounded-full" />
                     </div>
                   ) : null}
                   {sharesToken &&
@@ -93,7 +93,7 @@ export function OpenLongsContainer(): ReactElement {
                       className="daisy-avatar daisy-tooltip daisy-tooltip-bottom w-12 scale-75 overflow-visible sm:scale-100"
                       data-tip={sharesToken.symbol}
                     >
-                      <img src={sharesToken.iconUrl} />
+                      <img src={sharesToken.iconUrl} className="rounded-full" />
                     </div>
                   ) : null}
                 </div>

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
@@ -215,7 +215,7 @@ export function RemoveLiquidityForm({
           name="Input LP shares"
           token={
             <div className="daisy-join-item flex h-12 shrink-0 items-center gap-1.5 border border-neutral-content/30 bg-base-100 px-4">
-              <img src={baseToken.iconUrl} className="h-5" />{" "}
+              <img src={baseToken.iconUrl} className="h-5 rounded-full" />{" "}
               <span className="text-sm font-semibold">
                 {baseToken.symbol}-LP
               </span>

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktopTwo.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktopTwo.tsx
@@ -68,7 +68,7 @@ export function OpenShortsContainer(): ReactElement {
                       className="daisy-avatar daisy-tooltip daisy-tooltip-bottom w-12 scale-75 overflow-visible sm:scale-100"
                       data-tip={baseToken.symbol}
                     >
-                      <img src={baseToken.iconUrl} />
+                      <img src={baseToken.iconUrl} className="rounded-full" />
                     </div>
                   ) : null}
                   {sharesToken &&
@@ -77,7 +77,7 @@ export function OpenShortsContainer(): ReactElement {
                       className="daisy-avatar daisy-tooltip daisy-tooltip-bottom w-12 scale-75 overflow-visible sm:scale-100"
                       data-tip={sharesToken.symbol}
                     >
-                      <img src={sharesToken.iconUrl} />
+                      <img src={sharesToken.iconUrl} className="rounded-full" />
                     </div>
                   ) : null}
                 </div>

--- a/apps/hyperdrive-trading/src/ui/token/TokenPicker.tsx
+++ b/apps/hyperdrive-trading/src/ui/token/TokenPicker.tsx
@@ -34,7 +34,10 @@ export function TokenPicker({
           </label>
         ) : undefined}
         <div className="daisy-join-item flex h-12 w-32 shrink-0 items-center gap-1.5 border border-neutral-content/30 bg-base-100 px-4">
-          <img src={tokens[0].tokenConfig.iconUrl} className="h-5" />{" "}
+          <img
+            src={tokens[0].tokenConfig.iconUrl}
+            className="h-5 rounded-full"
+          />{" "}
           <span className="text-sm font-semibold">
             {tokens[0].tokenConfig.symbol}
           </span>
@@ -67,7 +70,10 @@ export function TokenPicker({
             e.preventDefault();
           }}
         >
-          <img src={activeToken?.tokenConfig?.iconUrl} className="h-5" />{" "}
+          <img
+            src={activeToken?.tokenConfig?.iconUrl}
+            className="h-5 rounded-full"
+          />{" "}
           {activeToken?.tokenConfig?.symbol}
           <ChevronDownIcon className="ml-2 h-3" />
         </button>
@@ -86,7 +92,10 @@ export function TokenPicker({
                   }}
                   className="gap-2"
                 >
-                  <img src={tokenConfig?.iconUrl} className="h-5" />{" "}
+                  <img
+                    src={tokenConfig?.iconUrl}
+                    className="h-5 rounded-full"
+                  />{" "}
                   {tokenConfig?.symbol}
                   <label className="flex w-32 flex-1 cursor-pointer text-neutral-content">
                     <span>

--- a/apps/hyperdrive-trading/src/ui/token/TokenPickerTwo.tsx
+++ b/apps/hyperdrive-trading/src/ui/token/TokenPickerTwo.tsx
@@ -32,7 +32,10 @@ export function TokenPickerTwo({
           </label>
         ) : undefined}
         <div className="daisy-btn daisy-btn-md flex items-center rounded-box bg-neutral text-lg">
-          <img src={tokens[0].tokenConfig.iconUrl} className="h-5" />
+          <img
+            src={tokens[0].tokenConfig.iconUrl}
+            className="h-5 rounded-full"
+          />
           <span className="text-sm font-semibold">
             {tokens[0].tokenConfig.symbol}
           </span>
@@ -62,7 +65,10 @@ export function TokenPickerTwo({
             e.preventDefault();
           }}
         >
-          <img src={activeToken?.tokenConfig?.iconUrl} className="h-5" />{" "}
+          <img
+            src={activeToken?.tokenConfig?.iconUrl}
+            className="h-5 rounded-full"
+          />{" "}
           {activeToken?.tokenConfig?.symbol}
           <ChevronDownIcon className="h-6 text-neutral-content" />
         </button>
@@ -81,7 +87,10 @@ export function TokenPickerTwo({
                   }}
                   className="gap-2"
                 >
-                  <img src={tokenConfig?.iconUrl} className="h-5" />{" "}
+                  <img
+                    src={tokenConfig?.iconUrl}
+                    className="h-5 rounded-full"
+                  />{" "}
                   {tokenConfig?.symbol}
                   <label className="flex w-32 flex-1 cursor-pointer text-neutral-content">
                     <span>


### PR DESCRIPTION
The token icons may not be round by default. When used in Daisy avatar components, the rounding is automatically applied. However, for instances where we use img tags, we need to manually apply the rounding to ensure consistent appearance.