### PR TITLE
Reorder wagmi wallets list

### DIFF
--- a/apps/hyperdrive-trading/src/network/wagmiClient.ts
+++ b/apps/hyperdrive-trading/src/network/wagmiClient.ts
@@ -99,10 +99,13 @@ const chains: Chain[] = [];
 const transports: Record<string, Transport> = {};
 const customWallets: CreateWalletFn[] = [];
 const recommendedWallets = [
-  injectedWallet,
+  // needs to be first
   safeWallet,
   rainbowWallet,
   metaMaskWallet,
+  // recommended to be last
+  // https://www.rainbowkit.com/docs/custom-wallet-list#injected-wallet
+  injectedWallet,
 ];
 
 // WalletConnect


### PR DESCRIPTION
when connecting via gnosis safe app the injected connector is taking priority. My guess is it's because of the order of the list which this rainbow-kit section suggests  [// needs to be first](https://www.rainbowkit.com/docs/custom-wallet-list#injected-wallet)