### PR TITLE
Don't show transaction details when inputs are empty

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
@@ -259,7 +259,7 @@ export function OpenLongForm({
             ) : null
           }
           bottomRightElement={
-            <div className="flex flex-col gap-1 text-xs text-neutral-content">
+            <div className="flex flex-col gap-1 text-sm text-neutral-content">
               <span>
                 {activeTokenBalance
                   ? `Balance: ${formatBalance({
@@ -286,17 +286,19 @@ export function OpenLongForm({
         />
       }
       transactionPreview={
-        <OpenLongPreview
-          hyperdrive={hyperdrive}
-          spotRateAfterOpen={spotRateAfterOpen}
-          curveFee={curveFee}
-          activeToken={activeToken}
-          amountPaid={depositAmountAsBigInt || 0n}
-          bondAmount={bondsReceived || 0n}
-          openLongPreviewStatus={openLongPreviewStatus}
-          asBase={activeToken.address === baseToken.address}
-          vaultSharePrice={poolInfo?.vaultSharePrice}
-        />
+        depositAmountAsBigInt ? (
+          <OpenLongPreview
+            hyperdrive={hyperdrive}
+            spotRateAfterOpen={spotRateAfterOpen}
+            curveFee={curveFee}
+            activeToken={activeToken}
+            amountPaid={depositAmountAsBigInt || 0n}
+            bondAmount={bondsReceived || 0n}
+            openLongPreviewStatus={openLongPreviewStatus}
+            asBase={activeToken.address === baseToken.address}
+            vaultSharePrice={poolInfo?.vaultSharePrice}
+          />
+        ) : null
       }
       disclaimer={(() => {
         if (!!depositAmountAsBigInt && !hasEnoughLiquidity) {

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm2.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm2.tsx
@@ -277,7 +277,7 @@ export function AddLiquidityForm2({
             </div>
           }
           bottomRightElement={
-            <div className="flex flex-col gap-1 text-xs text-neutral-content">
+            <div className="flex flex-col gap-1 text-sm text-neutral-content">
               <span>
                 {activeTokenBalance
                   ? `Balance: ${formatBalance({

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
@@ -475,20 +475,13 @@ export function OpenShortForm({
           );
         }
         // In all other cases where the user has input an amount, show the disclaimer, but ensure a skeleton is shown only on the stats that are being refetched on new blocks
-        return (
-          <div className="flex flex-col gap-4">
-            {!hasEnoughBalance && openShortPreviewStatus !== "loading" ? (
-              <p className="text-center text-sm text-error">
-                Insufficient balance
-              </p>
-            ) : null}
-            {hyperdrive.withdrawOptions.isBaseTokenWithdrawalEnabled ? null : (
-              <p className="text-center text-sm text-neutral-content">
-                {`When closing your Short position, you'll receive ${sharesToken?.symbol}.`}
-              </p>
-            )}
-          </div>
-        );
+        if (!hasEnoughBalance && openShortPreviewStatus !== "loading") {
+          return (
+            <p className="flex flex-col text-center text-sm text-error">
+              Insufficient balance
+            </p>
+          );
+        }
       })()}
       actionButton={(() => {
         if (!account) {

--- a/apps/hyperdrive-trading/src/ui/token/TokenInputTwo.tsx
+++ b/apps/hyperdrive-trading/src/ui/token/TokenInputTwo.tsx
@@ -120,7 +120,7 @@ export function TokenInputTwo({
               <div className="text-base-content">
                 <button
                   className={classNames(
-                    "ml-1 flex items-end text-xs font-semibold",
+                    "ml-1 flex items-end text-sm font-semibold",
                     {
                       "daisy-btn-error": hasError,
                     },

--- a/apps/hyperdrive-trading/src/ui/token/hooks/useTokenFiatPrice.ts
+++ b/apps/hyperdrive-trading/src/ui/token/hooks/useTokenFiatPrice.ts
@@ -1,6 +1,5 @@
 import { parseFixed } from "@delvtech/fixed-point-wasm";
 import { useQuery } from "@tanstack/react-query";
-import { ZERO_ADDRESS } from "src/base/constants";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { isTestnetChain } from "src/chains/isTestnetChain";
 import { ETH_MAGIC_NUMBER } from "src/token/ETH_MAGIC_NUMBER";
@@ -29,8 +28,7 @@ export function useTokenFiatPrice({
     defiLlamaTokenId = `ethereum:${ETH_MAGIC_NUMBER}`;
   }
 
-  const queryEnabled =
-    !isTestnetChain(chainId) && !!tokenAddress && tokenAddress !== ZERO_ADDRESS;
+  const queryEnabled = !isTestnetChain(chainId) && !!tokenAddress;
 
   const { data } = useQuery({
     queryKey: makeQueryKey("tokenFiatPrice", { defiLlamaTokenId }),


### PR DESCRIPTION
Similar to uniswap, if the user hasn't input anything we don't need to show the Transaction Details accordion.