### PR TITLE
Fix app crash when connected to unknown chain

### DIFF
--- a/apps/hyperdrive-trading/src/ui/appconfig/useAppConfigForConnectedChain.ts
+++ b/apps/hyperdrive-trading/src/ui/appconfig/useAppConfigForConnectedChain.ts
@@ -6,7 +6,7 @@ import {
 } from "@hyperdrive/appconfig";
 import { useChainId } from "wagmi";
 
-export function useAppConfig(): AppConfig {
+export function useAppConfigForConnectedChain(): AppConfig {
   const connectedChainId = useChainId();
 
   return isMainnetChain(connectedChainId) ? mainnetAppConfig : testnetAppConfig;

--- a/apps/hyperdrive-trading/src/ui/base/components/ConnectWallet.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/ConnectWallet.tsx
@@ -1,4 +1,12 @@
 import { ConnectButton } from "@rainbow-me/rainbowkit";
-export function ConnectWalletButton(): JSX.Element {
+export function ConnectWalletButton({ wide }: { wide?: boolean }): JSX.Element {
+  if (wide) {
+    return (
+      <div className="flex w-full [&>div>button]:w-full [&>div>button]:!text-center [&>div]:w-full">
+        <ConnectButton showBalance={false} />
+      </div>
+    );
+  }
+
   return <ConnectButton showBalance={false} />;
 }

--- a/apps/hyperdrive-trading/src/ui/base/components/LabelValue.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/LabelValue.tsx
@@ -24,7 +24,7 @@ export function LabelValue({
 }): JSX.Element {
   return (
     <div
-      className={classNames("flex w-full justify-between pb-2 ", {
+      className={classNames("flex w-full justify-between pb-2", {
         "text-md": size === "medium",
         "text-sm": size === "small",
       })}

--- a/apps/hyperdrive-trading/src/ui/base/components/MultiStat.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/MultiStat.tsx
@@ -60,7 +60,7 @@ export function MultiStat({
                 )}
               >
                 {activeItem.label}
-                <InformationCircleIcon className="group-hover:text-gray-500 ml-1 hidden w-4 text-neutral-content opacity-0 transition duration-150 ease-in-out group-hover:opacity-100 lg:inline-block" />
+                <InformationCircleIcon className="ml-1 hidden w-4 text-neutral-content opacity-0 transition duration-150 ease-in-out group-hover:text-gray-500 group-hover:opacity-100 lg:inline-block" />
               </p>
             ) : (
               <p className="self-start text-sm text-neutral-content">

--- a/apps/hyperdrive-trading/src/ui/base/components/Toaster/TransactionToast.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/Toaster/TransactionToast.tsx
@@ -1,6 +1,5 @@
 import { ArrowRightIcon } from "@heroicons/react/24/outline";
-import { makeTransactionUrl } from "@hyperdrive/appconfig";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
+import { appConfig, makeTransactionUrl } from "@hyperdrive/appconfig";
 import { Hash } from "viem";
 
 export default function TransactionToast({
@@ -12,7 +11,6 @@ export default function TransactionToast({
   message: string;
   txHash: Hash;
 }): JSX.Element {
-  const appConfig = useAppConfig();
   const link = makeTransactionUrl(txHash, appConfig.chains[chainId]);
 
   return (

--- a/apps/hyperdrive-trading/src/ui/base/components/UnexpectedErrorMessage.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/UnexpectedErrorMessage.tsx
@@ -11,8 +11,8 @@ export function UnexpectedErrorMessage({
     <div className={classNames("flex flex-col items-center gap-10", className)}>
       <ErrFace className="fill-neutral-content" />
       <div className="flex max-w-lg flex-col items-center gap-4">
-        <h1 className="text-white text-h2 font-bold">Unexpected Error</h1>
-        <p className="text-center text-lg leading-normal text-neutral-content">
+        <h1 className="text-h2 font-bold text-white">Unexpected Error</h1>
+        <p className="leading-normal text-center text-lg text-neutral-content">
           We&rsquo;re sorry, but an error occurred while loading the app.
           Refresh the page or try again later.
         </p>

--- a/apps/hyperdrive-trading/src/ui/chainlog/AddressCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/chainlog/AddressCell.tsx
@@ -1,6 +1,5 @@
-import { makeAddressUrl } from "@hyperdrive/appconfig";
+import { appConfig, makeAddressUrl } from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { formatAddress } from "src/ui/base/formatting/formatAddress";
 import { Address } from "viem";
 
@@ -11,7 +10,6 @@ export function AddressCell({
   address: Address;
   chainId: number;
 }): ReactElement {
-  const appConfig = useAppConfig();
   return (
     <a
       href={makeAddressUrl(address, appConfig.chains[chainId])}

--- a/apps/hyperdrive-trading/src/ui/chainlog/ChainCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/chainlog/ChainCell.tsx
@@ -1,8 +1,7 @@
+import { appConfig } from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 
 export function ChainCell({ chainId }: { chainId: number }): ReactElement {
-  const appConfig = useAppConfig();
   const { iconUrl, name } = appConfig.chains[chainId] || {};
   return (
     <a

--- a/apps/hyperdrive-trading/src/ui/chainlog/Chainlog.tsx
+++ b/apps/hyperdrive-trading/src/ui/chainlog/Chainlog.tsx
@@ -1,8 +1,7 @@
 import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/outline";
-import { makeAddressUrl } from "@hyperdrive/appconfig";
+import { appConfig, makeAddressUrl } from "@hyperdrive/appconfig";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { ReactElement } from "react";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { Tabs } from "src/ui/base/components/Tabs/Tabs";
 import { PoolsTable } from "src/ui/chainlog/PoolsTable";
 import { useChainId } from "wagmi";
@@ -11,7 +10,7 @@ import { FactoriesTable } from "./FactoriesTable";
 export function Chainlog(): ReactElement {
   const navigate = useNavigate();
   const chainId = useChainId();
-  const appConfig = useAppConfig();
+
   const registryAddress = appConfig.registries[chainId];
   const { tab = "pools", version } = useSearch({ from: "/chainlog" });
 

--- a/apps/hyperdrive-trading/src/ui/chainlog/FactoriesTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/chainlog/FactoriesTable.tsx
@@ -1,5 +1,6 @@
 import { ReadRegistry } from "@delvtech/hyperdrive-viem";
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/outline";
+import { appConfig } from "@hyperdrive/appconfig";
 import { UseQueryResult, useQuery } from "@tanstack/react-query";
 import {
   createColumnHelper,
@@ -15,7 +16,6 @@ import { makeQueryKey } from "src/base/makeQueryKey";
 import { wagmiConfig } from "src/network/wagmiClient";
 import { Status, decodeFactoryData } from "src/registry/data";
 import { sdkCache } from "src/sdk/sdkCache";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { NonIdealState } from "src/ui/base/components/NonIdealState";
 import { TableSkeleton } from "src/ui/base/components/TableSkeleton";
 import { AddressCell } from "src/ui/chainlog/AddressCell";
@@ -164,7 +164,6 @@ interface Factory {
 }
 
 function useFactoriesQuery(): UseQueryResult<Factory[], any> {
-  const appConfig = useAppConfig();
   const chainIds = Object.keys(appConfig.registries).map(Number);
 
   return useQuery({

--- a/apps/hyperdrive-trading/src/ui/chainlog/PoolsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/chainlog/PoolsTable.tsx
@@ -1,5 +1,6 @@
 import { ReadRegistry } from "@delvtech/hyperdrive-viem";
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/outline";
+import { appConfig } from "@hyperdrive/appconfig";
 import { UseQueryResult, useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import {
@@ -17,7 +18,6 @@ import { getReadHyperdrive } from "src/hyperdrive/getReadHyperdrive";
 import { wagmiConfig } from "src/network/wagmiClient";
 import { Status, decodeInstanceData } from "src/registry/data";
 import { sdkCache } from "src/sdk/sdkCache";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { NonIdealState } from "src/ui/base/components/NonIdealState";
 import { TableSkeleton } from "src/ui/base/components/TableSkeleton";
 import { AddressCell } from "src/ui/chainlog/AddressCell";
@@ -211,7 +211,6 @@ interface Pool {
 }
 
 function usePoolsQuery(): UseQueryResult<Pool[], any> {
-  const appConfig = useAppConfig();
   const chainIds = Object.keys(appConfig.registries).map(Number);
 
   return useQuery({

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/TransactionTable/TransactionsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/TransactionTable/TransactionsTable.tsx
@@ -3,6 +3,7 @@ import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/outline";
 import {
   AppConfig,
   HyperdriveConfig,
+  appConfig,
   findBaseToken,
   makeAddressUrl,
   makeTransactionUrl,
@@ -23,7 +24,6 @@ import * as dnum from "dnum";
 import { useState } from "react";
 import Skeleton from "react-loading-skeleton";
 import { formatTimeDifference } from "src/base/formatTimeDifference";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { NonIdealState } from "src/ui/base/components/NonIdealState";
 import { Pagination } from "src/ui/base/components/Pagination";
 import { TableSkeleton } from "src/ui/base/components/TableSkeleton";
@@ -69,7 +69,7 @@ export function TransactionTable({
     chainId: hyperdrive.chainId,
     account,
   });
-  const appConfig = useAppConfig();
+
   const isSmallScreenView = useIsTailwindSmallScreen();
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const tableInstance = useReactTable({
@@ -507,7 +507,6 @@ function EventNameCell({
   chainId: number;
   txHash: Hash | undefined;
 }) {
-  const appConfig = useAppConfig();
   return (
     <a
       href={makeTransactionUrl(txHash || "", appConfig.chains[chainId])}
@@ -527,7 +526,6 @@ function AccountCell({
   account: Address;
   chainId: number;
 }) {
-  const appConfig = useAppConfig();
   return (
     <a
       href={makeAddressUrl(account, appConfig.chains[chainId])}

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/TransactionTable/useTransactionData.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/TransactionTable/useTransactionData.ts
@@ -1,9 +1,8 @@
-import { findHyperdriveConfig } from "@hyperdrive/appconfig";
+import { appConfig, findHyperdriveConfig } from "@hyperdrive/appconfig";
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { convertSharesToBase } from "src/hyperdrive/convertSharesToBase";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address, Hash } from "viem";
 export interface TransactionData {
@@ -34,7 +33,7 @@ export function useTransactionData({
     chainId,
     address: hyperdriveAddress,
   });
-  const appConfig = useAppConfig();
+
   const { decimals } = findHyperdriveConfig({
     hyperdriveAddress,
     hyperdriveChainId: chainId,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useDevLogging.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useDevLogging.ts
@@ -1,11 +1,9 @@
 import { HyperdriveConfig } from "@hyperdrive/appconfig";
 import { useEffect } from "react";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { usePoolInfo } from "src/ui/hyperdrive/hooks/usePoolInfo";
 import { formatUnits } from "viem";
 
 export function useDevLogging(hyperdrive: HyperdriveConfig): void {
-  const appConfig = useAppConfig();
   useEffect(() => {
     if (import.meta.env.DEV) {
       console.log("Pool Config:");

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useIsNewPool.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useIsNewPool.ts
@@ -1,5 +1,4 @@
-import { HyperdriveConfig } from "@hyperdrive/appconfig";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
+import { HyperdriveConfig, appConfig } from "@hyperdrive/appconfig";
 import { useBlockNumber } from "wagmi";
 
 /**
@@ -10,8 +9,6 @@ export function useIsNewPool({
 }: {
   hyperdrive: HyperdriveConfig;
 }): boolean {
-  const appConfig = useAppConfig();
-
   const { data: currentBlockNumber } = useBlockNumber({
     chainId: hyperdrive.chainId,
   });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useLpApy.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useLpApy.ts
@@ -1,11 +1,10 @@
 import { Block } from "@delvtech/hyperdrive-viem";
-import { findHyperdriveConfig } from "@hyperdrive/appconfig";
+import { appConfig, findHyperdriveConfig } from "@hyperdrive/appconfig";
 import { useQuery } from "@tanstack/react-query";
 import { convertMillisecondsToDays } from "src/base/convertMillisecondsToDays";
 import { formatRate } from "src/base/formatRate";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { isForkChain } from "src/chains/isForkChain";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { usePoolInfo } from "src/ui/hyperdrive/hooks/usePoolInfo";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
@@ -27,7 +26,7 @@ export function useLpApy({
     hyperdriveAddress,
     chainId,
   });
-  const appConfig = useAppConfig();
+
   const hyperdrive = findHyperdriveConfig({
     hyperdriveChainId: chainId,
     hyperdriveAddress,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/usePrepareSharesIn.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/usePrepareSharesIn.ts
@@ -1,9 +1,12 @@
 import { ReadHyperdrive } from "@delvtech/hyperdrive-viem";
-import { AppConfig, findHyperdriveConfig } from "@hyperdrive/appconfig";
+import {
+  AppConfig,
+  appConfig,
+  findHyperdriveConfig,
+} from "@hyperdrive/appconfig";
 import { useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { QueryStatusWithIdle, getStatus } from "src/base/queryStatus";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
 
@@ -21,7 +24,6 @@ export function usePrepareSharesIn({
   amount: bigint | undefined;
   status: QueryStatusWithIdle;
 } {
-  const appConfig = useAppConfig();
   const readHyperdrive = useReadHyperdrive({
     chainId,
     address: hyperdriveAddress,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/usePrepareSharesOut.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/usePrepareSharesOut.ts
@@ -1,9 +1,12 @@
 import { ReadHyperdrive } from "@delvtech/hyperdrive-viem";
-import { AppConfig, findHyperdriveConfig } from "@hyperdrive/appconfig";
+import {
+  AppConfig,
+  appConfig,
+  findHyperdriveConfig,
+} from "@hyperdrive/appconfig";
 import { useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { QueryStatusWithIdle, getStatus } from "src/base/queryStatus";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
 
@@ -21,7 +24,6 @@ export function usePrepareSharesOut({
   amount: bigint | undefined;
   status: QueryStatusWithIdle;
 } {
-  const appConfig = useAppConfig();
   const readHyperdrive = useReadHyperdrive({
     chainId,
     address: hyperdriveAddress,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useReadHyperdrive.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useReadHyperdrive.ts
@@ -1,8 +1,8 @@
 import { ReadHyperdrive } from "@delvtech/hyperdrive-viem";
+import { appConfig } from "@hyperdrive/appconfig";
 import { useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { getReadHyperdrive } from "src/hyperdrive/getReadHyperdrive";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { Address } from "viem";
 import { usePublicClient } from "wagmi";
 
@@ -13,8 +13,6 @@ export function useReadHyperdrive({
   chainId: number;
   address: Address | undefined;
 }): ReadHyperdrive | undefined {
-  const appConfig = useAppConfig();
-
   const publicClient = usePublicClient({ chainId });
 
   const enabled = !!address && !!publicClient;

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useReadWriteHyperdrive.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useReadWriteHyperdrive.ts
@@ -1,8 +1,8 @@
 import { ReadWriteHyperdrive } from "@delvtech/hyperdrive-viem";
+import { appConfig } from "@hyperdrive/appconfig";
 import { useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { getReadWriteHyperdrive } from "src/hyperdrive/getReadWriteHyperdrive";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { Address } from "viem";
 import { usePublicClient, useWalletClient } from "wagmi";
 
@@ -15,8 +15,6 @@ export function useReadWriteHyperdrive({
 }): ReadWriteHyperdrive | undefined {
   const publicClient = usePublicClient({ chainId });
   const { data: walletClient } = useWalletClient({ chainId });
-
-  const appConfig = useAppConfig();
 
   const enabled = !!address && !!publicClient && !!walletClient;
 

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useTradingVolume.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useTradingVolume.ts
@@ -1,7 +1,6 @@
-import { findHyperdriveConfig } from "@hyperdrive/appconfig";
+import { appConfig, findHyperdriveConfig } from "@hyperdrive/appconfig";
 import { useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address, BlockTag } from "viem";
 
@@ -15,7 +14,6 @@ export function useTradingVolume(
   shortVolume: bigint | undefined;
   tradingVolumeStatus: "loading" | "error" | "success";
 } {
-  const appConfig = useAppConfig();
   const hyperdrive = findHyperdriveConfig({
     hyperdriveChainId: chainId,
     hyperdriveAddress,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongForm/CloseLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongForm/CloseLongForm.tsx
@@ -1,6 +1,7 @@
 import { fixed } from "@delvtech/fixed-point-wasm";
 import { adjustAmountByPercentage, Long } from "@delvtech/hyperdrive-viem";
 import {
+  appConfig,
   findBaseToken,
   findToken,
   HyperdriveConfig,
@@ -10,7 +11,6 @@ import { ConnectButton } from "@rainbow-me/rainbowkit";
 import classNames from "classnames";
 import { MouseEvent, ReactElement } from "react";
 import { isTestnetChain } from "src/chains/isTestnetChain";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { LoadingButton } from "src/ui/base/components/LoadingButton";
 import { PrimaryStat } from "src/ui/base/components/PrimaryStat";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
@@ -39,7 +39,6 @@ export function CloseLongForm({
   long,
   onCloseLong,
 }: CloseLongFormProps): ReactElement {
-  const appConfig = useAppConfig();
   const { address: account } = useAccount();
 
   const defaultItems: TokenConfig[] = [];

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongModalButton/CloseLongModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongModalButton/CloseLongModalButton.tsx
@@ -2,11 +2,11 @@ import { Long } from "@delvtech/hyperdrive-viem";
 import {
   HyperdriveConfig,
   TokenConfig,
+  appConfig,
   findBaseToken,
   findToken,
 } from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { Modal } from "src/ui/base/components/Modal/Modal";
 import { ModalHeader } from "src/ui/base/components/Modal/ModalHeader";
 import { CloseLongForm } from "src/ui/hyperdrive/longs/CloseLongForm/CloseLongForm";
@@ -21,7 +21,6 @@ export function CloseLongModalButton({
   long,
   hyperdrive,
 }: CloseLongModalButtonProps): ReactElement {
-  const appConfig = useAppConfig();
   const baseToken = findBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
@@ -322,11 +322,7 @@ export function OpenLongForm({
       })()}
       actionButton={(() => {
         if (!account) {
-          return (
-            <div className="flex w-full">
-              <ConnectWalletButton />
-            </div>
-          );
+          return <ConnectWalletButton wide />;
         }
 
         if (connectedChainId !== hyperdrive.chainId) {

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
@@ -1,6 +1,7 @@
 import { fixed } from "@delvtech/fixed-point-wasm";
 import { adjustAmountByPercentage } from "@delvtech/hyperdrive-js-core";
 import {
+  appConfig,
   findBaseToken,
   findToken,
   HyperdriveConfig,
@@ -10,7 +11,6 @@ import { isTestnetChain } from "src/chains/isTestnetChain";
 import { getIsValidTradeSize } from "src/hyperdrive/getIsValidTradeSize";
 import { getHasEnoughAllowance } from "src/token/getHasEnoughAllowance";
 import { getHasEnoughBalance } from "src/token/getHasEnoughBalance";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { ConnectWalletButton } from "src/ui/base/components/ConnectWallet";
 import { LoadingButton } from "src/ui/base/components/LoadingButton";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
@@ -35,7 +35,7 @@ import { SlippageSettingsTwo } from "src/ui/token/SlippageSettingsTwo";
 import { TokenInputTwo } from "src/ui/token/TokenInputTwo";
 import { TokenChoice, TokenPickerTwo } from "src/ui/token/TokenPickerTwo";
 import { formatUnits } from "viem";
-import { useAccount, useChainId, useSwitchChain } from "wagmi";
+import { useAccount, useChainId } from "wagmi";
 
 interface OpenLongFormProps {
   hyperdrive: HyperdriveConfig;
@@ -52,9 +52,7 @@ export function OpenLongForm({
     hyperdriveAddress: hyperdrive.address,
     chainId: hyperdrive.chainId,
   });
-  const { switchChain, status: switchChainStatus } = useSwitchChain();
 
-  const appConfig = useAppConfig();
   const { poolInfo } = usePoolInfo({
     hyperdriveAddress: hyperdrive.address,
     chainId: hyperdrive.chainId,
@@ -324,7 +322,11 @@ export function OpenLongForm({
       })()}
       actionButton={(() => {
         if (!account) {
-          return <ConnectWalletButton />;
+          return (
+            <div className="flex w-full">
+              <ConnectWalletButton />
+            </div>
+          );
         }
 
         if (connectedChainId !== hyperdrive.chainId) {

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongPreview.tsx
@@ -4,6 +4,7 @@ import { ChevronDownIcon } from "@heroicons/react/20/solid";
 import {
   HyperdriveConfig,
   TokenConfig,
+  appConfig,
   findBaseToken,
 } from "@hyperdrive/appconfig";
 import classNames from "classnames";
@@ -12,7 +13,6 @@ import Skeleton from "react-loading-skeleton";
 import { formatRate } from "src/base/formatRate";
 import { QueryStatusWithIdle } from "src/base/queryStatus";
 import { convertSharesToBase } from "src/hyperdrive/convertSharesToBase";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { AccordionSection } from "src/ui/base/components/AccordionSection/AccordionSection";
 import { LabelValue } from "src/ui/base/components/LabelValue";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
@@ -40,7 +40,6 @@ export function OpenLongPreview({
   asBase,
   vaultSharePrice,
 }: OpenLongPreviewProps): ReactElement {
-  const appConfig = useAppConfig();
   const baseToken = findBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongStats.tsx
@@ -1,6 +1,7 @@
 import { fixed } from "@delvtech/fixed-point-wasm";
 import { calculateAprFromPrice } from "@delvtech/hyperdrive-viem";
 import {
+  appConfig,
   findBaseToken,
   HyperdriveConfig,
   TokenConfig,
@@ -12,7 +13,6 @@ import { formatRate } from "src/base/formatRate";
 import { QueryStatusWithIdle } from "src/base/queryStatus";
 import { isTestnetChain } from "src/chains/isTestnetChain";
 import { convertSharesToBase } from "src/hyperdrive/convertSharesToBase";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { PrimaryStat } from "src/ui/base/components/PrimaryStat";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { formatDate } from "src/ui/base/formatting/formatDate";
@@ -36,7 +36,6 @@ export function OpenLongStats({
   asBase,
   vaultSharePrice,
 }: OpenLongStatsProps): JSX.Element {
-  const appConfig = useAppConfig();
   const baseToken = findBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/CurrentValueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/CurrentValueCell.tsx
@@ -1,10 +1,13 @@
 import { OpenLongPositionReceived } from "@delvtech/hyperdrive-viem";
 import { ExclamationTriangleIcon } from "@heroicons/react/20/solid";
-import { HyperdriveConfig, findBaseToken } from "@hyperdrive/appconfig";
+import {
+  HyperdriveConfig,
+  appConfig,
+  findBaseToken,
+} from "@hyperdrive/appconfig";
 import classNames from "classnames";
 import { ReactElement } from "react";
 import Skeleton from "react-loading-skeleton";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { usePreviewCloseLong } from "src/ui/hyperdrive/longs/hooks/usePreviewCloseLong";
 
@@ -15,7 +18,6 @@ export function CurrentValueCellTwo({
   row: OpenLongPositionReceived;
   hyperdrive: HyperdriveConfig;
 }): ReactElement {
-  const appConfig = useAppConfig();
   const baseToken = findBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktopTwo.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktopTwo.tsx
@@ -6,6 +6,7 @@ import { Cog8ToothIcon } from "@heroicons/react/20/solid";
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/outline";
 import {
   AppConfig,
+  appConfig,
   findBaseToken,
   findToken,
   HyperdriveConfig,
@@ -24,7 +25,6 @@ import { ReactElement } from "react";
 import { calculateAnnualizedPercentageChange } from "src/base/calculateAnnualizedPercentageChange";
 import { convertMillisecondsToDays } from "src/base/convertMillisecondsToDays";
 import { formatRate } from "src/base/formatRate";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { ConnectWalletButton } from "src/ui/base/components/ConnectWallet";
 import LoadingState from "src/ui/base/components/LoadingState";
 import { NonIdealState } from "src/ui/base/components/NonIdealState";
@@ -41,7 +41,6 @@ import { useAccount } from "wagmi";
 export function OpenLongsContainer(): ReactElement {
   const { openLongPositions, openLongPositionsStatus } =
     usePortfolioLongsData();
-  const appConfig = useAppConfig();
 
   if (openLongPositionsStatus === "loading") {
     return (
@@ -151,7 +150,6 @@ export function OpenLongsTableDesktopTwo({
   openLongs: OpenLongPositionReceived[] | undefined;
 }): ReactElement {
   const { address: account } = useAccount();
-  const appConfig = useAppConfig();
 
   const tableInstance = useReactTable({
     columns: getColumns({ hyperdrive, appConfig }),

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/TotalOpenLongsValue.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/TotalOpenLongsValue.tsx
@@ -1,8 +1,11 @@
 import { fixed } from "@delvtech/fixed-point-wasm";
-import { findBaseToken, HyperdriveConfig } from "@hyperdrive/appconfig";
+import {
+  appConfig,
+  findBaseToken,
+  HyperdriveConfig,
+} from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
 import { isTestnetChain } from "src/chains/isTestnetChain";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { useOpenLongs } from "src/ui/hyperdrive/longs/hooks/useOpenLongs";
 import { useTotalOpenLongsValueTwo } from "src/ui/hyperdrive/longs/hooks/useTotalOpenLongsValue";
@@ -15,7 +18,7 @@ export function TotalOpenLongsValue({
   hyperdrive: HyperdriveConfig;
 }): ReactElement {
   const { address: account } = useAccount();
-  const appConfig = useAppConfig();
+
   const { openLongs, openLongsStatus } = useOpenLongs({
     account,
     chainId: hyperdrive.chainId,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useCloseLong.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useCloseLong.tsx
@@ -1,3 +1,4 @@
+import { appConfig } from "@hyperdrive/appconfig";
 import { useAddRecentTransaction } from "@rainbow-me/rainbowkit";
 import {
   MutationStatus,
@@ -6,7 +7,6 @@ import {
 } from "@tanstack/react-query";
 import toast from "react-hot-toast";
 import { parseError } from "src/network/parseError";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import TransactionToast from "src/ui/base/components/Toaster/TransactionToast";
 import { SUCCESS_TOAST_DURATION } from "src/ui/base/toasts";
 import { prepareSharesIn } from "src/ui/hyperdrive/hooks/usePrepareSharesIn";
@@ -52,7 +52,6 @@ export function useCloseLong({
   const publicClient = usePublicClient();
   const queryClient = useQueryClient();
   const addTransaction = useAddRecentTransaction();
-  const appConfig = useAppConfig();
 
   const mutationEnabled =
     !!maturityTime &&

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useFixedRate.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useFixedRate.ts
@@ -1,11 +1,10 @@
 import { getHprFromApr } from "@delvtech/hyperdrive-viem";
-import { findHyperdriveConfig } from "@hyperdrive/appconfig";
+import { appConfig, findHyperdriveConfig } from "@hyperdrive/appconfig";
 import { useQuery } from "@tanstack/react-query";
 
 import { formatRate } from "src/base/formatRate";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { QueryStatusWithIdle, getStatus } from "src/base/queryStatus";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
 
@@ -22,7 +21,7 @@ export function useFixedRate({
   fixedRoi: { roi: bigint; formatted: string } | undefined;
   fixedRateStatus: QueryStatusWithIdle;
 } {
-  const { hyperdrives } = useAppConfig();
+  const { hyperdrives } = appConfig;
   const hyperdrive = findHyperdriveConfig({
     hyperdriveChainId: chainId,
     hyperdrives,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useMaxLong.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useMaxLong.ts
@@ -1,7 +1,7 @@
+import { appConfig } from "@hyperdrive/appconfig";
 import { useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { QueryStatusWithIdle, getStatus } from "src/base/queryStatus";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { prepareSharesOut } from "src/ui/hyperdrive/hooks/usePrepareSharesOut";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
@@ -23,7 +23,6 @@ export function useMaxLong({
     address: hyperdriveAddress,
   });
   const queryEnabled = !!readHyperdrive;
-  const appConfig = useAppConfig();
 
   const { data, status, fetchStatus } = useQuery({
     queryKey: makeQueryKey("maxLong", {

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useOpenLong.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useOpenLong.tsx
@@ -1,9 +1,9 @@
+import { appConfig } from "@hyperdrive/appconfig";
 import { useAddRecentTransaction } from "@rainbow-me/rainbowkit";
 import { MutationStatus } from "@tanstack/query-core";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import toast from "react-hot-toast";
 import { parseError } from "src/network/parseError";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import TransactionToast from "src/ui/base/components/Toaster/TransactionToast";
 import { SUCCESS_TOAST_DURATION } from "src/ui/base/toasts";
 import { prepareSharesIn } from "src/ui/hyperdrive/hooks/usePrepareSharesIn";
@@ -46,7 +46,7 @@ export function useOpenLong({
 }: UseOpenLongOptions): UseOpenLongResult {
   const addTransaction = useAddRecentTransaction();
   const publicClient = usePublicClient();
-  const appConfig = useAppConfig();
+
   const queryClient = useQueryClient();
   const readWriteHyperdrive = useReadWriteHyperdrive({
     chainId,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/usePreviewCloseLong.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/usePreviewCloseLong.ts
@@ -1,7 +1,7 @@
+import { appConfig } from "@hyperdrive/appconfig";
 import { useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { QueryStatusWithIdle, getStatus } from "src/base/queryStatus";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { prepareSharesOut } from "src/ui/hyperdrive/hooks/usePrepareSharesOut";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
@@ -33,7 +33,6 @@ export function usePreviewCloseLong({
   asBase = true,
   enabled = true,
 }: UsePreviewCloseLongOptions): UsePreviewCloseLongResult {
-  const appConfig = useAppConfig();
   const readHyperdrive = useReadHyperdrive({
     chainId,
     address: hyperdriveAddress,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/usePreviewOpenLong.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/usePreviewOpenLong.ts
@@ -1,7 +1,7 @@
+import { appConfig } from "@hyperdrive/appconfig";
 import { useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { QueryStatusWithIdle, getStatus } from "src/base/queryStatus";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { prepareSharesIn } from "src/ui/hyperdrive/hooks/usePrepareSharesIn";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
@@ -33,7 +33,6 @@ export function usePreviewOpenLong({
     address: hyperdriveAddress,
   });
 
-  const appConfig = useAppConfig();
   const queryEnabled = amountIn !== undefined && !!readHyperdrive;
   const { data: blockNumber } = useBlockNumber({
     watch: true,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
@@ -3,6 +3,7 @@ import { adjustAmountByPercentage } from "@delvtech/hyperdrive-viem";
 import {
   HyperdriveConfig,
   TokenConfig,
+  appConfig,
   findBaseToken,
   findToken,
 } from "@hyperdrive/appconfig";
@@ -13,7 +14,6 @@ import { calculateRatio } from "src/base/calculateRatio";
 import { isTestnetChain } from "src/chains/isTestnetChain";
 import { getHasEnoughAllowance } from "src/token/getHasEnoughAllowance";
 import { getHasEnoughBalance } from "src/token/getHasEnoughBalance";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { ConnectWalletButton } from "src/ui/base/components/ConnectWallet";
 import { LoadingButton } from "src/ui/base/components/LoadingButton";
 import { PrimaryStat } from "src/ui/base/components/PrimaryStat";
@@ -57,7 +57,7 @@ export function AddLiquidityForm({
     hyperdriveAddress: hyperdrive.address,
     chainId: hyperdrive.chainId,
   });
-  const appConfig = useAppConfig();
+
   const baseToken = findBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
@@ -420,7 +420,7 @@ export function AddLiquidityForm({
       })()}
       actionButton={(() => {
         if (!account) {
-          return <ConnectWalletButton />;
+          return <ConnectWalletButton wide />;
         }
 
         if (!hasEnoughBalance) {

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm2.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm2.tsx
@@ -14,7 +14,6 @@ import { calculateRatio } from "src/base/calculateRatio";
 import { isTestnetChain } from "src/chains/isTestnetChain";
 import { getHasEnoughAllowance } from "src/token/getHasEnoughAllowance";
 import { getHasEnoughBalance } from "src/token/getHasEnoughBalance";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { ConnectWalletButton } from "src/ui/base/components/ConnectWallet";
 import { LoadingButton } from "src/ui/base/components/LoadingButton";
 import { PrimaryStat } from "src/ui/base/components/PrimaryStat";
@@ -63,7 +62,7 @@ export function AddLiquidityForm2({
     hyperdriveAddress: hyperdrive.address,
     chainId: hyperdrive.chainId,
   });
-  const appConfig = useAppConfig();
+
   const baseToken = findBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm2.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm2.tsx
@@ -341,7 +341,7 @@ export function AddLiquidityForm2({
       })()}
       actionButton={(() => {
         if (!account) {
-          return <ConnectWalletButton />;
+          return <ConnectWalletButton wide />;
         }
         if (connectedChainId !== hyperdrive.chainId) {
           return (

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable.tsx
@@ -1,5 +1,6 @@
 import {
   AppConfig,
+  appConfig,
   findBaseToken,
   HyperdriveConfig,
 } from "@hyperdrive/appconfig";
@@ -13,7 +14,6 @@ import {
 import classNames from "classnames";
 import { ReactElement, useMemo } from "react";
 import { convertMillisecondsToDays } from "src/base/convertMillisecondsToDays";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { ConnectWalletButton } from "src/ui/base/components/ConnectWallet";
 import LoadingState from "src/ui/base/components/LoadingState";
 import { NonIdealState } from "src/ui/base/components/NonIdealState";
@@ -27,7 +27,6 @@ import { WithdrawalQueueCell } from "./WithdrawalQueueCell";
 
 export function LpAndWithdrawalSharesContainer(): ReactElement {
   const { openLpPositions, openLpPositionStatus } = usePortfolioLpData();
-  const appConfig = useAppConfig();
 
   if (openLpPositionStatus === "loading") {
     return (
@@ -141,7 +140,6 @@ export function OpenLpTableDesktop({
   openLpPositionStatus?: "loading" | "success" | "error";
 }): ReactElement {
   const { address: account } = useAccount();
-  const appConfig = useAppConfig();
 
   const columns = useMemo(
     () => getColumns({ hyperdrive, appConfig }),

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/LpAndWithdrawalSharesTable/LpCurrentValueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/LpAndWithdrawalSharesTable/LpCurrentValueCell.tsx
@@ -1,11 +1,14 @@
 import { fixed, parseFixed } from "@delvtech/fixed-point-wasm";
-import { findBaseToken, HyperdriveConfig } from "@hyperdrive/appconfig";
+import {
+  appConfig,
+  findBaseToken,
+  HyperdriveConfig,
+} from "@hyperdrive/appconfig";
 import classNames from "classnames";
 import { ReactElement } from "react";
 import Skeleton from "react-loading-skeleton";
 import { calculateRatio } from "src/base/calculateRatio";
 import { formatRate } from "src/base/formatRate";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { useOpenLpPosition } from "src/ui/hyperdrive/lp/hooks/useOpenLpPosition";
 import { usePreviewRemoveLiquidity } from "src/ui/hyperdrive/lp/hooks/usePreviewRemoveLiquidity";
@@ -19,7 +22,7 @@ export function LpCurrentValueCell({
   lpShares: bigint;
 }): ReactElement {
   const { address: account } = useAccount();
-  const appConfig = useAppConfig();
+
   const baseToken = findBaseToken({
     appConfig,
     hyperdriveAddress: hyperdrive.address,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/LpAndWithdrawalSharesTable/ManageLpAndWithdrawalSharesButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/LpAndWithdrawalSharesTable/ManageLpAndWithdrawalSharesButton.tsx
@@ -1,5 +1,6 @@
 import { Cog8ToothIcon } from "@heroicons/react/24/solid";
 import {
+  appConfig,
   findBaseToken,
   findToken,
   HyperdriveConfig,
@@ -7,7 +8,6 @@ import {
 import { ReactElement, useRef, useState } from "react";
 import Skeleton from "react-loading-skeleton";
 import { useClickAway } from "react-use";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { Modal } from "src/ui/base/components/Modal/Modal";
 import { ModalHeader } from "src/ui/base/components/Modal/ModalHeader";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
@@ -29,7 +29,7 @@ export function ManageLpAndWithdrawalSharesButton({
   const dropdownRef = useRef<HTMLDivElement>(null);
   useClickAway(dropdownRef, () => setIsOpen(false));
   const { address: account } = useAccount();
-  const appConfig = useAppConfig();
+
   const baseToken = findBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/LpAndWithdrawalSharesTable/SizeAndPoolShareCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/LpAndWithdrawalSharesTable/SizeAndPoolShareCell.tsx
@@ -1,9 +1,12 @@
 import { fixed } from "@delvtech/fixed-point-wasm";
-import { findBaseToken, HyperdriveConfig } from "@hyperdrive/appconfig";
+import {
+  appConfig,
+  findBaseToken,
+  HyperdriveConfig,
+} from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
 import Skeleton from "react-loading-skeleton";
 import { calculateRatio } from "src/base/calculateRatio";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { useLpSharesTotalSupply } from "src/ui/hyperdrive/lp/hooks/useLpSharesTotalSupply";
 
@@ -19,7 +22,7 @@ export function SizeAndPoolShareCell({
       hyperdriveAddress: hyperdrive.address,
       chainId: hyperdrive.chainId,
     });
-  const appConfig = useAppConfig();
+
   const baseToken = findBaseToken({
     appConfig,
     hyperdriveAddress: hyperdrive.address,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/LpAndWithdrawalSharesTable/WithdrawalQueueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/LpAndWithdrawalSharesTable/WithdrawalQueueCell.tsx
@@ -1,5 +1,8 @@
-import { findBaseToken, HyperdriveConfig } from "@hyperdrive/appconfig";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
+import {
+  appConfig,
+  findBaseToken,
+  HyperdriveConfig,
+} from "@hyperdrive/appconfig";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { usePoolInfo } from "src/ui/hyperdrive/hooks/usePoolInfo";
 import { usePreviewRedeemWithdrawalShares } from "src/ui/hyperdrive/lp/hooks/usePreviewRedeemWithdrawalShares";
@@ -13,7 +16,7 @@ export function WithdrawalQueueCell({
   hyperdrive: HyperdriveConfig;
 }): JSX.Element {
   const { address: account } = useAccount();
-  const appConfig = useAppConfig();
+
   const baseToken = findBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
@@ -1,6 +1,7 @@
 import { fixed } from "@delvtech/fixed-point-wasm";
 import { adjustAmountByPercentage } from "@delvtech/hyperdrive-viem";
 import {
+  appConfig,
   findBaseToken,
   findToken,
   HyperdriveConfig,
@@ -9,7 +10,6 @@ import { ConnectButton } from "@rainbow-me/rainbowkit";
 import { MouseEvent, ReactElement } from "react";
 import { calculateValueFromPrice } from "src/base/calculateValueFromPrice";
 import { getHasEnoughBalance } from "src/token/getHasEnoughBalance";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { LabelValue } from "src/ui/base/components/LabelValue";
 import { LoadingButton } from "src/ui/base/components/LoadingButton";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
@@ -38,7 +38,7 @@ export function RemoveLiquidityForm({
   onRemoveLiquidity,
 }: RemoveLiquidityFormProps): ReactElement {
   const { address: account } = useAccount();
-  const appConfig = useAppConfig();
+
   const baseToken = findBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useAddLiquidity.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useAddLiquidity.tsx
@@ -1,3 +1,4 @@
+import { appConfig } from "@hyperdrive/appconfig";
 import { useAddRecentTransaction } from "@rainbow-me/rainbowkit";
 import {
   MutationStatus,
@@ -6,7 +7,6 @@ import {
 } from "@tanstack/react-query";
 import toast from "react-hot-toast";
 import { parseError } from "src/network/parseError";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import TransactionToast from "src/ui/base/components/Toaster/TransactionToast";
 import { SUCCESS_TOAST_DURATION } from "src/ui/base/toasts";
 import { prepareSharesIn } from "src/ui/hyperdrive/hooks/usePrepareSharesIn";
@@ -54,7 +54,6 @@ export function useAddLiquidity({
     address: hyperdriveAddress,
   });
 
-  const appConfig = useAppConfig();
   const queryClient = useQueryClient();
   const addTransaction = useAddRecentTransaction();
 

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useOpenLpPosition.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useOpenLpPosition.ts
@@ -1,7 +1,6 @@
-import { findHyperdriveConfig } from "@hyperdrive/appconfig";
+import { appConfig, findHyperdriveConfig } from "@hyperdrive/appconfig";
 import { useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
 export function useOpenLpPosition({
@@ -23,7 +22,7 @@ export function useOpenLpPosition({
     chainId,
     address: hyperdriveAddress,
   });
-  const appConfig = useAppConfig();
+
   const queryEnabled = !!hyperdriveAddress && !!readHyperdrive && !!account;
   const { data, status: openLpPositionStatus } = useQuery({
     queryKey: makeQueryKey("openLpPosition", {

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/usePreviewAddLiquidity.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/usePreviewAddLiquidity.ts
@@ -1,7 +1,7 @@
+import { appConfig } from "@hyperdrive/appconfig";
 import { useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { QueryStatusWithIdle } from "src/base/queryStatus";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { prepareSharesIn } from "src/ui/hyperdrive/hooks/usePrepareSharesIn";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
@@ -39,7 +39,7 @@ export function usePreviewAddLiquidity({
   ethValue,
 }: UsePreviewAddLiquidityOptions): UsePreviewAddLiquidityResult {
   const publicClient = usePublicClient();
-  const appConfig = useAppConfig();
+
   const { address: account } = useAccount();
   const readHyperdrive = useReadHyperdrive({
     chainId,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/usePreviewRedeemWithdrawalShares.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/usePreviewRedeemWithdrawalShares.ts
@@ -1,7 +1,6 @@
-import { findHyperdriveConfig } from "@hyperdrive/appconfig";
+import { appConfig, findHyperdriveConfig } from "@hyperdrive/appconfig";
 import { MutationStatus, useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { prepareSharesOut } from "src/ui/hyperdrive/hooks/usePrepareSharesOut";
 import { useReadWriteHyperdrive } from "src/ui/hyperdrive/hooks/useReadWriteHyperdrive";
 import { Address } from "viem";
@@ -35,7 +34,7 @@ export function usePreviewRedeemWithdrawalShares({
     chainId,
     address: hyperdriveAddress,
   });
-  const appConfig = useAppConfig();
+
   const hyperdriveConfig = findHyperdriveConfig({
     hyperdriveChainId: chainId,
     hyperdrives: appConfig.hyperdrives,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/usePreviewRemoveLiquidity.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/usePreviewRemoveLiquidity.ts
@@ -1,6 +1,6 @@
+import { appConfig } from "@hyperdrive/appconfig";
 import { MutationStatus, useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { prepareSharesIn } from "src/ui/hyperdrive/hooks/usePrepareSharesIn";
 import { prepareSharesOut } from "src/ui/hyperdrive/hooks/usePrepareSharesOut";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
@@ -35,7 +35,6 @@ export function usePreviewRemoveLiquidity({
     chainId,
     address: hyperdriveAddress,
   });
-  const appConfig = useAppConfig();
 
   const queryEnabled =
     !!lpSharesIn &&

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useRedeemWithdrawalShares.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useRedeemWithdrawalShares.ts
@@ -1,5 +1,6 @@
 import { useReadWriteHyperdrive } from "src/ui/hyperdrive/hooks/useReadWriteHyperdrive";
 
+import { appConfig } from "@hyperdrive/appconfig";
 import { useAddRecentTransaction } from "@rainbow-me/rainbowkit";
 import {
   MutationStatus,
@@ -8,7 +9,6 @@ import {
 } from "@tanstack/react-query";
 import toast from "react-hot-toast";
 import { parseError } from "src/network/parseError";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { prepareSharesIn } from "src/ui/hyperdrive/hooks/usePrepareSharesIn";
 import { Address } from "viem";
 import { usePublicClient } from "wagmi";
@@ -43,7 +43,7 @@ export function useRedeemWithdrawalShares({
   });
   const publicClient = usePublicClient();
   const queryClient = useQueryClient();
-  const appConfig = useAppConfig();
+
   const addTransaction = useAddRecentTransaction();
   const mutationEnabled =
     !!withdrawalSharesIn &&

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useRemoveLiquidity.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useRemoveLiquidity.tsx
@@ -1,3 +1,4 @@
+import { appConfig } from "@hyperdrive/appconfig";
 import { useAddRecentTransaction } from "@rainbow-me/rainbowkit";
 import {
   MutationStatus,
@@ -6,7 +7,6 @@ import {
 } from "@tanstack/react-query";
 import toast from "react-hot-toast";
 import { parseError } from "src/network/parseError";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import TransactionToast from "src/ui/base/components/Toaster/TransactionToast";
 import { SUCCESS_TOAST_DURATION } from "src/ui/base/toasts";
 import { prepareSharesIn } from "src/ui/hyperdrive/hooks/usePrepareSharesIn";
@@ -46,7 +46,7 @@ export function useRemoveLiquidity({
     chainId,
     address: hyperdriveAddress,
   });
-  const appConfig = useAppConfig();
+
   const queryClient = useQueryClient();
   const addTransaction = useAddRecentTransaction();
   const mutationEnabled =

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortForm/CloseShortForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortForm/CloseShortForm.tsx
@@ -1,12 +1,12 @@
 import { adjustAmountByPercentage, OpenShort } from "@delvtech/hyperdrive-viem";
 import {
+  appConfig,
   findBaseToken,
   findToken,
   HyperdriveConfig,
 } from "@hyperdrive/appconfig";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
 import { MouseEvent, ReactElement } from "react";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { LabelValue } from "src/ui/base/components/LabelValue";
 import { LoadingButton } from "src/ui/base/components/LoadingButton";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
@@ -32,8 +32,6 @@ export function CloseShortForm({
   hyperdrive,
   short,
 }: CloseShortFormProps): ReactElement {
-  const appConfig = useAppConfig();
-
   const { address: account } = useAccount();
   const defaultItems = [];
   const baseToken = findBaseToken({

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortModalButton/CloseShortModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortModalButton/CloseShortModalButton.tsx
@@ -3,12 +3,12 @@ import { CheckIcon, XMarkIcon } from "@heroicons/react/24/solid";
 import {
   HyperdriveConfig,
   TokenConfig,
+  appConfig,
   findBaseToken,
   findToken,
 } from "@hyperdrive/appconfig";
 import classNames from "classnames";
 import { ReactElement } from "react";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { Modal } from "src/ui/base/components/Modal/Modal";
 import { ModalHeader } from "src/ui/base/components/Modal/ModalHeader";
 import { Stat } from "src/ui/base/components/Stat";
@@ -26,7 +26,6 @@ export function CloseShortModalButton({
   short,
   hyperdrive,
 }: CloseShortModalButtonProps): ReactElement {
-  const appConfig = useAppConfig();
   const baseToken = findBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/ClosedShortsTable/ClosedShortsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/ClosedShortsTable/ClosedShortsTable.tsx
@@ -3,6 +3,7 @@ import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/16/solid";
 import {
   AppConfig,
   HyperdriveConfig,
+  appConfig,
   findBaseToken,
 } from "@hyperdrive/appconfig";
 import {
@@ -15,7 +16,6 @@ import {
 } from "@tanstack/react-table";
 import classNames from "classnames";
 import { ReactElement, useMemo } from "react";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { ConnectWalletButton } from "src/ui/base/components/ConnectWallet";
 import LoadingState from "src/ui/base/components/LoadingState";
 import { NonIdealState } from "src/ui/base/components/NonIdealState";
@@ -171,7 +171,7 @@ export function ClosedShortsTable({
   hyperdrive,
 }: ClosedShortsTableProps): ReactElement {
   const { address: account } = useAccount();
-  const appConfig = useAppConfig();
+
   const isTailwindSmallScreen = useIsTailwindSmallScreen();
   const { closedShorts, closedShortsStatus } = useClosedShorts({
     chainId: hyperdrive.chainId,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
@@ -2,6 +2,7 @@ import { fixed } from "@delvtech/fixed-point-wasm";
 import { adjustAmountByPercentage } from "@delvtech/hyperdrive-js-core";
 
 import {
+  appConfig,
   findBaseToken,
   findToken,
   HyperdriveConfig,
@@ -14,7 +15,6 @@ import { isTestnetChain } from "src/chains/isTestnetChain";
 import { getIsValidTradeSize } from "src/hyperdrive/getIsValidTradeSize";
 import { getHasEnoughAllowance } from "src/token/getHasEnoughAllowance";
 import { getHasEnoughBalance } from "src/token/getHasEnoughBalance";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { ConnectWalletButton } from "src/ui/base/components/ConnectWallet";
 import { LoadingButton } from "src/ui/base/components/LoadingButton";
 import { PrimaryStat } from "src/ui/base/components/PrimaryStat";
@@ -61,7 +61,7 @@ export function OpenShortForm({
     hyperdriveAddress: hyperdrive.address,
     chainId: hyperdrive.chainId,
   });
-  const appConfig = useAppConfig();
+
   const { poolInfo } = usePoolInfo({
     chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
@@ -492,7 +492,7 @@ export function OpenShortForm({
       })()}
       actionButton={(() => {
         if (!account) {
-          return <ConnectWalletButton />;
+          return <ConnectWalletButton wide />;
         }
         if (connectedChainId !== hyperdrive.chainId) {
           return (

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
@@ -5,6 +5,7 @@ import { ClockIcon } from "@heroicons/react/24/outline";
 import {
   HyperdriveConfig,
   TokenConfig,
+  appConfig,
   findBaseToken,
 } from "@hyperdrive/appconfig";
 import classNames from "classnames";
@@ -12,7 +13,6 @@ import { ReactElement, useState } from "react";
 import Skeleton from "react-loading-skeleton";
 import { formatRate } from "src/base/formatRate";
 import { QueryStatusWithIdle } from "src/base/queryStatus";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { AccordionSection } from "src/ui/base/components/AccordionSection/AccordionSection";
 import { LabelValue } from "src/ui/base/components/LabelValue";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
@@ -40,7 +40,7 @@ export function OpenShortPreview({
   openShortPreviewStatus,
 }: OpenShortPreviewProps): ReactElement {
   const [detailsOpen, setDetailsOpen] = useState(false);
-  const appConfig = useAppConfig();
+
   const baseToken = findBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/AccruedYieldCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/AccruedYieldCell.tsx
@@ -1,8 +1,11 @@
 import { OpenShort } from "@delvtech/hyperdrive-viem";
-import { HyperdriveConfig, findBaseToken } from "@hyperdrive/appconfig";
+import {
+  HyperdriveConfig,
+  appConfig,
+  findBaseToken,
+} from "@hyperdrive/appconfig";
 import classNames from "classnames";
 import { ReactElement } from "react";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { useIsTailwindSmallScreen } from "src/ui/base/mediaBreakpoints";
 import { useAccruedYield } from "src/ui/hyperdrive/hooks/useAccruedYield";
@@ -16,7 +19,7 @@ export function AccruedYieldCell({
 }): ReactElement {
   const { bondAmount, checkpointTime } = openShort;
   const isTailwindSmallScreen = useIsTailwindSmallScreen();
-  const appConfig = useAppConfig();
+
   const baseToken = findBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/CurrentShortsValueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/CurrentShortsValueCell.tsx
@@ -1,10 +1,13 @@
 import { OpenShort } from "@delvtech/hyperdrive-viem";
 import { ExclamationTriangleIcon } from "@heroicons/react/16/solid";
-import { findBaseToken, HyperdriveConfig } from "@hyperdrive/appconfig";
+import {
+  appConfig,
+  findBaseToken,
+  HyperdriveConfig,
+} from "@hyperdrive/appconfig";
 import classNames from "classnames";
 import { ReactElement } from "react";
 import Skeleton from "react-loading-skeleton";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { useIsTailwindSmallScreen } from "src/ui/base/mediaBreakpoints";
 import { useEstimateShortMarketValue } from "src/ui/hyperdrive/shorts/hooks/useEstimateShortMarketValue";
@@ -18,7 +21,7 @@ export function CurrentShortsValueCell({
   hyperdrive: HyperdriveConfig;
 }): ReactElement {
   const isTailwindSmallScreen = useIsTailwindSmallScreen();
-  const appConfig = useAppConfig();
+
   const baseToken = findBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/CurrentValueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/CurrentValueCell.tsx
@@ -1,10 +1,13 @@
 import { OpenShort } from "@delvtech/hyperdrive-viem";
 import { ExclamationTriangleIcon } from "@heroicons/react/20/solid";
-import { HyperdriveConfig, findBaseToken } from "@hyperdrive/appconfig";
+import {
+  HyperdriveConfig,
+  appConfig,
+  findBaseToken,
+} from "@hyperdrive/appconfig";
 import classNames from "classnames";
 import { ReactElement } from "react";
 import Skeleton from "react-loading-skeleton";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { useIsTailwindSmallScreen } from "src/ui/base/mediaBreakpoints";
 import { useEstimateShortMarketValue } from "src/ui/hyperdrive/shorts/hooks/useEstimateShortMarketValue";
@@ -18,7 +21,7 @@ export function CurrentValueCell({
   hyperdrive: HyperdriveConfig;
 }): ReactElement {
   const isTailwindSmallScreen = useIsTailwindSmallScreen();
-  const appConfig = useAppConfig();
+
   const baseToken = findBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktopTwo.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktopTwo.tsx
@@ -3,6 +3,7 @@ import { Cog8ToothIcon } from "@heroicons/react/20/solid";
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/outline";
 import {
   AppConfig,
+  appConfig,
   findBaseToken,
   findToken,
   HyperdriveConfig,
@@ -18,7 +19,6 @@ import {
 } from "@tanstack/react-table";
 import classNames from "classnames";
 import { ReactElement } from "react";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { ConnectWalletButton } from "src/ui/base/components/ConnectWallet";
 import LoadingState from "src/ui/base/components/LoadingState";
 import { NonIdealState } from "src/ui/base/components/NonIdealState";
@@ -36,7 +36,6 @@ import { useAccount } from "wagmi";
 export function OpenShortsContainer(): ReactElement {
   const { openShortPositions, openShortPositionsStatus } =
     usePortfolioShortsData();
-  const appConfig = useAppConfig();
 
   if (openShortPositionsStatus === "loading") {
     return (
@@ -148,7 +147,6 @@ export function OpenShortsTableDesktopTwo({
   openShorts: OpenShort[] | undefined;
 }): ReactElement {
   const { address: account } = useAccount();
-  const appConfig = useAppConfig();
 
   const tableInstance = useReactTable({
     columns: getColumns({ hyperdrive, appConfig }),

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/ShortRateAndSizeCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/ShortRateAndSizeCell.tsx
@@ -1,9 +1,12 @@
 import { OpenShort } from "@delvtech/hyperdrive-viem";
-import { findBaseToken, HyperdriveConfig } from "@hyperdrive/appconfig";
+import {
+  appConfig,
+  findBaseToken,
+  HyperdriveConfig,
+} from "@hyperdrive/appconfig";
 import classNames from "classnames";
 import { ReactElement } from "react";
 import { formatRate } from "src/base/formatRate";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { useFixedRate } from "src/ui/hyperdrive/longs/hooks/useFixedRate";
 import { useBlock } from "wagmi";
@@ -15,7 +18,6 @@ export function ShortRateAndSizeCell({
   hyperdrive: HyperdriveConfig;
   short: OpenShort;
 }): ReactElement {
-  const appConfig = useAppConfig();
   const baseToken = findBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/TotalOpenShortsValue.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/TotalOpenShortsValue.tsx
@@ -1,7 +1,10 @@
 import { fixed } from "@delvtech/fixed-point-wasm";
-import { findBaseToken, HyperdriveConfig } from "@hyperdrive/appconfig";
+import {
+  appConfig,
+  findBaseToken,
+  HyperdriveConfig,
+} from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { useOpenShorts } from "src/ui/hyperdrive/shorts/hooks/useOpenShorts";
 import { useTotalOpenShortsValue } from "src/ui/hyperdrive/shorts/hooks/useTotalOpenShortsValue";
@@ -16,7 +19,7 @@ export function TotalOpenShortValue({
 }): ReactElement {
   {
     const { address: account } = useAccount();
-    const appConfig = useAppConfig();
+
     const { openShorts, openShortsStatus } = useOpenShorts({
       account,
       chainId: hyperdrive.chainId,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useCloseShort.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useCloseShort.tsx
@@ -1,3 +1,4 @@
+import { appConfig } from "@hyperdrive/appconfig";
 import { useAddRecentTransaction } from "@rainbow-me/rainbowkit";
 import {
   MutationStatus,
@@ -6,7 +7,6 @@ import {
 } from "@tanstack/react-query";
 import toast from "react-hot-toast";
 import { parseError } from "src/network/parseError";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import TransactionToast from "src/ui/base/components/Toaster/TransactionToast";
 import { SUCCESS_TOAST_DURATION } from "src/ui/base/toasts";
 import { prepareSharesIn } from "src/ui/hyperdrive/hooks/usePrepareSharesIn";
@@ -48,7 +48,7 @@ export function useCloseShort({
     chainId,
     address: hyperdriveAddress,
   });
-  const appConfig = useAppConfig();
+
   const queryClient = useQueryClient();
   const addTransaction = useAddRecentTransaction();
   const isMutationEnabled =

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useEstimateShortMarketValue.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useEstimateShortMarketValue.ts
@@ -1,7 +1,7 @@
+import { appConfig } from "@hyperdrive/appconfig";
 import { useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { QueryStatusWithIdle, getStatus } from "src/base/queryStatus";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { prepareSharesOut } from "src/ui/hyperdrive/hooks/usePrepareSharesOut";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
@@ -32,7 +32,7 @@ export function useEstimateShortMarketValue({
     chainId,
     address: hyperdriveAddress,
   });
-  const appConfig = useAppConfig();
+
   const queryEnabled =
     !!readHyperdrive && !!maturityTime && !!shortAmountIn && enabled;
 

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useMaxShort.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useMaxShort.ts
@@ -1,7 +1,7 @@
+import { appConfig } from "@hyperdrive/appconfig";
 import { useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { QueryStatusWithIdle } from "src/base/queryStatus";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { prepareSharesOut } from "src/ui/hyperdrive/hooks/usePrepareSharesOut";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
@@ -26,7 +26,7 @@ export function useMaxShort({
     chainId,
     address: hyperdriveAddress,
   });
-  const appConfig = useAppConfig();
+
   const queryEnabled = !!readHyperdrive && !!budget;
 
   const { data, status } = useQuery({

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useOpenShort.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useOpenShort.tsx
@@ -1,4 +1,5 @@
 import { adjustAmountByPercentage } from "@delvtech/hyperdrive-viem";
+import { appConfig } from "@hyperdrive/appconfig";
 import { useAddRecentTransaction } from "@rainbow-me/rainbowkit";
 import {
   MutationStatus,
@@ -7,7 +8,6 @@ import {
 } from "@tanstack/react-query";
 import toast from "react-hot-toast";
 import { parseError } from "src/network/parseError";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import TransactionToast from "src/ui/base/components/Toaster/TransactionToast";
 import { SUCCESS_TOAST_DURATION } from "src/ui/base/toasts";
 import { prepareSharesIn } from "src/ui/hyperdrive/hooks/usePrepareSharesIn";
@@ -55,7 +55,7 @@ export function useOpenShort({
   });
   const publicClient = usePublicClient();
   const queryClient = useQueryClient();
-  const appConfig = useAppConfig();
+
   const addTransaction = useAddRecentTransaction();
   const mutationEnabled =
     !!amountBondShorts &&

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/usePreviewCloseShort.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/usePreviewCloseShort.ts
@@ -1,7 +1,7 @@
+import { appConfig } from "@hyperdrive/appconfig";
 import { useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { QueryStatusWithIdle, getStatus } from "src/base/queryStatus";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { prepareSharesOut } from "src/ui/hyperdrive/hooks/usePrepareSharesOut";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
@@ -34,7 +34,7 @@ export function usePreviewCloseShort({
     chainId,
     address: hyperdriveAddress,
   });
-  const appConfig = useAppConfig();
+
   const queryEnabled =
     !!readHyperdrive && !!maturityTime && !!shortAmountIn && enabled;
 

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/usePreviewOpenShort.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/usePreviewOpenShort.ts
@@ -1,7 +1,7 @@
+import { appConfig } from "@hyperdrive/appconfig";
 import { MutationStatus, useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { getStatus } from "src/base/queryStatus";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { prepareSharesOut } from "src/ui/hyperdrive/hooks/usePrepareSharesOut";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
@@ -33,7 +33,7 @@ export function usePreviewOpenShort({
     chainId,
     address: hyperdriveAddress,
   });
-  const appConfig = useAppConfig();
+
   const queryEnabled = !!readHyperdrive && !!amountOfBondsToShort;
   const { data: blockNumber } = useBlockNumber({
     watch: true,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useShortRate.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useShortRate.ts
@@ -1,10 +1,9 @@
 import { getHprFromApr } from "@delvtech/hyperdrive-viem";
-import { findHyperdriveConfig } from "@hyperdrive/appconfig";
+import { appConfig, findHyperdriveConfig } from "@hyperdrive/appconfig";
 import { useQuery } from "@tanstack/react-query";
 import { formatRate } from "src/base/formatRate";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { getStatus } from "src/base/queryStatus";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
 
@@ -28,7 +27,7 @@ export function useShortRate({
   shortRoi: { roi: bigint; formatted: string } | undefined;
   shortRateStatus: "loading" | "error" | "success" | "idle";
 } {
-  const { hyperdrives } = useAppConfig();
+  const { hyperdrives } = appConfig;
   const readHyperdrive = useReadHyperdrive({
     chainId,
     address: hyperdriveAddress,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/withdrawalShares/OpenWithdrawalSharesCard/OpenWithdrawalSharesCard.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/withdrawalShares/OpenWithdrawalSharesCard/OpenWithdrawalSharesCard.tsx
@@ -1,7 +1,10 @@
-import { HyperdriveConfig, findBaseToken } from "@hyperdrive/appconfig";
+import {
+  HyperdriveConfig,
+  appConfig,
+  findBaseToken,
+} from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
 import Skeleton from "react-loading-skeleton";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { LabelValue } from "src/ui/base/components/LabelValue";
 import { Modal } from "src/ui/base/components/Modal/Modal";
 import { ModalHeader } from "src/ui/base/components/Modal/ModalHeader";
@@ -22,7 +25,7 @@ export function OpenWithdrawalSharesCard({
   hyperdrive,
 }: LpPortfolioCardProps): ReactElement {
   const { address: account } = useAccount();
-  const appConfig = useAppConfig();
+
   const baseToken = findBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/withdrawalShares/RedeemWithdrawalSharesForm/RedeemWithdrawalSharesForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/withdrawalShares/RedeemWithdrawalSharesForm/RedeemWithdrawalSharesForm.tsx
@@ -1,6 +1,7 @@
 import { fixed } from "@delvtech/fixed-point-wasm";
 import { adjustAmountByPercentage } from "@delvtech/hyperdrive-viem";
 import {
+  appConfig,
   findBaseToken,
   findToken,
   HyperdriveConfig,
@@ -9,7 +10,6 @@ import {
 import { ConnectButton } from "@rainbow-me/rainbowkit";
 import { ReactElement } from "react";
 import { convertSharesToBase } from "src/hyperdrive/convertSharesToBase";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { LabelValue } from "src/ui/base/components/LabelValue";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { useActiveItem } from "src/ui/base/hooks/useActiveItem";
@@ -32,7 +32,6 @@ interface RedeemWithdrawalSharesFormProps {
 export function RedeemWithdrawalSharesForm({
   hyperdrive,
 }: RedeemWithdrawalSharesFormProps): ReactElement {
-  const appConfig = useAppConfig();
   const baseToken = findBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,

--- a/apps/hyperdrive-trading/src/ui/markets/AssetStack.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/AssetStack.tsx
@@ -1,6 +1,5 @@
-import { findBaseToken, findToken } from "@hyperdrive/appconfig";
+import { appConfig, findBaseToken, findToken } from "@hyperdrive/appconfig";
 import { ReactElement } from "react";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { Address } from "viem";
 
 export function AssetStack({
@@ -8,7 +7,6 @@ export function AssetStack({
 }: {
   hyperdriveAddress: Address;
 }): ReactElement {
-  const appConfig = useAppConfig();
   const hyperdrive = appConfig.hyperdrives.find(
     (hyperdrive) => hyperdrive.address === hyperdriveAddress,
   )!;

--- a/apps/hyperdrive-trading/src/ui/markets/Market.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/Market.tsx
@@ -1,15 +1,13 @@
-import { findHyperdriveConfig } from "@hyperdrive/appconfig";
+import { appConfig, findHyperdriveConfig } from "@hyperdrive/appconfig";
 import { useParams } from "@tanstack/react-router";
 import { ReactElement } from "react";
 import { Helmet } from "react-helmet";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { PoolDetails } from "src/ui/markets/PoolDetails/PoolDetails";
 import { MARKET_DETAILS_ROUTE } from "src/ui/markets/routes";
 import { Address } from "viem";
 
 export function Market(): ReactElement {
   const { address, chainId } = useParams({ from: MARKET_DETAILS_ROUTE });
-  const appConfig = useAppConfig();
 
   const hyperdrive = findHyperdriveConfig({
     hyperdriveChainId: Number(chainId),

--- a/apps/hyperdrive-trading/src/ui/markets/PoolRow/PoolRow.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PoolRow/PoolRow.tsx
@@ -2,6 +2,7 @@ import { fixed } from "@delvtech/fixed-point-wasm";
 import { ClockIcon } from "@heroicons/react/16/solid";
 import {
   HyperdriveConfig,
+  appConfig,
   findBaseToken,
   findToken,
 } from "@hyperdrive/appconfig";
@@ -11,7 +12,6 @@ import { ReactElement, ReactNode } from "react";
 import Skeleton from "react-loading-skeleton";
 import { formatRate } from "src/base/formatRate";
 import { isTestnetChain } from "src/chains/isTestnetChain";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { Well } from "src/ui/base/components/Well/Well";
 import { formatCompact } from "src/ui/base/formatting/formatCompact";
 import { useIsNewPool } from "src/ui/hyperdrive/hooks/useIsNewPool";
@@ -31,7 +31,7 @@ export function PoolRow({
   hyperdrive: HyperdriveConfig;
 }): ReactElement {
   const navigate = useNavigate();
-  const appConfig = useAppConfig();
+
   const { yieldSources, chains } = appConfig;
 
   const chainInfo = chains[hyperdrive.chainId];

--- a/apps/hyperdrive-trading/src/ui/markets/PoolRow/PoolsList.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PoolRow/PoolsList.tsx
@@ -4,10 +4,11 @@ import { getPublicClient } from "@wagmi/core";
 import { ReactElement } from "react";
 import { getReadHyperdrive } from "src/hyperdrive/getReadHyperdrive";
 import { wagmiConfig } from "src/network/wagmiClient";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
+import { useAppConfigForConnectedChain } from "src/ui/appconfig/useAppConfigForConnectedChain";
 import LoadingState from "src/ui/base/components/LoadingState";
 import { PoolRow } from "src/ui/markets/PoolRow/PoolRow";
 import { PublicClient } from "viem";
+import { useChainId } from "wagmi";
 
 export function PoolsList(): ReactElement {
   const { hyperdrives, status } = usePoolsListHyperdriveConfigs();
@@ -43,9 +44,16 @@ function usePoolsListHyperdriveConfigs(): {
   hyperdrives: HyperdriveConfig[] | undefined;
   status: QueryStatus;
 } {
-  const appConfigForConnectedChain = useAppConfig();
+  // Only show testnet and fork pools if the user is connected to a testnet
+  // chain
+  const appConfigForConnectedChain = useAppConfigForConnectedChain();
+
+  // Use the chain id in the query key to make sure the pools list updates when
+  // you switch chains
+  const connectedChainId = useChainId();
+
   const { data, status } = useQuery({
-    queryKey: ["poolsListHyperdriveConfigs"],
+    queryKey: ["poolsListHyperdriveConfigs", { connectedChainId }],
     queryFn: async () => {
       // We only show hyperdrives that are not paused
       const marketStates = await Promise.all(

--- a/apps/hyperdrive-trading/src/ui/portfolio/usePortfolioLongsData.ts
+++ b/apps/hyperdrive-trading/src/ui/portfolio/usePortfolioLongsData.ts
@@ -3,7 +3,7 @@ import { HyperdriveConfig } from "@hyperdrive/appconfig";
 import { useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { getReadHyperdrive } from "src/hyperdrive/getReadHyperdrive";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
+import { useAppConfigForConnectedChain } from "src/ui/appconfig/useAppConfigForConnectedChain";
 import { usePublicClients } from "src/ui/hyperdrive/hooks/usePublicClients";
 import { useAccount } from "wagmi";
 
@@ -17,9 +17,13 @@ export function usePortfolioLongsData(): {
   openLongPositionsStatus: "error" | "success" | "loading";
 } {
   const { address: account } = useAccount();
-  const appConfig = useAppConfig();
-  const clients = usePublicClients(Object.keys(appConfig.chains).map(Number));
-  const queryEnabled = !!account && !!appConfig && !!clients;
+
+  const appConfigForConnectedChain = useAppConfigForConnectedChain();
+
+  const clients = usePublicClients(
+    Object.keys(appConfigForConnectedChain.chains).map(Number),
+  );
+  const queryEnabled = !!account && !!appConfigForConnectedChain && !!clients;
 
   const { data: openLongPositions, status: openLongPositionsStatus } = useQuery(
     {
@@ -28,7 +32,7 @@ export function usePortfolioLongsData(): {
       queryFn: queryEnabled
         ? async () =>
             await Promise.all(
-              appConfig.hyperdrives.map(async (hyperdrive) => {
+              appConfigForConnectedChain.hyperdrives.map(async (hyperdrive) => {
                 const publicClient = clients[hyperdrive.chainId]?.publicClient;
 
                 if (!publicClient) {
@@ -42,7 +46,7 @@ export function usePortfolioLongsData(): {
                 }
 
                 const readHyperdrive = await getReadHyperdrive({
-                  appConfig,
+                  appConfig: appConfigForConnectedChain,
                   hyperdriveAddress: hyperdrive.address,
                   publicClient,
                 });

--- a/apps/hyperdrive-trading/src/ui/portfolio/usePortfolioShortsData.ts
+++ b/apps/hyperdrive-trading/src/ui/portfolio/usePortfolioShortsData.ts
@@ -3,7 +3,7 @@ import { HyperdriveConfig } from "@hyperdrive/appconfig";
 import { useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { getReadHyperdrive } from "src/hyperdrive/getReadHyperdrive";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
+import { useAppConfigForConnectedChain } from "src/ui/appconfig/useAppConfigForConnectedChain";
 import { usePublicClients } from "src/ui/hyperdrive/hooks/usePublicClients";
 import { useAccount } from "wagmi";
 
@@ -18,9 +18,12 @@ export function usePortfolioShortsData(): {
 } {
   const { address: account } = useAccount();
 
-  const appConfig = useAppConfig();
-  const clients = usePublicClients(Object.keys(appConfig.chains).map(Number));
-  const queryEnabled = !!account && !!appConfig && !!clients;
+  const appConfigForConnectedChain = useAppConfigForConnectedChain();
+
+  const clients = usePublicClients(
+    Object.keys(appConfigForConnectedChain.chains).map(Number),
+  );
+  const queryEnabled = !!account && !!appConfigForConnectedChain && !!clients;
 
   const { data: openShortPositions, status: openShortPositionsStatus } =
     useQuery({
@@ -29,7 +32,7 @@ export function usePortfolioShortsData(): {
       queryFn: queryEnabled
         ? async () =>
             await Promise.all(
-              appConfig.hyperdrives.map(async (hyperdrive) => {
+              appConfigForConnectedChain.hyperdrives.map(async (hyperdrive) => {
                 const publicClient = clients[hyperdrive.chainId]?.publicClient;
 
                 if (!publicClient) {
@@ -43,7 +46,7 @@ export function usePortfolioShortsData(): {
                 }
 
                 const readHyperdrive = await getReadHyperdrive({
-                  appConfig,
+                  appConfig: appConfigForConnectedChain,
                   hyperdriveAddress: hyperdrive.address,
                   publicClient,
                 });

--- a/apps/hyperdrive-trading/src/ui/registry/hooks/useReadRegistry.ts
+++ b/apps/hyperdrive-trading/src/ui/registry/hooks/useReadRegistry.ts
@@ -1,11 +1,11 @@
 import { ReadRegistry } from "@delvtech/hyperdrive-viem";
 import { useMemo } from "react";
 import { sdkCache } from "src/sdk/sdkCache";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
+import { useAppConfigForConnectedChain } from "src/ui/appconfig/useAppConfigForConnectedChain";
 import { usePublicClient } from "wagmi";
 
 export function useReadRegistry(chainId: number): ReadRegistry | undefined {
-  const { registries } = useAppConfig();
+  const { registries } = useAppConfigForConnectedChain();
   const publicClient = usePublicClient();
   return useMemo(
     () =>

--- a/apps/hyperdrive-trading/src/ui/rewards/RewardsTooltip.tsx
+++ b/apps/hyperdrive-trading/src/ui/rewards/RewardsTooltip.tsx
@@ -2,7 +2,6 @@ import { appConfig, findHyperdriveConfig } from "@hyperdrive/appconfig";
 import * as Tooltip from "@radix-ui/react-tooltip";
 import { PropsWithChildren, ReactNode } from "react";
 import { assertNever } from "src/base/assertNever";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { useRewards } from "src/ui/rewards/useRewards";
 import { Address } from "viem";
 
@@ -16,9 +15,8 @@ export function RewardsTooltip({
   chainId: number;
   positionType: "lp" | "short";
 }>): ReactNode {
-  const { hyperdrives } = useAppConfig();
   const hyperdrive = findHyperdriveConfig({
-    hyperdrives,
+    hyperdrives: appConfig.hyperdrives,
     hyperdriveAddress: hyperdriveAddress,
     hyperdriveChainId: chainId,
   });

--- a/apps/hyperdrive-trading/src/ui/token/TokenInput.tsx
+++ b/apps/hyperdrive-trading/src/ui/token/TokenInput.tsx
@@ -120,9 +120,7 @@ export function TokenInput({
               onClick={(e) => {
                 e.preventDefault();
               }}
-              className="daisy-btn daisy-join-item border-b-neutral-content/30  border-l-neutral-content/30 border-r-neutral-content/30 border-t-neutral-content/30 bg-base-100 hover:border-b-neutral-content/30 hover:border-l-neutral-content/30 hover:border-r-neutral-content/30
-              hover:border-t-neutral-content/30
-              hover:bg-base-100 hover:underline"
+              className="daisy-btn daisy-join-item border-b-neutral-content/30 border-l-neutral-content/30 border-r-neutral-content/30 border-t-neutral-content/30 bg-base-100 hover:border-b-neutral-content/30 hover:border-l-neutral-content/30 hover:border-r-neutral-content/30 hover:border-t-neutral-content/30 hover:bg-base-100 hover:underline"
             >
               <Cog6ToothIcon className="h-4" />
             </button>

--- a/apps/hyperdrive-trading/src/ui/token/hooks/useApproveToken.tsx
+++ b/apps/hyperdrive-trading/src/ui/token/hooks/useApproveToken.tsx
@@ -4,11 +4,10 @@ import { queryClient } from "src/network/queryClient";
 import { waitForTransactionAndInvalidateCache } from "src/network/waitForTransactionAndInvalidateCache";
 import { usePublicClient, useWriteContract } from "wagmi";
 
-import { findToken } from "@hyperdrive/appconfig";
+import { appConfig, findToken } from "@hyperdrive/appconfig";
 import { useState } from "react";
 import { MAX_UINT256 } from "src/base/constants";
 import { QueryStatusWithIdle } from "src/base/queryStatus";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import TransactionToast from "src/ui/base/components/Toaster/TransactionToast";
 import { SUCCESS_TOAST_DURATION } from "src/ui/base/toasts";
 import { Address, erc20Abi, parseUnits } from "viem";
@@ -32,7 +31,6 @@ export function useApproveToken({
   pendingWalletSignatureStatus: QueryStatusWithIdle;
   isTransactionMined: boolean;
 } {
-  const appConfig = useAppConfig();
   const { writeContract, status } = useWriteContract();
   const addRecentTransaction = useAddRecentTransaction();
   const publicClient = usePublicClient({ chainId: tokenChainId });

--- a/apps/hyperdrive-trading/src/ui/token/hooks/useTokenBalance.ts
+++ b/apps/hyperdrive-trading/src/ui/token/hooks/useTokenBalance.ts
@@ -1,7 +1,7 @@
+import { appConfig } from "@hyperdrive/appconfig";
 import { ZERO_ADDRESS } from "src/base/constants";
 import { isTestnetChain } from "src/chains/isTestnetChain";
 import { ETH_MAGIC_NUMBER } from "src/token/ETH_MAGIC_NUMBER";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { Address, erc20Abi, formatUnits } from "viem";
 import { useBalance, useChainId, useReadContract } from "wagmi";
 
@@ -31,7 +31,7 @@ export function useTokenBalance({
 } {
   const isEth = tokenAddress === ETH_MAGIC_NUMBER;
   const isZeroAddress = tokenAddress === ZERO_ADDRESS;
-  const appConfig = useAppConfig();
+
   const chainId = useChainId();
 
   const { data: ethBalance, status: ethBalanceStatus } = useBalance({

--- a/apps/hyperdrive-trading/src/ui/vaults/useYieldSourceRate.ts
+++ b/apps/hyperdrive-trading/src/ui/vaults/useYieldSourceRate.ts
@@ -1,8 +1,8 @@
+import { appConfig } from "@hyperdrive/appconfig";
 import { useQuery } from "@tanstack/react-query";
 import { formatRate } from "src/base/formatRate";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { getYieldSourceRate } from "src/hyperdrive/getYieldSourceRate";
-import { useAppConfig } from "src/ui/appconfig/useAppConfig";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
 import { Address } from "viem";
 
@@ -22,7 +22,7 @@ export function useYieldSourceRate({
     chainId,
     address: hyperdriveAddress,
   });
-  const appConfig = useAppConfig();
+
   const queryEnabled = !!hyperdriveAddress && !!readHyperdrive;
   const { data, status: vaultRateStatus } = useQuery({
     enabled: queryEnabled,


### PR DESCRIPTION
The app would crash if you were connected to Sepolia but tried to load the pool details page for a Mainnet pool. This fixes the issue and cleans up our usage of `useAppConfig`, which is only really needed in a few places, i.e.: at the top of the PoolsList and Portfolio components. 99% of the time, we should just import `appConfig` directly from our package.