### PR TITLE
Show the correct number of days when pool is younger than rate period

### DIFF
--- a/apps/hyperdrive-trading/src/hyperdrive/getYieldSourceRate.ts
+++ b/apps/hyperdrive-trading/src/hyperdrive/getYieldSourceRate.ts
@@ -1,40 +1,86 @@
 import { Block, ReadHyperdrive } from "@delvtech/hyperdrive-viem";
-import { AppConfig, findHyperdriveConfig } from "@hyperdrive/appconfig";
+import {
+  AppConfig,
+  findHyperdriveConfig,
+  HyperdriveConfig,
+} from "@hyperdrive/appconfig";
+import { convertMillisecondsToDays } from "src/base/convertMillisecondsToDays";
 import { isForkChain } from "src/chains/isForkChain";
 
 export async function getYieldSourceRate(
   readHyperdrive: ReadHyperdrive,
   appConfig: AppConfig,
-): Promise<bigint> {
+): Promise<{ rate: bigint; ratePeriodDays: number }> {
   const hyperdriveChainId = await readHyperdrive.network.getChainId();
   const hyperdrive = findHyperdriveConfig({
     hyperdriveChainId,
     hyperdriveAddress: readHyperdrive.address,
     hyperdrives: appConfig.hyperdrives,
   });
+
+  const numBlocksForHistoricalRate = getNumBlocksForHistoricalRate({
+    appConfig,
+    hyperdrive,
+  });
+
+  const currentBlock = (await readHyperdrive.network.getBlock()) as Block;
+  const initializationBlock = hyperdrive.initializationBlock;
+
+  const isPoolYoungerThanOneRatePeriod =
+    initializationBlock >
+    currentBlock.blockNumber! - numBlocksForHistoricalRate;
+
+  // If we don't have enough blocks to go back 1 full historical period, then
+  // grab the all-time rate instead.
+  if (isPoolYoungerThanOneRatePeriod) {
+    const blocksSinceInitialization =
+      currentBlock.blockNumber! - initializationBlock;
+
+    const daysSinceInitialization = convertMillisecondsToDays(
+      Date.now() - Number(hyperdrive.initializationTimestamp * 1000n),
+    );
+
+    return {
+      rate: await readHyperdrive.getYieldSourceRate({
+        blockRange: blocksSinceInitialization,
+      }),
+      ratePeriodDays: daysSinceInitialization,
+    };
+  }
+
+  const rate = await readHyperdrive.getYieldSourceRate({
+    blockRange: numBlocksForHistoricalRate,
+  });
+
+  return {
+    rate,
+    ratePeriodDays:
+      appConfig.yieldSources[hyperdrive.yieldSource].historicalRatePeriod,
+  };
+}
+
+function getNumBlocksForHistoricalRate({
+  appConfig,
+  hyperdrive,
+}: {
+  appConfig: AppConfig;
+  hyperdrive: HyperdriveConfig;
+}) {
+  const blocksPerDay = appConfig.chains[hyperdrive.chainId].dailyAverageBlocks;
+  const historicalRatePeriod =
+    appConfig.yieldSources[hyperdrive.yieldSource].historicalRatePeriod;
+
   const numBlocksForHistoricalRate = isForkChain(hyperdrive.chainId)
     ? 1000n // roughly 3 hours for cloudchain
-    : appConfig.chains[hyperdrive.chainId].dailyAverageBlocks *
-      BigInt(
-        appConfig.yieldSources[hyperdrive.yieldSource].historicalRatePeriod,
-      );
+    : blocksPerDay * BigInt(historicalRatePeriod);
 
-  return (
-    readHyperdrive
-      .getYieldSourceRate({
-        blockRange: numBlocksForHistoricalRate,
-      })
-      // If the 24 hour rate doesn't exist, assume the pool was initialized less
-      // than 24 hours ago and try to get the all-time rate
-      .catch(async () => {
-        const currentBlock = (await readHyperdrive.network.getBlock()) as Block;
-        const initializationBlock = hyperdrive.initializationBlock;
-        const blocksSinceInitialization =
-          currentBlock.blockNumber! - initializationBlock;
+  return numBlocksForHistoricalRate;
+}
 
-        return readHyperdrive.getYieldSourceRate({
-          blockRange: blocksSinceInitialization,
-        });
-      })
-  );
+function getDaysSinceInitialization({
+  hyperdrive,
+}: {
+  hyperdrive: HyperdriveConfig;
+}): number {
+  return Number(hyperdrive.initializationTimestamp * 1000n) - Date.now();
 }

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/VariableRateStat.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/VariableRateStat.tsx
@@ -33,7 +33,7 @@ export function VariableRateStat({
 
   return (
     <Stat
-      label={`Variable APY (${yieldSource.historicalRatePeriod}d)`}
+      label={`Variable APY (${vaultRate?.ratePeriodDays}d)`}
       description={`The yield rate earned on deposits into ${yieldSource.shortName} in the last ${yieldSource.historicalRatePeriod} days.`}
       tooltipPosition="bottom"
       value={

--- a/apps/hyperdrive-trading/src/ui/markets/MarketStats/YieldStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/MarketStats/YieldStats.tsx
@@ -50,7 +50,7 @@ export function YieldStats({
           </Animated>
           <Animated isActive={position === "lp"}>
             <Stat
-              label={`LP APY (${yieldSource.historicalRatePeriod}d)`}
+              label={lpApy ? `LP APY (${lpApy.ratePeriodDays}d)` : "LP APY"}
               value={
                 <RewardsTooltip
                   chainId={hyperdrive.chainId}

--- a/apps/hyperdrive-trading/src/ui/markets/PoolRow/PoolRow.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PoolRow/PoolRow.tsx
@@ -247,7 +247,7 @@ export function PoolRow({
             }
           />
           <PoolStat
-            label={`LP APY (${yieldSources[hyperdrive.yieldSource].historicalRatePeriod}d)`}
+            label={lpApy ? `LP APY (${lpApy.ratePeriodDays}d)` : "LP APY"}
             isLoading={lpApyStatus === "loading"}
             isNew={isLpApyNew}
             value={

--- a/apps/hyperdrive-trading/src/ui/vaults/useYieldSourceRate.ts
+++ b/apps/hyperdrive-trading/src/ui/vaults/useYieldSourceRate.ts
@@ -13,7 +13,9 @@ export function useYieldSourceRate({
   chainId: number;
   hyperdriveAddress: Address | undefined;
 }): {
-  vaultRate: { vaultRate: bigint; formatted: string } | undefined;
+  vaultRate:
+    | { vaultRate: bigint; formatted: string; ratePeriodDays: number }
+    | undefined;
   vaultRateStatus: "error" | "success" | "loading";
 } {
   const readHyperdrive = useReadHyperdrive({
@@ -22,7 +24,7 @@ export function useYieldSourceRate({
   });
   const appConfig = useAppConfig();
   const queryEnabled = !!hyperdriveAddress && !!readHyperdrive;
-  const { data: vaultRate, status: vaultRateStatus } = useQuery({
+  const { data, status: vaultRateStatus } = useQuery({
     enabled: queryEnabled,
     queryKey: makeQueryKey("vaultRate", {
       chainId,
@@ -30,14 +32,18 @@ export function useYieldSourceRate({
     }),
     queryFn: queryEnabled
       ? async () => {
-          const rate = await getYieldSourceRate(readHyperdrive, appConfig);
+          const { rate, ratePeriodDays } = await getYieldSourceRate(
+            readHyperdrive,
+            appConfig,
+          );
           return {
             vaultRate: rate,
             formatted: formatRate(rate),
+            ratePeriodDays,
           };
         }
       : undefined,
   });
 
-  return { vaultRate, vaultRateStatus };
+  return { vaultRate: data, vaultRateStatus };
 }


### PR DESCRIPTION
The number of days we display for LP APY is now based on either the full rate period (if we have enough history) or the maximum days we have.

Below you can see that the `Ether.fi Staked Eth` pool is now reflecting a more accurate `20d` period, than the pre-set `30d`.

New vs Old
<img width="2553" alt="image" src="https://github.com/user-attachments/assets/0344b2a5-8331-440a-a8f6-35c7c853db70">
