### PR TITLE
Persist pool filters in route

### DIFF
--- a/apps/hyperdrive-trading/src/ui/landing/Landing.tsx
+++ b/apps/hyperdrive-trading/src/ui/landing/Landing.tsx
@@ -7,7 +7,7 @@ export function Landing(): ReactElement | null {
     <div className="flex flex-col items-center gap-4 lg:w-[900px]">
       <Hero />
       <div className="flex w-full flex-col items-center">
-        <div className="flex flex-col gap-4">
+        <div className="flex w-full flex-col gap-4">
           <PoolsList />
         </div>
       </div>

--- a/apps/hyperdrive-trading/src/ui/landing/Landing.tsx
+++ b/apps/hyperdrive-trading/src/ui/landing/Landing.tsx
@@ -8,21 +8,6 @@ export function Landing(): ReactElement | null {
       <Hero />
       <div className="flex w-full flex-col items-center">
         <div className="flex flex-col gap-4">
-          {/* TODO: Implement filter buttons
-             <div className="flex items-center gap-3">
-              <button className="daisy-btn daisy-btn-sm gap-1.5 rounded-full">
-                All Terms
-                <ChevronDownIcon className="ml-1 size-4 text-neutral-content" />
-              </button>
-              <button className="daisy-btn daisy-btn-sm gap-1.5 rounded-full">
-                All Assets
-                <ChevronDownIcon className="ml-1 size-4 text-neutral-content" />
-              </button>
-              <button className="daisy-btn daisy-btn-sm gap-1.5 rounded-full">
-                All Chains
-                <ChevronDownIcon className="ml-1 size-4 text-neutral-content" />
-              </button>
-            </div> */}
           <PoolsList />
         </div>
       </div>

--- a/apps/hyperdrive-trading/src/ui/markets/PoolsList.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PoolsList.tsx
@@ -43,7 +43,9 @@ type SortOption = (typeof sortOptions)[number];
 
 export function PoolsList(): ReactElement {
   const { pools: allPools, status } = usePoolsList();
-  const { chains: selectedChains, assets } = useSearch({ from: LANDING_ROUTE });
+  const { chains: selectedChains, assets: selectedAssets } = useSearch({
+    from: LANDING_ROUTE,
+  });
   const navigate = useNavigate({ from: LANDING_ROUTE });
   const [sort, setSort] = useState<SortOption>("TVL");
 
@@ -92,8 +94,6 @@ export function PoolsList(): ReactElement {
     };
   }, [allPools]);
 
-  const [selectedAssets, setSelectedAssets] = useState<string[]>([]);
-
   // Filter and sort pools
   const selectedPools = allPools
     ?.filter((pool) => {
@@ -105,7 +105,7 @@ export function PoolsList(): ReactElement {
       }
 
       if (
-        selectedAssets.length &&
+        selectedAssets?.length &&
         !pool.depositAssets.some(({ symbol }) =>
           selectedAssets.includes(symbol),
         )
@@ -197,13 +197,22 @@ export function PoolsList(): ReactElement {
               {filters && filters.assets.length > 1 && (
                 <MultiSelect
                   title="Filter by deposit asset"
-                  selected={selectedAssets}
-                  onChange={setSelectedAssets}
+                  selected={selectedAssets || []}
+                  onChange={(assets) =>
+                    navigate({
+                      search: (current) => {
+                        return {
+                          ...current,
+                          assets,
+                        };
+                      },
+                    })
+                  }
                   displayValue={
-                    selectedAssets.length === 1
+                    selectedAssets?.length === 1
                       ? selectedAssets[0]
                       : `${
-                          selectedAssets.length || filters.assets.length
+                          selectedAssets?.length || filters.assets.length
                         } assets`
                   }
                   searchEnabled

--- a/apps/hyperdrive-trading/src/ui/markets/PoolsList.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PoolsList.tsx
@@ -13,7 +13,7 @@ import {
 import { QueryStatus, useQuery } from "@tanstack/react-query";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { getPublicClient } from "@wagmi/core";
-import { ReactElement, ReactNode, useMemo, useRef, useState } from "react";
+import { ReactElement, ReactNode, useMemo, useState } from "react";
 import { ZERO_ADDRESS } from "src/base/constants";
 import { isTestnetChain } from "src/chains/isTestnetChain";
 import { calculateMarketYieldMultiplier } from "src/hyperdrive/calculateMarketYieldMultiplier";
@@ -139,14 +139,8 @@ export function PoolsList(): ReactElement {
       }
     });
 
-  // To prevent jarring layout shifts when no pools match the selected filters,
-  // the NonIdealState is wrapped in a div with a width set to match the outer
-  // container's width, which will be the width it rendered at before the
-  // filter's were changed.
-  const containerRef = useRef<HTMLDivElement>(null);
-
   return (
-    <div className="flex w-full flex-col gap-5" ref={containerRef}>
+    <div className="flex w-full flex-col gap-5">
       {status === "loading" && !selectedPools ? (
         <LoadingState />
       ) : selectedPools ? (
@@ -269,12 +263,7 @@ export function PoolsList(): ReactElement {
           </div>
 
           {!selectedPools.length ? (
-            <Well
-              className="max-w-[90vw]"
-              style={{
-                width: containerRef.current?.offsetWidth,
-              }}
-            >
+            <Well className="max-w-[90vw]">
               {allPools?.length ? (
                 <NonIdealState
                   heading={"No pools found"}

--- a/apps/hyperdrive-trading/src/ui/routes/index.tsx
+++ b/apps/hyperdrive-trading/src/ui/routes/index.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { Page } from "src/ui/app/Page";
 import { Landing } from "src/ui/landing/Landing";
 import { LANDING_ROUTE } from "src/ui/landing/routes";
+import { z } from "zod";
 
 export const Route = createFileRoute(LANDING_ROUTE)({
   component: () => (
@@ -9,4 +10,8 @@ export const Route = createFileRoute(LANDING_ROUTE)({
       <Landing />
     </Page>
   ),
+  validateSearch: z.object({
+    chains: z.array(z.number()).optional(),
+    assets: z.array(z.string()).optional(),
+  }),
 });


### PR DESCRIPTION
The pool filter state is now stored in the URL. This allows you to refresh the page or use the Back button from a pool details page, and still see the same list of filtered pools.

[Hyperdrive---DeFi-Yield-your-way (3).webm](https://github.com/user-attachments/assets/dcb06e3e-7ad1-49ba-9cb5-8520f07df72f)
