### PR TITLE
Move disclaimers into buttons

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/InvalidTransactionButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/InvalidTransactionButton.tsx
@@ -1,0 +1,19 @@
+import classNames from "classnames";
+import { PropsWithChildren, ReactElement } from "react";
+
+export function InvalidTransactionButton({
+  children,
+  wide,
+}: PropsWithChildren<{ wide?: boolean }>): ReactElement {
+  return (
+    <button
+      disabled
+      className={classNames(
+        "daisy-btn daisy-btn-error rounded-full disabled:bg-error disabled:text-base-100 disabled:opacity-70",
+        { "w-full": wide },
+      )}
+    >
+      {children}
+    </button>
+  );
+}

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
@@ -18,6 +18,7 @@ import { useNumericInput } from "src/ui/base/hooks/useNumericInput";
 import { SwitchNetworksButton } from "src/ui/chains/SwitchChainButton/SwitchChainButton";
 import { useMarketState } from "src/ui/hyperdrive/hooks/useMarketState";
 import { usePoolInfo } from "src/ui/hyperdrive/hooks/usePoolInfo";
+import { InvalidTransactionButton } from "src/ui/hyperdrive/InvalidTransactionButton";
 import { useMaxLong } from "src/ui/hyperdrive/longs/hooks/useMaxLong";
 import { useOpenLong } from "src/ui/hyperdrive/longs/hooks/useOpenLong";
 import { usePreviewOpenLong } from "src/ui/hyperdrive/longs/hooks/usePreviewOpenLong";
@@ -300,29 +301,15 @@ export function OpenLongForm({
           />
         ) : null
       }
-      disclaimer={(() => {
-        if (!!depositAmountAsBigInt && !hasEnoughLiquidity) {
-          return (
-            <p className="text-center text-sm text-error">
-              Pool limit exceeded. Max long size is{" "}
-              {formatBalance({
-                balance: maxBondsOut || 0n,
-                decimals: baseToken.decimals,
-                places: baseToken.places,
-              })}{" "}
-              hy{baseToken.symbol}
-            </p>
-          );
-        }
-        if (!!depositAmountAsBigInt && !hasEnoughBalance) {
-          return (
-            <p className="text-center text-sm text-error">
-              Insufficient balance
-            </p>
-          );
-        }
-      })()}
       actionButton={(() => {
+        if (marketState?.isPaused) {
+          return (
+            <InvalidTransactionButton wide>
+              This market is paused
+            </InvalidTransactionButton>
+          );
+        }
+
         if (!account) {
           return <ConnectWalletButton wide />;
         }
@@ -336,14 +323,24 @@ export function OpenLongForm({
           );
         }
 
-        if (!hasEnoughBalance || !hasEnoughLiquidity || marketState?.isPaused) {
+        if (!!depositAmountAsBigInt && !hasEnoughLiquidity) {
           return (
-            <button
-              disabled
-              className="daisy-btn daisy-btn-circle daisy-btn-primary w-full disabled:bg-primary disabled:text-base-100 disabled:opacity-30"
-            >
-              Open Long
-            </button>
+            <InvalidTransactionButton wide>
+              Pool limit exceeded. Max long is{" "}
+              {formatBalance({
+                balance: maxBondsOut || 0n,
+                decimals: baseToken.decimals,
+                places: baseToken.places,
+              })}{" "}
+              hy{baseToken.symbol}
+            </InvalidTransactionButton>
+          );
+        }
+        if (!!depositAmountAsBigInt && !hasEnoughBalance) {
+          return (
+            <InvalidTransactionButton wide>
+              Insufficient balance
+            </InvalidTransactionButton>
           );
         }
 

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm2.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm2.tsx
@@ -20,6 +20,7 @@ import { PrimaryStat } from "src/ui/base/components/PrimaryStat";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { useNumericInput } from "src/ui/base/hooks/useNumericInput";
 import { SwitchNetworksButton } from "src/ui/chains/SwitchChainButton/SwitchChainButton";
+import { InvalidTransactionButton } from "src/ui/hyperdrive/InvalidTransactionButton";
 import { TransactionView } from "src/ui/hyperdrive/TransactionView";
 import { useIsNewPool } from "src/ui/hyperdrive/hooks/useIsNewPool";
 import { useLpApy } from "src/ui/hyperdrive/hooks/useLpApy";
@@ -304,13 +305,6 @@ export function AddLiquidityForm2({
         </div>
       }
       disclaimer={(() => {
-        if (!!depositAmountAsBigInt && !hasEnoughBalance) {
-          return (
-            <p className="text-center text-sm text-error">
-              Insufficient balance
-            </p>
-          );
-        }
         if (
           previewAddLiquidityError?.message.includes(
             "Not enough lp shares minted.",
@@ -323,32 +317,48 @@ export function AddLiquidityForm2({
             </p>
           );
         }
-        if (
-          previewAddLiquidityError?.message.includes("MinimumTransactionAmount")
-        ) {
-          return (
-            <p className="text-center text-sm text-error">
-              Trade does not meet the minimum transaction amount:{" "}
-              {formatBalance({
-                balance: hyperdrive.poolConfig.minimumTransactionAmount,
-                decimals: hyperdrive.decimals,
-                places: activeToken.places,
-              })}{" "}
-              {activeToken.symbol}.
-            </p>
-          );
-        }
       })()}
       actionButton={(() => {
+        if (marketState?.isPaused) {
+          return (
+            <InvalidTransactionButton wide>
+              This market is paused
+            </InvalidTransactionButton>
+          );
+        }
+
         if (!account) {
           return <ConnectWalletButton wide />;
         }
+
         if (connectedChainId !== hyperdrive.chainId) {
           return (
             <SwitchNetworksButton
               targetChainId={hyperdrive.chainId}
               targetChainName={appConfig.chains[hyperdrive.chainId].name}
             />
+          );
+        }
+        if (!!depositAmountAsBigInt && !hasEnoughBalance) {
+          return (
+            <InvalidTransactionButton wide>
+              Insufficient balance
+            </InvalidTransactionButton>
+          );
+        }
+        if (
+          previewAddLiquidityError?.message.includes("MinimumTransactionAmount")
+        ) {
+          return (
+            <InvalidTransactionButton wide>
+              Deposit must be greater than{" "}
+              {formatBalance({
+                balance: hyperdrive.poolConfig.minimumTransactionAmount,
+                decimals: hyperdrive.decimals,
+                places: activeToken.places * 2,
+              })}{" "}
+              {activeToken.symbol}
+            </InvalidTransactionButton>
           );
         }
 


### PR DESCRIPTION
Moving our disclaimers into disabled buttons instead. This looks much nicer and avoids a layout shift:
|Long|Short|Supply|
|---|---|---|
|<img width="619" alt="image" src="https://github.com/user-attachments/assets/41a36af5-e16a-4a09-913d-f4b0da5a4119">|<img width="558" alt="image" src="https://github.com/user-attachments/assets/219a7b70-f2e1-4d6b-96e8-1fc511ebf9a7">|<img width="570" alt="image" src="https://github.com/user-attachments/assets/1fa28427-dd57-4738-86a1-1e331c1f23e3">|