### PR TITLE
Wire up buttons for Long, Short, and Supply

### DIFF
--- a/apps/hyperdrive-trading/src/ui/markets/PoolDetails/PoolDetails.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PoolDetails/PoolDetails.tsx
@@ -1,7 +1,8 @@
 import { ArrowLeftIcon } from "@heroicons/react/16/solid";
 import { Cog6ToothIcon } from "@heroicons/react/24/outline";
 import { HyperdriveConfig } from "@hyperdrive/appconfig";
-import { Link } from "@tanstack/react-router";
+import { Link, useNavigate, useSearch } from "@tanstack/react-router";
+import classNames from "classnames";
 import { ReactElement } from "react";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import CustomBanner from "src/ui/base/components/CustomBanner";
@@ -9,6 +10,7 @@ import { useMarketState } from "src/ui/hyperdrive/hooks/useMarketState";
 import { OpenLongForm2 } from "src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm2";
 import { AssetStack } from "src/ui/markets/AssetStack";
 import { formatTermLength2 } from "src/ui/markets/formatTermLength";
+import { MARKET_DETAILS_ROUTE } from "src/ui/markets/routes";
 
 export function PoolDetails({
   hyperdrive,
@@ -16,6 +18,11 @@ export function PoolDetails({
   hyperdrive: HyperdriveConfig;
 }): ReactElement {
   const appConfig = useAppConfig();
+  const { position: activePosition } = useSearch({
+    from: MARKET_DETAILS_ROUTE,
+  });
+  // used to set the active position
+  const navigate = useNavigate({ from: MARKET_DETAILS_ROUTE });
   const { marketState } = useMarketState({
     chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
@@ -49,15 +56,60 @@ export function PoolDetails({
               // TODO: Implement the term picker here
             }
           </button>
-          <button className="daisy-btn daisy-btn-md h-8 min-h-8 rounded-full text-md text-white">
+          <Link
+            className={classNames(
+              "daisy-btn daisy-btn-md h-8 min-h-8 rounded-full text-md",
+              {
+                "daisy-btn-ghost font-normal text-inactive-tab":
+                  activePosition !== "longs",
+                "text-white": activePosition === "longs",
+              },
+            )}
+            to={MARKET_DETAILS_ROUTE}
+            params={{
+              chainId: hyperdrive.chainId.toString(),
+              address: hyperdrive.address,
+            }}
+            search={{ position: "longs" }}
+          >
             Long
-          </button>
-          <button className="daisy-btn daisy-btn-ghost daisy-btn-md h-8 min-h-8 rounded-full text-md font-normal text-inactive-tab">
+          </Link>
+          <Link
+            className={classNames(
+              "daisy-btn daisy-btn-md h-8 min-h-8 rounded-full text-md",
+              {
+                "daisy-btn-ghost font-normal text-inactive-tab":
+                  activePosition !== "shorts",
+                "text-white": activePosition === "shorts",
+              },
+            )}
+            to={MARKET_DETAILS_ROUTE}
+            params={{
+              chainId: hyperdrive.chainId.toString(),
+              address: hyperdrive.address,
+            }}
+            search={{ position: "shorts" }}
+          >
             Short
-          </button>
-          <button className="daisy-btn daisy-btn-ghost daisy-btn-md h-8 min-h-8 rounded-full text-md font-normal text-inactive-tab">
+          </Link>
+          <Link
+            className={classNames(
+              "daisy-btn daisy-btn-md h-8 min-h-8 rounded-full text-md",
+              {
+                "daisy-btn-ghost font-normal text-inactive-tab":
+                  activePosition !== "lp",
+                "text-white": activePosition === "lp",
+              },
+            )}
+            to={MARKET_DETAILS_ROUTE}
+            params={{
+              chainId: hyperdrive.chainId.toString(),
+              address: hyperdrive.address,
+            }}
+            search={{ position: "lp" }}
+          >
             Supply
-          </button>
+          </Link>
         </div>
         <button className="daisy-btn daisy-btn-md h-8 min-h-8 rounded-full text-xs font-normal text-neutral-content">
           0.5% slippage <Cog6ToothIcon className="size-4" />

--- a/apps/hyperdrive-trading/src/ui/markets/PoolDetails/PoolDetails.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PoolDetails/PoolDetails.tsx
@@ -1,13 +1,15 @@
 import { ArrowLeftIcon } from "@heroicons/react/16/solid";
 import { Cog6ToothIcon } from "@heroicons/react/24/outline";
 import { HyperdriveConfig } from "@hyperdrive/appconfig";
-import { Link, useNavigate, useSearch } from "@tanstack/react-router";
+import { Link, useSearch } from "@tanstack/react-router";
 import classNames from "classnames";
 import { ReactElement } from "react";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import CustomBanner from "src/ui/base/components/CustomBanner";
 import { useMarketState } from "src/ui/hyperdrive/hooks/useMarketState";
 import { OpenLongForm2 } from "src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm2";
+import { AddLiquidityForm } from "src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm";
+import { OpenShortForm } from "src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm";
 import { AssetStack } from "src/ui/markets/AssetStack";
 import { formatTermLength2 } from "src/ui/markets/formatTermLength";
 import { MARKET_DETAILS_ROUTE } from "src/ui/markets/routes";
@@ -22,7 +24,6 @@ export function PoolDetails({
     from: MARKET_DETAILS_ROUTE,
   });
   // used to set the active position
-  const navigate = useNavigate({ from: MARKET_DETAILS_ROUTE });
   const { marketState } = useMarketState({
     chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
@@ -48,74 +49,96 @@ export function PoolDetails({
       </div>
       <div className="flex justify-between">
         <div className="flex gap-4">
+          {/* TODO: Implement the term picker button */}
           <button className="daisy-btn daisy-btn-sm gap-2 rounded-full text-xs text-white">
             {formatTermLength2(
               Number(hyperdrive.poolConfig.positionDuration * 1000n),
             )}
-            {
-              // TODO: Implement the term picker here
-            }
           </button>
-          <Link
-            className={classNames(
-              "daisy-btn daisy-btn-md h-8 min-h-8 rounded-full text-md",
-              {
-                "daisy-btn-ghost font-normal text-inactive-tab":
-                  activePosition !== "longs",
-                "text-white": activePosition === "longs",
-              },
-            )}
-            to={MARKET_DETAILS_ROUTE}
-            params={{
-              chainId: hyperdrive.chainId.toString(),
-              address: hyperdrive.address,
-            }}
-            search={{ position: "longs" }}
-          >
-            Long
-          </Link>
-          <Link
-            className={classNames(
-              "daisy-btn daisy-btn-md h-8 min-h-8 rounded-full text-md",
-              {
-                "daisy-btn-ghost font-normal text-inactive-tab":
-                  activePosition !== "shorts",
-                "text-white": activePosition === "shorts",
-              },
-            )}
-            to={MARKET_DETAILS_ROUTE}
-            params={{
-              chainId: hyperdrive.chainId.toString(),
-              address: hyperdrive.address,
-            }}
-            search={{ position: "shorts" }}
-          >
-            Short
-          </Link>
-          <Link
-            className={classNames(
-              "daisy-btn daisy-btn-md h-8 min-h-8 rounded-full text-md",
-              {
-                "daisy-btn-ghost font-normal text-inactive-tab":
-                  activePosition !== "lp",
-                "text-white": activePosition === "lp",
-              },
-            )}
-            to={MARKET_DETAILS_ROUTE}
-            params={{
-              chainId: hyperdrive.chainId.toString(),
-              address: hyperdrive.address,
-            }}
-            search={{ position: "lp" }}
-          >
-            Supply
-          </Link>
+          <PositionPicker hyperdrive={hyperdrive} />
         </div>
         <button className="daisy-btn daisy-btn-md h-8 min-h-8 rounded-full text-xs font-normal text-neutral-content">
           0.5% slippage <Cog6ToothIcon className="size-4" />
         </button>
       </div>
-      <OpenLongForm2 hyperdrive={hyperdrive} />
+      {(() => {
+        switch (activePosition) {
+          case "longs":
+            return <OpenLongForm2 hyperdrive={hyperdrive} />;
+          case "shorts":
+            return <OpenShortForm hyperdrive={hyperdrive} />;
+          case "lp":
+            return <AddLiquidityForm hyperdrive={hyperdrive} />;
+        }
+      })()}
+    </div>
+  );
+}
+
+function PositionPicker({
+  hyperdrive,
+}: {
+  hyperdrive: HyperdriveConfig;
+}): ReactElement {
+  const { position: activePosition } = useSearch({
+    from: MARKET_DETAILS_ROUTE,
+  });
+  return (
+    <div className="flex gap-4">
+      <Link
+        className={classNames(
+          "daisy-btn daisy-btn-md h-8 min-h-8 rounded-full text-md",
+          {
+            "daisy-btn-ghost font-normal text-inactive-tab":
+              activePosition !== "longs",
+            "text-white": activePosition === "longs",
+          },
+        )}
+        to={MARKET_DETAILS_ROUTE}
+        params={{
+          chainId: hyperdrive.chainId.toString(),
+          address: hyperdrive.address,
+        }}
+        search={{ position: "longs" }}
+      >
+        Long
+      </Link>
+      <Link
+        className={classNames(
+          "daisy-btn daisy-btn-md h-8 min-h-8 rounded-full text-md",
+          {
+            "daisy-btn-ghost font-normal text-inactive-tab":
+              activePosition !== "shorts",
+            "text-white": activePosition === "shorts",
+          },
+        )}
+        to={MARKET_DETAILS_ROUTE}
+        params={{
+          chainId: hyperdrive.chainId.toString(),
+          address: hyperdrive.address,
+        }}
+        search={{ position: "shorts" }}
+      >
+        Short
+      </Link>
+      <Link
+        className={classNames(
+          "daisy-btn daisy-btn-md h-8 min-h-8 rounded-full text-md",
+          {
+            "daisy-btn-ghost font-normal text-inactive-tab":
+              activePosition !== "lp",
+            "text-white": activePosition === "lp",
+          },
+        )}
+        to={MARKET_DETAILS_ROUTE}
+        params={{
+          chainId: hyperdrive.chainId.toString(),
+          address: hyperdrive.address,
+        }}
+        search={{ position: "lp" }}
+      >
+        Supply
+      </Link>
     </div>
   );
 }


### PR DESCRIPTION
Wire up the Long, Short, and Supply buttons. These buttons update the route.
[182d-Lido-wstETH---Hyperdrive.webm](https://github.com/user-attachments/assets/ad426d89-af31-4724-8d5c-b3c583e13aab)
