### PR TITLE
Optimize chainlog

### DIFF
--- a/apps/hyperdrive-trading/src/ui/chainlog/FactoriesTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/chainlog/FactoriesTable.tsx
@@ -193,7 +193,7 @@ function useFactoriesQuery(): UseQueryResult<Factory[], any> {
           const factoryAddresses = await registry.getFactoryAddresses();
           const metas = await registry.getFactoryInfos(factoryAddresses);
 
-          metas.forEach(({ data, name, version }, i) => {
+          for (const [i, { data, name, version }] of metas.entries()) {
             const { status } = decodeFactoryData(data);
             factories.push({
               name,
@@ -202,7 +202,7 @@ function useFactoriesQuery(): UseQueryResult<Factory[], any> {
               version,
               status,
             });
-          });
+          }
         }),
       );
 

--- a/apps/hyperdrive-trading/src/ui/chainlog/PoolsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/chainlog/PoolsTable.tsx
@@ -42,8 +42,6 @@ export function PoolsTable(): ReactElement {
     },
   });
 
-  console.log(data.length);
-
   return (
     <div className="w-full overflow-x-auto">
       {!isFetching && !data.length ? (

--- a/apps/hyperdrive-trading/src/ui/chainlog/PoolsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/chainlog/PoolsTable.tsx
@@ -244,13 +244,17 @@ function usePoolsQuery(): UseQueryResult<Pool[], any> {
             const { data, factory, name, version } = metas[i];
             const { status } = decodeInstanceData(data);
 
-            const { baseToken, vaultSharesToken: vaultToken } =
-              await readHyperdrive.getPoolConfig();
-            const { isPaused } = await readHyperdrive.getMarketState();
-            const [deployerCoordinatorAddress] =
-              await factory.getDeployerCoordinatorAddresses({
+            const [
+              { baseToken, vaultSharesToken: vaultToken },
+              { isPaused },
+              [deployerCoordinatorAddress],
+            ] = await Promise.all([
+              readHyperdrive.getPoolConfig(),
+              readHyperdrive.getMarketState(),
+              factory.getDeployerCoordinatorAddresses({
                 instances: [readHyperdrive.address],
-              });
+              }),
+            ]);
 
             pools.push({
               name,

--- a/apps/hyperdrive-trading/src/ui/chainlog/PoolsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/chainlog/PoolsTable.tsx
@@ -42,6 +42,8 @@ export function PoolsTable(): ReactElement {
     },
   });
 
+  console.log(data.length);
+
   return (
     <div className="w-full overflow-x-auto">
       {!isFetching && !data.length ? (
@@ -219,10 +221,11 @@ function usePoolsQuery(): UseQueryResult<Pool[], any> {
       chainIds,
     }),
     placeholderData: [],
-    queryFn: async () => {
-      const pools: Pool[] = [];
-
-      await Promise.all(
+    queryFn: async () =>
+      // Wrapping these RPC requests in Promise.all and using `.then()` chaining
+      // allows viem to batch requests via MultiCall3 and reduces the number of
+      // requests by 80% and data transfer by 65%.
+      Promise.all(
         chainIds.map(async (chainId) => {
           const publicClient = getPublicClient(wagmiConfig as any, {
             chainId,
@@ -235,44 +238,43 @@ function usePoolsQuery(): UseQueryResult<Pool[], any> {
             namespace: chainId.toString(),
           });
 
-          const instances = await registry.getInstances();
-          const metas = await registry.getInstanceInfos(
-            instances.map((pool) => pool.address),
-          );
+          return registry.getInstances().then((instances) => {
+            return Promise.all(
+              instances.map((pool) => {
+                return registry
+                  .getInstanceInfo(pool.address)
+                  .then(({ data, factory, name, version }) => {
+                    const { status } = decodeInstanceData(data);
 
-          for (const [i, readHyperdrive] of instances.entries()) {
-            const { data, factory, name, version } = metas[i];
-            const { status } = decodeInstanceData(data);
-
-            const [
-              { baseToken, vaultSharesToken: vaultToken },
-              { isPaused },
-              [deployerCoordinatorAddress],
-            ] = await Promise.all([
-              readHyperdrive.getPoolConfig(),
-              readHyperdrive.getMarketState(),
-              factory.getDeployerCoordinatorAddresses({
-                instances: [readHyperdrive.address],
+                    return Promise.all([
+                      pool.getPoolConfig(),
+                      pool.getMarketState(),
+                      factory.getDeployerCoordinatorAddresses({
+                        instances: [pool.address],
+                      }),
+                    ]).then(
+                      ([
+                        { baseToken, vaultSharesToken },
+                        { isPaused },
+                        [deployerCoordinatorAddress],
+                      ]) => ({
+                        name,
+                        address: pool.address,
+                        chainId,
+                        version,
+                        isPaused,
+                        status,
+                        factoryAddress: factory.address,
+                        deployerCoordinatorAddress,
+                        baseToken,
+                        vaultToken: vaultSharesToken,
+                      }),
+                    );
+                  });
               }),
-            ]);
-
-            pools.push({
-              name,
-              address: readHyperdrive.address,
-              chainId,
-              version,
-              isPaused,
-              status,
-              factoryAddress: factory.address,
-              deployerCoordinatorAddress,
-              baseToken,
-              vaultToken,
-            });
-          }
+            );
+          });
         }),
-      );
-
-      return pools;
-    },
+      ).then((groupedPools) => groupedPools.flat()),
   });
 }


### PR DESCRIPTION
This refactors the chainlog pools table query to use `Promise.all()` and `.then()` chaining which reduced the number of requests from **87** to **17**, and the data transfer from **36.6 kB** to **12.6 kB**.