### PR TITLE
Fix math on LP Current Value Cell

### DIFF
--- a/.changeset/clean-phones-trade.md
+++ b/.changeset/clean-phones-trade.md
@@ -1,0 +1,5 @@
+---
+"@delvtech/hyperdrive-js-core": patch
+---
+
+Fix bug in calcOpenLpPosition causing baseAmountPaid to be wrong when withdrawalShares are present.

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/LpAndWithdrawalSharesTable/LpCurrentValueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/LpAndWithdrawalSharesTable/LpCurrentValueCell.tsx
@@ -56,44 +56,8 @@ export function LpCurrentValueCell({
         : 0n
     : 0n;
 
-  // const { withdrawalShares: balanceOfWithdrawalShares } = useWithdrawalShares({
-  //   hyperdriveAddress: hyperdrive.address,
-  //   account,
-  //   chainId: hyperdrive.chainId,
-  // });
-
-  // const {
-  //   baseProceeds: baseProceedsFromPreview,
-  //   withdrawalSharesRedeemed: withdrawalSharesRedeemedFromPreview,
-  // } = usePreviewRedeemWithdrawalShares({
-  //   hyperdriveAddress: hyperdrive.address,
-  //   withdrawalSharesIn: balanceOfWithdrawalShares,
-  //   minOutputPerShare: 1n, // TODO: slippage,
-  //   destination: account,
-  //   chainId: hyperdrive.chainId,
-  // });
-
-  const withdrawalSharesBaseValue = fixed(withdrawalShares || 0n).mul(
-    poolInfo?.lpSharePrice || 0n,
-  ).bigint;
-  // const withdrawalSharesCurrentValue = getWithdrawalSharesCurrentValue({
-  //   decimals: hyperdrive.decimals,
-  //   lpSharePrice: poolInfo?.lpSharePrice,
-  //   withdrawalShares: balanceOfWithdrawalShares,
-  //   baseProceedsFromPreview,
-  //   withdrawalSharesRedeemedFromPreview,
-  // });
-
-  // const baseProceeds = proceeds
-  //   ? hyperdrive.withdrawOptions.isBaseTokenWithdrawalEnabled
-  //     ? proceeds
-  //     : poolInfo
-  //       ? fixed(proceeds).mul(poolInfo.vaultSharePrice).bigint
-  //       : 0n
-  //   : 0n;
-
   const withdrawablePercent =
-    withdrawalShares && baseProceeds && baseValue
+    baseProceeds && baseValue
       ? fixed(
           calculateRatio({
             a: baseProceeds,
@@ -103,13 +67,13 @@ export function LpCurrentValueCell({
         )
       : parseFixed("100");
 
-  // Compute the difference between current value and base amount paid
+  // profitLoss is the difference between baseValue and baseAmountPaid
   const profitLoss =
     previewRemoveLiquidityStatus === "success" ? (
       formatBalance({
         balance:
           baseValue !== undefined
-            ? // Use Math.abs to get the absolute difference between currentValue and baseAmountPaid.
+            ? // Use Math.abs to get the absolute difference between baseValue and baseAmountPaid.
               // This ensures we always have a positive value for display purposes,
               // as the sign (profit/loss) is handled separately in the UI.
               BigInt(Math.abs(Number(baseValue - baseAmountPaid)))
@@ -137,24 +101,27 @@ export function LpCurrentValueCell({
                 places: baseToken?.places,
               })}`
             )}
-
-            <div
-              data-tip={
-                "Profit/Loss since open, after closing fees. Assuming any outstanding withdrawal shares are redeemed at current price."
-              }
-              className={classNames(
-                "daisy-tooltip daisy-tooltip-left flex text-xs before:border before:font-inter",
-                {
-                  "rounded-md border border-success/20 bg-success/20 px-1 text-success":
-                    isPositiveChangeInValue,
-                  "rounded-md border border-error/20 bg-error/20 px-1 text-error":
-                    !isPositiveChangeInValue && profitLoss !== "0",
-                },
-              )}
-            >
-              <span>{isPositiveChangeInValue ? "+" : "-"}</span>
-              {profitLoss === "0" ? "0" : profitLoss}
-            </div>
+            {openLpPositionStatus === "loading" ? (
+              <Skeleton className="w-12" />
+            ) : (
+              <div
+                data-tip={
+                  "Profit/Loss since open, after closing fees. Assuming any outstanding withdrawal shares are redeemed at current price."
+                }
+                className={classNames(
+                  "daisy-tooltip daisy-tooltip-left flex text-xs before:border before:font-inter",
+                  {
+                    "rounded-md border border-success/20 bg-success/20 px-1 text-success":
+                      isPositiveChangeInValue,
+                    "rounded-md border border-error/20 bg-error/20 px-1 text-error":
+                      !isPositiveChangeInValue && profitLoss !== "0",
+                  },
+                )}
+              >
+                <span>{isPositiveChangeInValue ? "+" : "-"}</span>
+                {profitLoss === "0" ? "0" : profitLoss}
+              </div>
+            )}
           </span>
           <span className="text-sm text-gray-500">
             {`${formatRate(withdrawablePercent.div(parseFixed("100")).bigint)} withdrawable`}

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/LpAndWithdrawalSharesTable/LpCurrentValueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/LpAndWithdrawalSharesTable/LpCurrentValueCell.tsx
@@ -7,7 +7,6 @@ import { calculateRatio } from "src/base/calculateRatio";
 import { formatRate } from "src/base/formatRate";
 import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
-import { usePoolInfo } from "src/ui/hyperdrive/hooks/usePoolInfo";
 import { useOpenLpPosition } from "src/ui/hyperdrive/lp/hooks/useOpenLpPosition";
 import { usePreviewRemoveLiquidity } from "src/ui/hyperdrive/lp/hooks/usePreviewRemoveLiquidity";
 import { useAccount } from "wagmi";
@@ -26,10 +25,7 @@ export function LpCurrentValueCell({
     hyperdriveAddress: hyperdrive.address,
     hyperdriveChainId: hyperdrive.chainId,
   });
-  const { poolInfo } = usePoolInfo({
-    hyperdriveAddress: hyperdrive.address,
-    chainId: hyperdrive.chainId,
-  });
+
   const { baseAmountPaid, baseValue, openLpPositionStatus } = useOpenLpPosition(
     {
       hyperdriveAddress: hyperdrive.address,
@@ -82,48 +78,39 @@ export function LpCurrentValueCell({
 
   return (
     <div className="flex flex-col">
-      {poolInfo && lpShares ? (
-        <>
-          <span className="flex items-center justify-end gap-2 text-md">
-            {openLpPositionStatus === "loading" ? (
-              <Skeleton className="w-24" />
-            ) : (
-              `${formatBalance({
-                balance: baseValue,
-                decimals: baseToken?.decimals || 18,
-                places: baseToken?.places,
-              })}`
-            )}
-            {openLpPositionStatus === "loading" ? (
-              <Skeleton className="w-12" />
-            ) : (
-              <div
-                data-tip="Profit/Loss since open, after closing fees. Assuming any outstanding withdrawal shares are redeemed at current price."
-                className={classNames(
-                  "daisy-tooltip daisy-tooltip-left flex text-xs before:border before:font-inter",
-                  {
-                    "rounded-md border border-success/20 bg-success/20 px-1 text-success":
-                      isPositiveChangeInValue,
-                    "rounded-md border border-error/20 bg-error/20 px-1 text-error":
-                      !isPositiveChangeInValue && profitLoss !== "0",
-                  },
-                )}
-              >
-                <span>{isPositiveChangeInValue ? "+" : "-"}</span>
-                {profitLoss === "0" ? "0" : profitLoss}
-              </div>
-            )}
-          </span>
-          <span className="text-sm text-gray-500">
-            {`${formatRate(withdrawablePercent.div(parseFixed("100")).bigint)} withdrawable`}
-          </span>
-        </>
-      ) : (
-        <div className="flex flex-col items-end">
+      <span className="flex items-center justify-end gap-2 text-md">
+        {openLpPositionStatus === "loading" ? (
           <Skeleton className="w-24" />
-          <Skeleton className="mt-1 w-32" />
-        </div>
-      )}
+        ) : (
+          `${formatBalance({
+            balance: baseValue,
+            decimals: hyperdrive.decimals,
+            places: baseToken?.places,
+          })}`
+        )}
+        {openLpPositionStatus === "loading" ? (
+          <Skeleton className="w-12" />
+        ) : (
+          <div
+            data-tip="Profit/Loss since open, after closing fees. Assuming any outstanding withdrawal shares are redeemed at current price."
+            className={classNames(
+              "daisy-tooltip daisy-tooltip-left flex text-xs before:border before:font-inter",
+              {
+                "rounded-md border border-success/20 bg-success/20 px-1 text-success":
+                  isPositiveChangeInValue,
+                "rounded-md border border-error/20 bg-error/20 px-1 text-error":
+                  !isPositiveChangeInValue && profitLoss !== "0",
+              },
+            )}
+          >
+            <span>{isPositiveChangeInValue ? "+" : "-"}</span>
+            {profitLoss === "0" ? "0" : profitLoss}
+          </div>
+        )}
+      </span>
+      <span className="text-sm text-gray-500">
+        {`${formatRate(withdrawablePercent.div(parseFixed("100")).bigint)} withdrawable`}
+      </span>
     </div>
   );
 }

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/LpAndWithdrawalSharesTable/LpCurrentValueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/LpAndWithdrawalSharesTable/LpCurrentValueCell.tsx
@@ -60,13 +60,10 @@ export function LpCurrentValueCell({
   const profitLoss =
     previewRemoveLiquidityStatus === "success" ? (
       formatBalance({
-        balance:
-          baseValue !== undefined
-            ? // Use Math.abs to get the absolute difference between baseValue and baseAmountPaid.
-              // This ensures we always have a positive value for display purposes,
-              // as the sign (profit/loss) is handled separately in the UI.
-              BigInt(Math.abs(Number(baseValue - baseAmountPaid)))
-            : 0n,
+        // Use Math.abs to get the absolute difference between baseValue and baseAmountPaid.
+        // This ensures we always have a positive value for display purposes,
+        // as the sign (profit/loss) is handled separately in the UI.
+        balance: BigInt(Math.abs(Number(baseValue - baseAmountPaid))),
         decimals: hyperdrive?.decimals,
         places: baseToken?.places,
       })


### PR DESCRIPTION
This PR updates ReadHyperdrive to Include the base value of withdrawal shares received when recalculating baseAmountPaid for _calcOpenLpPosition. Also the calc is updated on the frontend to reflect the correct profit/loss for both partially and fully withdrawable lp.