### PR TITLE
Return bigint for `getLpApy`

### DIFF
--- a/.changeset/ninety-queens-walk.md
+++ b/.changeset/ninety-queens-walk.md
@@ -1,0 +1,5 @@
+---
+"@delvtech/hyperdrive-js-core": patch
+---
+
+Return bigint instead of number for getLpApy

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
@@ -357,10 +357,10 @@ export function AddLiquidityForm({
           <PrimaryStat
             label="LP APY"
             value={
-              isNewPool || lpApy == undefined ? (
+              isNewPool || lpApy === undefined ? (
                 <div className="flex gap-2">✨New✨</div>
               ) : (
-                `${(lpApy * 100).toFixed(2) === "-0.00" ? "0.00" : (lpApy * 100).toFixed(2)}%`
+                `${lpApy.formatted === "-0.00" ? "0.00" : lpApy.formatted}%`
               )
             }
             tooltipContent="The annual percentage yield projection for providing liquidity."

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/YieldStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/YieldStats.tsx
@@ -67,9 +67,7 @@ export function YieldStats({
                         <span className="flex flex-row">✨New✨</span>
                       ) : (
                         `${
-                          (lpApy * 100).toFixed(2) === "-0.00"
-                            ? "0.00"
-                            : (lpApy * 100).toFixed(2)
+                          lpApy.formatted === "-0.00" ? "0.00" : lpApy.formatted
                         }%`
                       )}{" "}
                     </span>

--- a/apps/hyperdrive-trading/src/ui/markets/PoolRow/PoolRow.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PoolRow/PoolRow.tsx
@@ -208,15 +208,13 @@ export function PoolRow({
             isLoading={lpApyStatus === "loading"}
             isNew={isLpApyNew}
             value={
-              // TODO: Fix useLpApy to have the same interface as
-              // useYieldSourceRate and useFixedRate
               lpApy && !isLpApyNew ? (
                 <RewardsTooltip
                   positionType="lp"
                   chainId={hyperdrive.chainId}
                   hyperdriveAddress={hyperdrive.address}
                 >
-                  <PercentLabel value={`${(lpApy * 100).toFixed(2)}`} />
+                  <PercentLabel value={`${lpApy.formatted}`} />
                 </RewardsTooltip>
               ) : (
                 "-"

--- a/packages/hyperdrive-js-core/src/hyperdrive/base/ReadHyperdrive.ts
+++ b/packages/hyperdrive-js-core/src/hyperdrive/base/ReadHyperdrive.ts
@@ -664,7 +664,7 @@ export class ReadHyperdrive extends ReadModel {
   }: {
     fromBlock: bigint;
     options?: ContractReadOptions;
-  }): Promise<{ lpApy: number }> {
+  }): Promise<{ lpApy: bigint }> {
     // If the 24 hour rate doesn't exist, assume the pool was initialized less
     // than 24 hours before and try to get the all-time rate until toBlock
     const { blockNumber: initializationBlock } =
@@ -695,7 +695,7 @@ export class ReadHyperdrive extends ReadModel {
         endPrice: currentLpSharePrice,
         timeFrame,
       }),
-    ).toNumber();
+    ).bigint;
 
     return { lpApy };
   }


### PR DESCRIPTION
Making this more consistent with our our other rates, this now returns a bigint from the SDK. The frontend now uses the same pattern for rate hooks. (see todo that was removed)