### PR TITLE
Remove portfolio row clickability

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktopTwo.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktopTwo.tsx
@@ -224,16 +224,7 @@ export function OpenLongsTableDesktopTwo({
             return (
               <tr
                 key={row.id}
-                className={classNames(
-                  "daisy-hover h-32 cursor-pointer font-dmMono transition duration-300 ease-in-out",
-                  "!border-b-0", // Remove default bottom border for table rows
-                )}
-                onClick={() => {
-                  const modalId = `${row.original.assetId}`;
-                  (
-                    document.getElementById(modalId) as HTMLDialogElement
-                  )?.showModal();
-                }}
+                className={classNames("h-32 !border-b-0 font-dmMono")}
               >
                 {row.getVisibleCells().map((cell, cellIndex) => (
                   <td
@@ -389,7 +380,9 @@ function getColumns({
               className="daisy-btn daisy-btn-ghost rounded-full bg-gray-600 hover:bg-gray-700"
               onClick={() => {
                 const modalId = `${row.original.assetId}`;
-                (window as any)[modalId].showModal();
+                (
+                  document.getElementById(modalId) as HTMLDialogElement
+                ).showModal();
               }}
             >
               <Cog8ToothIcon className="h-5" />

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktopTwo.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktopTwo.tsx
@@ -222,10 +222,7 @@ export function OpenLongsTableDesktopTwo({
             const isLastRow =
               index === tableInstance.getRowModel().rows.length - 1;
             return (
-              <tr
-                key={row.id}
-                className={classNames("h-32 !border-b-0 font-dmMono")}
-              >
+              <tr key={row.id} className="h-32 !border-b-0 font-dmMono">
                 {row.getVisibleCells().map((cell, cellIndex) => (
                   <td
                     className={classNames(

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktopTwo.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktopTwo.tsx
@@ -212,19 +212,7 @@ export function OpenShortsTableDesktopTwo({
             const isLastRow =
               index === tableInstance.getRowModel().rows.length - 1;
             return (
-              <tr
-                key={row.id}
-                className={classNames(
-                  "daisy-hover h-32 cursor-pointer font-dmMono transition duration-300 ease-in-out",
-                  "!border-b-0", // Remove default bottom border for table rows
-                )}
-                onClick={() => {
-                  const modalId = `${row.original.assetId}`;
-                  (
-                    document.getElementById(modalId) as HTMLDialogElement
-                  )?.showModal();
-                }}
-              >
+              <tr key={row.id} className="h-32 !border-b-0 font-dmMono">
                 {row.getVisibleCells().map((cell, cellIndex) => (
                   <td
                     className={classNames(
@@ -347,7 +335,9 @@ function getColumns({
               className="daisy-btn daisy-btn-ghost rounded-full bg-gray-600 hover:bg-gray-700"
               onClick={() => {
                 const modalId = `${row.original.assetId}`;
-                (window as any)[modalId].showModal();
+                (
+                  document.getElementById(modalId) as HTMLDialogElement
+                ).showModal();
               }}
             >
               <Cog8ToothIcon className="h-5" />


### PR DESCRIPTION
This PR removes the clickability for the entire row in the portfolio page. This is in favor of the manage button.