### PR TITLE
Adds selector for getRewardsFn

### DIFF
--- a/apps/hyperdrive-trading/src/hyperdrive/getLpApy.ts
+++ b/apps/hyperdrive-trading/src/hyperdrive/getLpApy.ts
@@ -1,8 +1,8 @@
 import { fixed } from "@delvtech/fixed-point-wasm";
 import {
   appConfig,
+  getRewardsFn,
   HyperdriveConfig,
-  rewardFunctions,
 } from "@delvtech/hyperdrive-appconfig";
 import { Block, ReadHyperdrive } from "@delvtech/hyperdrive-viem";
 import { getPublicClient } from "@wagmi/core";
@@ -78,11 +78,12 @@ export async function getLpApy({
     const publicClient = getPublicClient(wagmiConfig as any, {
       chainId: hyperdrive.chainId,
     }) as PublicClient;
-    // TODO: Create an appconfig selector to grab the rewards function from a
-    // given hyperdrive
-    const rewardsFn = appConfig.yieldSources[hyperdrive.yieldSource].rewardsFn;
+    const rewardsFn = getRewardsFn({
+      yieldSourceId: hyperdrive.yieldSource,
+      appConfig,
+    });
     if (rewardsFn) {
-      const rewards = await rewardFunctions[rewardsFn](publicClient);
+      const rewards = await rewardsFn(publicClient);
       rewards?.forEach((reward) => {
         if (reward.type === "transferableToken") {
           netLpApy = fixed(reward.apy).add(

--- a/apps/hyperdrive-trading/src/ui/rewards/useRewards.ts
+++ b/apps/hyperdrive-trading/src/ui/rewards/useRewards.ts
@@ -1,8 +1,8 @@
 import {
   AnyReward,
   appConfig,
+  getRewardsFn,
   HyperdriveConfig,
-  rewardFunctions,
 } from "@delvtech/hyperdrive-appconfig";
 import { useQuery } from "@tanstack/react-query";
 import { getPublicClient } from "@wagmi/core";
@@ -14,8 +14,10 @@ export function useRewards(hyperdriveConfig: HyperdriveConfig): {
   rewards: AnyReward[] | undefined;
   status: "error" | "success" | "loading";
 } {
-  const rewardsFn =
-    appConfig.yieldSources[hyperdriveConfig.yieldSource].rewardsFn;
+  const rewardsFn = getRewardsFn({
+    yieldSourceId: hyperdriveConfig.yieldSource,
+    appConfig,
+  });
 
   const queryEnabled = !!rewardsFn;
 
@@ -30,7 +32,7 @@ export function useRewards(hyperdriveConfig: HyperdriveConfig): {
           const publicClient = getPublicClient(wagmiConfig as any, {
             chainId: hyperdriveConfig.chainId,
           }) as PublicClient;
-          return rewardFunctions[rewardsFn](publicClient);
+          return rewardsFn(publicClient);
         }
       : undefined,
   });

--- a/packages/hyperdrive-appconfig/src/index.ts
+++ b/packages/hyperdrive-appconfig/src/index.ts
@@ -32,12 +32,12 @@ export type { YieldSource, YieldSourceId } from "src/yieldSources/types";
 export { yieldSources } from "src/yieldSources/yieldSources";
 
 // rewards
-export { rewardFunctions } from "src/rewards/rewards";
+export { getRewardsFn } from "src/rewards/selectors";
 export type {
   AnyReward,
   InfoReward,
   NonTransferableTokenReward,
-  RewardsResolver as RewardsFn,
+  RewardsResolver,
   TransferableTokenReward,
 } from "src/rewards/types";
 

--- a/packages/hyperdrive-appconfig/src/rewards/selectors.ts
+++ b/packages/hyperdrive-appconfig/src/rewards/selectors.ts
@@ -1,0 +1,25 @@
+import { AppConfig } from "src/appconfig/AppConfig";
+import { rewardFunctions } from "src/rewards/rewards";
+import { RewardsResolver } from "src/rewards/types";
+import { YieldSourceId } from "src/yieldSources/types";
+
+/**
+ * Find the rewards resolver for a given yield source. This will return
+ * `undefined` if no rewards function exists for this yield source.
+ */
+export function getRewardsFn({
+  yieldSourceId,
+  appConfig,
+}: {
+  // TODO: change this type to YieldSourceId once YieldSourceId can be used outside
+  // of the appconfig package.k
+  yieldSourceId: string;
+  appConfig: AppConfig;
+}): RewardsResolver | undefined {
+  // casting this for now because YieldSourceId doesn't work outside of the appconfig package
+  const yieldSource = appConfig.yieldSources[yieldSourceId as YieldSourceId];
+  if (!yieldSource.rewardsFn) {
+    return;
+  }
+  return rewardFunctions[yieldSource.rewardsFn];
+}


### PR DESCRIPTION
Adds a selector to prevent directly accessing the `rewardsFunctions` object.

While here I noticed that the `YieldSourceId` type does not work outside of the appconfig package, so for now the id argument to the `getRewardsFn` is typed as `string`. See #1637 for more info.