### PR TITLE
Add mint route, wire up mint buttons

### DIFF
--- a/apps/hyperdrive-trading/src/routeTree.gen.ts
+++ b/apps/hyperdrive-trading/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as ErrorImport } from "./ui/routes/error";
 import { Route as IndexImport } from "./ui/routes/index";
 import { Route as IneligibleImport } from "./ui/routes/ineligible";
 import { Route as MarketChainIdAddressImport } from "./ui/routes/market.$chainId.$address";
+import { Route as MintImport } from "./ui/routes/mint";
 import { Route as PortfolioImport } from "./ui/routes/portfolio";
 import { Route as RestrictedcountriesImport } from "./ui/routes/restricted_countries";
 import { Route as VpnImport } from "./ui/routes/vpn";
@@ -34,6 +35,11 @@ const RestrictedcountriesRoute = RestrictedcountriesImport.update({
 
 const PortfolioRoute = PortfolioImport.update({
   path: "/portfolio",
+  getParentRoute: () => rootRoute,
+} as any);
+
+const MintRoute = MintImport.update({
+  path: "/mint",
   getParentRoute: () => rootRoute,
 } as any);
 
@@ -82,6 +88,10 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof IneligibleImport;
       parentRoute: typeof rootRoute;
     };
+    "/mint": {
+      preLoaderRoute: typeof MintImport;
+      parentRoute: typeof rootRoute;
+    };
     "/portfolio": {
       preLoaderRoute: typeof PortfolioImport;
       parentRoute: typeof rootRoute;
@@ -108,6 +118,7 @@ export const routeTree = rootRoute.addChildren([
   ChainlogRoute,
   ErrorRoute,
   IneligibleRoute,
+  MintRoute,
   PortfolioRoute,
   RestrictedcountriesRoute,
   VpnRoute,

--- a/apps/hyperdrive-trading/src/ui/app/Navbar/Navbar.tsx
+++ b/apps/hyperdrive-trading/src/ui/app/Navbar/Navbar.tsx
@@ -6,11 +6,15 @@ import { ConnectButton } from "@rainbow-me/rainbowkit";
 import { Link, useRouterState } from "@tanstack/react-router";
 import classNames from "classnames";
 import { ReactElement } from "react";
+import { isTestnetChain } from "src/chains/isTestnetChain";
 import { DevtoolsMenu } from "src/ui/app/Navbar/DevtoolsMenu";
 import { HyperdriveLogo } from "src/ui/app/Navbar/HyperdriveLogo";
 import VersionPicker from "src/ui/base/components/VersionPicker";
 import { useIsTailwindSmallScreen } from "src/ui/base/mediaBreakpoints";
 import { useRegionInfo } from "src/ui/compliance/hooks/useRegionInfo";
+import { LANDING_ROUTE } from "src/ui/landing/routes";
+import { MINT_ROUTE } from "src/ui/mint/routes";
+import { PORTFOLIO_ROUTE } from "src/ui/portfolio/routes";
 import { sepolia } from "viem/chains";
 import { useChainId } from "wagmi";
 export function Navbar(): ReactElement {
@@ -18,6 +22,7 @@ export function Navbar(): ReactElement {
   const { location } = useRouterState();
   const chainId = useChainId();
   const { isReadOnly } = useRegionInfo();
+  const isTestnet = isTestnetChain(chainId);
 
   return (
     <div className="daisy-navbar">
@@ -29,26 +34,38 @@ export function Navbar(): ReactElement {
           <img className="h-8" src="/hyperdrive-solo-logo-white.svg" />
         </Link>
         <div className="ml-16 flex gap-8">
-          <Link to={"/"} className="hidden sm:inline">
+          <Link to={LANDING_ROUTE} className="hidden sm:inline">
             <span
               className={classNames("text-md", {
-                "text-white": location.pathname === "/",
-                "text-neutral-content": location.pathname !== "/",
+                "text-white": location.pathname === LANDING_ROUTE,
+                "text-neutral-content": location.pathname !== LANDING_ROUTE,
               })}
             >
               All Pools
             </span>
           </Link>
-          <Link to={"/portfolio"}>
+          <Link to={PORTFOLIO_ROUTE}>
             <span
               className={classNames("text-md", {
-                "text-white": location.pathname === "/portfolio",
-                "text-neutral-content": location.pathname !== "/portfolio",
+                "text-white": location.pathname === PORTFOLIO_ROUTE,
+                "text-neutral-content": location.pathname !== PORTFOLIO_ROUTE,
               })}
             >
               Portfolio
             </span>
           </Link>
+          {isTestnet ? (
+            <Link to={MINT_ROUTE}>
+              <span
+                className={classNames("text-md", {
+                  "text-white": location.pathname === MINT_ROUTE,
+                  "text-neutral-content": location.pathname !== MINT_ROUTE,
+                })}
+              >
+                Mint Tokens
+              </span>
+            </Link>
+          ) : null}
         </div>
       </div>
       <div className="daisy-navbar-end gap-2 sm:gap-8">

--- a/apps/hyperdrive-trading/src/ui/chains/SwitchChainButton/SwitchChainButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/chains/SwitchChainButton/SwitchChainButton.tsx
@@ -5,16 +5,19 @@ import { useSwitchChain } from "wagmi";
 export function SwitchNetworksButton({
   targetChainId,
   targetChainName,
+  wide = true,
 }: {
   targetChainId: number;
   targetChainName: string;
+  wide?: boolean;
 }): ReactElement {
   const { switchChain, status: switchChainStatus } = useSwitchChain();
   return (
     <button
       disabled={switchChainStatus === "loading"}
       className={classNames(
-        "daisy-btn daisy-btn-warning w-full rounded-full disabled:bg-warning disabled:text-base-100 disabled:opacity-30",
+        "daisy-btn daisy-btn-warning rounded-full disabled:bg-warning disabled:text-base-100 disabled:opacity-30",
+        { "w-full": wide },
       )}
       onClick={() => {
         switchChain({ chainId: targetChainId });

--- a/apps/hyperdrive-trading/src/ui/markets/routes.ts
+++ b/apps/hyperdrive-trading/src/ui/markets/routes.ts
@@ -1,2 +1,1 @@
 export const MARKET_DETAILS_ROUTE = "/market/$chainId/$address";
-export const PORTFOLIO_ROUTE = "/portfolio";

--- a/apps/hyperdrive-trading/src/ui/mint/MintView.tsx
+++ b/apps/hyperdrive-trading/src/ui/mint/MintView.tsx
@@ -1,0 +1,96 @@
+import { TokenConfig } from "@delvtech/hyperdrive-appconfig";
+import classNames from "classnames";
+import { ReactElement } from "react";
+import { MAX_UINT256 } from "src/base/constants";
+import { isTestnetChain } from "src/chains/isTestnetChain";
+import { ETH_MAGIC_NUMBER } from "src/token/ETH_MAGIC_NUMBER";
+import { useAppConfigForConnectedChain } from "src/ui/appconfig/useAppConfigForConnectedChain";
+import { SwitchNetworksButton } from "src/ui/chains/SwitchChainButton/SwitchChainButton";
+import { useMintToken } from "src/ui/token/hooks/useMintToken";
+import { sepolia } from "viem/chains";
+import { useAccount, useChainId } from "wagmi";
+
+export function MintView(): ReactElement {
+  const appConfig = useAppConfigForConnectedChain();
+  const chainId = useChainId();
+  const isTestnet = isTestnetChain(chainId);
+  return (
+    <div className="flex flex-col items-center gap-4 lg:w-[900px]">
+      <Hero />
+      <div className="flex w-full flex-col items-center">
+        {!isTestnet ? (
+          <div>
+            <SwitchNetworksButton
+              targetChainId={sepolia.id}
+              targetChainName={"Sepolia"}
+            />
+          </div>
+        ) : (
+          <div className="flex w-full flex-wrap gap-4">
+            {appConfig.tokens
+              .filter((t) => t.address !== ETH_MAGIC_NUMBER)
+              .map((token) => (
+                <div key={token.address}>
+                  <MintButton token={token} />
+                </div>
+              ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function MintButton({ token }: { token: TokenConfig }) {
+  const { address: account } = useAccount();
+  const chainId = useChainId();
+  const isTestnet = isTestnetChain(chainId);
+  const { mint } = useMintToken({
+    token,
+    destination: account,
+    amount: MAX_UINT256,
+  });
+  return (
+    <button
+      key={token.address}
+      onClick={mint}
+      disabled={!isTestnet}
+      className={classNames("daisy-btn", { "daisy-btn-disabled": !isTestnet })}
+    >
+      <div className="flex items-center justify-start gap-4">
+        <img
+          src={token.iconUrl}
+          className={classNames("size-6 rounded-full", {
+            "opacity-50": !isTestnet,
+          })}
+        />
+        <span className="w-20 text-left">Mint {token.symbol}</span>
+      </div>
+    </button>
+  );
+}
+
+export function Hero(): ReactElement {
+  return (
+    <div className="daisy-hero">
+      <div className={"daisy-hero-content"}>
+        <div className="max-w-4xl">
+          <h1
+            className={classNames(
+              "gradient-text mb-4 text-h3 font-medium md:text-h2",
+            )}
+          >
+            Mint Tokens
+          </h1>
+          <h5
+            className={classNames(
+              "font-inter text-lg leading-bodyText text-neutral-content",
+            )}
+          >
+            Mint tokens to use with the testnet Hyperdrive pools.
+          </h5>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/hyperdrive-trading/src/ui/mint/routes.ts
+++ b/apps/hyperdrive-trading/src/ui/mint/routes.ts
@@ -1,0 +1,1 @@
+export const MINT_ROUTE = "/mint";

--- a/apps/hyperdrive-trading/src/ui/portfolio/Portfolio.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/Portfolio.tsx
@@ -4,7 +4,7 @@ import { TabsTwo } from "src/ui/base/components/Tabs/TabsTwo";
 import { OpenLongsContainer } from "src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktopTwo";
 import { LpAndWithdrawalSharesContainer } from "src/ui/hyperdrive/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable";
 import { OpenShortsContainer } from "src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktopTwo";
-import { PORTFOLIO_ROUTE } from "src/ui/markets/routes";
+import { PORTFOLIO_ROUTE } from "./routes";
 
 export function Portfolio(): ReactElement {
   const { position } = useSearch({ from: PORTFOLIO_ROUTE });

--- a/apps/hyperdrive-trading/src/ui/portfolio/routes.ts
+++ b/apps/hyperdrive-trading/src/ui/portfolio/routes.ts
@@ -1,0 +1,1 @@
+export const PORTFOLIO_ROUTE = "/portfolio";

--- a/apps/hyperdrive-trading/src/ui/routes/mint.tsx
+++ b/apps/hyperdrive-trading/src/ui/routes/mint.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { Page } from "src/ui/app/Page";
+import { MintView } from "src/ui/mint/MintView";
+import { MINT_ROUTE } from "src/ui/mint/routes";
+export const Route = createFileRoute(MINT_ROUTE)({
+  component: () => (
+    <Page>
+      <MintView />
+    </Page>
+  ),
+});

--- a/apps/hyperdrive-trading/src/ui/routes/portfolio.tsx
+++ b/apps/hyperdrive-trading/src/ui/routes/portfolio.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { Page } from "src/ui/app/Page";
-import { PORTFOLIO_ROUTE } from "src/ui/markets/routes";
 import { Portfolio } from "src/ui/portfolio/Portfolio";
+import { PORTFOLIO_ROUTE } from "src/ui/portfolio/routes";
 import { z } from "zod";
 export const Route = createFileRoute(PORTFOLIO_ROUTE)({
   component: () => (


### PR DESCRIPTION
Add a route item to the navbar when on testnet to take you to a Mint Tokens page, where you can mint any of the tokens available in the testnet appconfig.

Closes #1560

[Hyperdrive---DeFi-Yield-your-way (5).webm](https://github.com/user-attachments/assets/75f0a105-da38-4539-9f61-754d3e48d8cf)

