### PR TITLE
Fix error in modal closing behavior

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongForm/CloseLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongForm/CloseLongForm.tsx
@@ -125,7 +125,9 @@ export function CloseLongForm({
     asBase: activeWithdrawToken.address === hyperdrive.poolConfig.baseToken,
     enabled: previewCloseLongStatus === "success",
     onSubmitted: () => {
-      (document.getElementById(`${long.assetId}`) as HTMLDialogElement).close();
+      (
+        document.getElementById(`${long.assetId}`) as HTMLDialogElement
+      )?.close();
     },
     onExecuted: () => {
       setAmount("");

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
@@ -186,7 +186,7 @@ export function OpenLongForm({
     destination: account,
     enabled: openLongPreviewStatus === "success" && hasEnoughAllowance,
     onSubmitted: () => {
-      (document.getElementById("open-long") as HTMLDialogElement).close();
+      (document.getElementById("open-long") as HTMLDialogElement)?.close();
     },
     onExecuted: () => {
       setAmount("");

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm2.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm2.tsx
@@ -183,7 +183,7 @@ export function OpenLongForm2({
     destination: account,
     enabled: openLongPreviewStatus === "success" && hasEnoughAllowance,
     onSubmitted: () => {
-      (document.getElementById("open-long") as HTMLDialogElement).close();
+      (document.getElementById("open-long") as HTMLDialogElement)?.close();
     },
     onExecuted: () => {
       setAmount("");

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongModalButton/OpenLongModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongModalButton/OpenLongModalButton.tsx
@@ -24,7 +24,7 @@ export function OpenLongModalButton({
 
   function closeModal() {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window as any)[modalId].close();
+    (window as any)[modalId]?.close();
   }
 
   if (marketState?.isPaused) {

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
@@ -243,7 +243,7 @@ export function AddLiquidityForm({
       addLiquidityPreviewStatus === "success",
     onSubmitted: () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any)["add-lp"].close();
+      (window as any)["add-lp"]?.close();
     },
     onExecuted: () => {
       setAmount("");

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm2.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm2.tsx
@@ -241,7 +241,7 @@ export function AddLiquidityForm2({
       addLiquidityPreviewStatus === "success",
     onSubmitted: () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any)["add-lp"].close();
+      (window as any)["add-lp"]?.close();
     },
     onExecuted: () => {
       setAmount("");

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/OpenLpSharesCard/OpenLpSharesCard.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/OpenLpSharesCard/OpenLpSharesCard.tsx
@@ -227,7 +227,7 @@ export function OpenLpSharesCard({
                       className="daisy-btn daisy-btn-circle daisy-btn-ghost daisy-btn-sm absolute right-4 top-4"
                       onClick={() =>
                         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                        (window as any)["withdrawalLpModal"].close()
+                        (window as any)["withdrawalLpModal"]?.close()
                       }
                     >
                       <XMarkIcon className="w-6" title="Close" />

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
@@ -157,7 +157,7 @@ export function RemoveLiquidityForm({
       activeWithdrawToken.address === baseToken.address,
     onSubmitted: () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any)["withdrawalLpModal"].close();
+      (window as any)["withdrawalLpModal"]?.close();
     },
     onExecuted: () => {
       setAmount("");

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortForm/CloseShortForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortForm/CloseShortForm.tsx
@@ -110,7 +110,7 @@ export function CloseShortForm({
       hyperdrive.withdrawOptions.isBaseTokenWithdrawalEnabled &&
       activeWithdrawToken.address === hyperdrive.poolConfig.baseToken,
     onSubmitted: (hash) => {
-      (window as any)[`${short.assetId}`].close();
+      (window as any)[`${short.assetId}`]?.close();
     },
     onExecuted: (hash) => {
       setAmount("");

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortModalButton/CloseShortModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortModalButton/CloseShortModalButton.tsx
@@ -44,7 +44,7 @@ export function CloseShortModalButton({
   const maturityMilliseconds = Number(short.maturity * 1000n);
   const isMature = Date.now() > maturityMilliseconds;
   function closeModal() {
-    (window as any)[modalId].close();
+    (window as any)[modalId]?.close();
   }
 
   return (

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
@@ -244,7 +244,7 @@ export function OpenShortForm({
     // traderDeposit as msg.value
     ethValue: isActiveTokenEth ? traderDeposit : undefined,
     onSubmitted: () => {
-      (window as any)["open-short"].close();
+      (window as any)["open-short"]?.close();
     },
     onExecuted: () => {
       setShortAmount("");

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm2.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm2.tsx
@@ -241,7 +241,7 @@ export function OpenShortForm2({
     // traderDeposit as msg.value
     ethValue: isActiveTokenEth ? traderDeposit : undefined,
     onSubmitted: () => {
-      (window as any)["open-short"].close();
+      (window as any)["open-short"]?.close();
     },
     onExecuted: () => {
       setShortAmount("");

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm2.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm2.tsx
@@ -398,7 +398,7 @@ export function OpenShortForm2({
         <div className="flex justify-between px-4 py-8">
           <PrimaryStat
             label="Exposure Multiplier"
-            tooltipContent="Reflects the leverage effect of your short position."
+            tooltipContent={`This represents how much exposure you get to ${appConfig.yieldSources[hyperdrive.yieldSource].shortName} compared to what you pay to open the short.`}
             value={exposureMultiplier}
             valueClassName="bg-gradient-to-r from-accent to-primary bg-clip-text text-transparent flex items-end font-bold text-h5"
             valueUnit="x"
@@ -417,6 +417,7 @@ export function OpenShortForm2({
           <div className="daisy-divider daisy-divider-horizontal" />
           <PrimaryStat
             label="Rate you pay"
+            tooltipContent={`The market fixed rate you pay which determines the cost of this short.`}
             value={formatRate(fixedRatePaid || 0n)}
             valueClassName="flex items-end font-bold text-h5"
             valueUnit="APR"

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortModalButton/OpenShortModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortModalButton/OpenShortModalButton.tsx
@@ -26,7 +26,7 @@ export function OpenShortModalButton({
   const termLengthMS = Number(hyperdrive.poolConfig.positionDuration * 1000n);
   const numDays = convertMillisecondsToDays(termLengthMS);
   function closeModal() {
-    (window as any)[modalId].close();
+    (window as any)[modalId]?.close();
   }
 
   if (marketState?.isPaused) {

--- a/apps/hyperdrive-trading/src/ui/token/RevokeAllowanceModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/token/RevokeAllowanceModalButton.tsx
@@ -68,7 +68,7 @@ export function RevokeAllowanceModalButton({
   });
   const modalId = `revoke_token`;
   function closeModal() {
-    (window as any)[modalId].close();
+    (window as any)[modalId]?.close();
   }
   return (
     <Modal


### PR DESCRIPTION
User was seeing the following error when going to the pool details page. This comes from trying to call `close()` on the modal dom node, which may not exist yet.

![image](https://github.com/user-attachments/assets/970ff256-ad8b-4ffb-af00-f1a0ef05fb52)
