### PR TITLE
Refactor declaration merging to type union, add yieldSource selector

### DIFF
--- a/apps/hyperdrive-trading/src/hyperdrive/getYieldSourceRate.ts
+++ b/apps/hyperdrive-trading/src/hyperdrive/getYieldSourceRate.ts
@@ -3,6 +3,7 @@ import { fixed } from "@delvtech/fixed-point-wasm";
 import {
   AppConfig,
   findHyperdriveConfig,
+  findYieldSource,
   getRewardsFn,
   HyperdriveConfig,
 } from "@delvtech/hyperdrive-appconfig";
@@ -66,11 +67,16 @@ export async function getYieldSourceRate(
 
   const netRate = await calcNetRate(rate, appConfig, hyperdrive);
 
+  const yieldSource = findYieldSource({
+    appConfig,
+    hyperdriveAddress: hyperdrive.address,
+    hyperdriveChainId: hyperdrive.chainId,
+  });
+
   return {
     rate,
     netRate,
-    ratePeriodDays:
-      appConfig.yieldSources[hyperdrive.yieldSource].historicalRatePeriod,
+    ratePeriodDays: yieldSource.historicalRatePeriod,
   };
 }
 
@@ -109,8 +115,12 @@ function getNumBlocksForHistoricalRate({
   hyperdrive: HyperdriveConfig;
 }) {
   const blocksPerDay = appConfig.chains[hyperdrive.chainId].dailyAverageBlocks;
-  const historicalRatePeriod =
-    appConfig.yieldSources[hyperdrive.yieldSource].historicalRatePeriod;
+  const yieldSource = findYieldSource({
+    hyperdriveAddress: hyperdrive.address,
+    hyperdriveChainId: hyperdrive.chainId,
+    appConfig,
+  });
+  const historicalRatePeriod = yieldSource.historicalRatePeriod;
 
   const numBlocksForHistoricalRate = isForkChain(hyperdrive.chainId)
     ? 1000n // roughly 3 hours for cloudchain

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/usePrepareSharesIn.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/usePrepareSharesIn.ts
@@ -2,6 +2,7 @@ import {
   AppConfig,
   appConfig,
   findHyperdriveConfig,
+  findYieldSource,
 } from "@delvtech/hyperdrive-appconfig";
 import { ReadHyperdrive } from "@delvtech/hyperdrive-js";
 import { useQuery } from "@tanstack/react-query";
@@ -75,9 +76,12 @@ export async function prepareSharesIn({
   // If the shares token is pegged to its base token (e.g., stETH to ETH), then
   // we need to treat the amount as if it were base. To get the actual shares
   // amount then, we convert to the shares used by the pool (eg: lidoShares).
-  if (
-    appConfig.yieldSources[hyperdriveConfig.yieldSource].isSharesPeggedToBase
-  ) {
+  const yieldSource = findYieldSource({
+    hyperdriveAddress: hyperdriveConfig.address,
+    hyperdriveChainId: hyperdriveConfig.chainId,
+    appConfig,
+  });
+  if (yieldSource.isSharesPeggedToBase) {
     return readHyperdrive.convertToShares({
       baseAmount: sharesAmount,
     });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/usePrepareSharesOut.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/usePrepareSharesOut.ts
@@ -2,6 +2,7 @@ import {
   AppConfig,
   appConfig,
   findHyperdriveConfig,
+  findYieldSource,
 } from "@delvtech/hyperdrive-appconfig";
 import { ReadHyperdrive } from "@delvtech/hyperdrive-js";
 import { useQuery } from "@tanstack/react-query";
@@ -81,9 +82,12 @@ export async function prepareSharesOut({
   // amount then, we convert to base. For example, when preparing lido shares
   // received back from a steth hyperdrive, this will convert lido shares to
   // eth, and since 1 eth = 1 steth we return this as the shares value.
-  if (
-    appConfig.yieldSources[hyperdriveConfig.yieldSource].isSharesPeggedToBase
-  ) {
+  const yieldSource = findYieldSource({
+    hyperdriveAddress: hyperdriveConfig.address,
+    hyperdriveChainId: hyperdriveConfig.chainId,
+    appConfig,
+  });
+  if (yieldSource.isSharesPeggedToBase) {
     return readHyperdrive.convertToBase({
       sharesAmount,
     });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongStats.tsx
@@ -2,6 +2,7 @@ import { fixed } from "@delvtech/fixed-point-wasm";
 import {
   appConfig,
   findBaseToken,
+  findYieldSource,
   HyperdriveConfig,
 } from "@delvtech/hyperdrive-appconfig";
 import { calculateAprFromPrice } from "@delvtech/hyperdrive-js";
@@ -47,9 +48,12 @@ export function OpenLongStats({
     hyperdriveAddress: hyperdrive.address,
   });
 
-  const isBaseAmount =
-    asBase ||
-    appConfig.yieldSources[hyperdrive.yieldSource].isSharesPeggedToBase;
+  const yieldSource = findYieldSource({
+    hyperdriveAddress: hyperdrive.address,
+    hyperdriveChainId: hyperdrive.chainId,
+    appConfig,
+  });
+  const isBaseAmount = asBase || yieldSource.isSharesPeggedToBase;
   const amountPaidInBase = isBaseAmount
     ? amountPaid
     : convertSharesToBase({

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
@@ -5,6 +5,7 @@ import {
   appConfig,
   findBaseToken,
   findToken,
+  findYieldSource,
 } from "@delvtech/hyperdrive-appconfig";
 import { adjustAmountByPercentage } from "@delvtech/hyperdrive-js";
 import classNames from "classnames";
@@ -533,7 +534,11 @@ function LpApyStat({ hyperdrive }: { hyperdrive: HyperdriveConfig }) {
   });
 
   const showSkeleton = !lpApy && lpApyStatus === "loading";
-
+  const yieldSource = findYieldSource({
+    hyperdriveAddress: hyperdrive.address,
+    hyperdriveChainId: hyperdrive.chainId,
+    appConfig,
+  });
   return (
     <PrimaryStat
       label="LP APY"
@@ -560,7 +565,7 @@ function LpApyStat({ hyperdrive }: { hyperdrive: HyperdriveConfig }) {
       subValue={
         vaultRateStatus === "success" && vaultRate ? (
           <div>
-            {appConfig.yieldSources[hyperdrive.yieldSource].shortName} @{" "}
+            {yieldSource.shortName} @{" "}
             {isNewPool
               ? "✨New✨"
               : `${formatRate({ rate: vaultRate.netVaultRate })} APY`}

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/LpAndWithdrawalSharesTable/ManageLpAndWithdrawalSharesButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/LpAndWithdrawalSharesTable/ManageLpAndWithdrawalSharesButton.tsx
@@ -46,7 +46,6 @@ export function ManageLpAndWithdrawalSharesButton({
     account,
     chainId: hyperdrive.chainId,
   });
-  const yieldSource = appConfig.yieldSources[hyperdrive.yieldSource];
 
   const { withdrawalShares: balanceOfWithdrawalShares } = useWithdrawalShares({
     hyperdriveAddress: hyperdrive.address,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
@@ -5,6 +5,7 @@ import {
   appConfig,
   findBaseToken,
   findToken,
+  findYieldSource,
   HyperdriveConfig,
 } from "@delvtech/hyperdrive-appconfig";
 import { MouseEvent, ReactElement, useState } from "react";
@@ -284,6 +285,12 @@ export function OpenShortForm({
     Date.now() + Number(hyperdrive.poolConfig.positionDuration * 1000n),
   );
 
+  const yieldSource = findYieldSource({
+    hyperdriveAddress: hyperdrive.address,
+    hyperdriveChainId: hyperdrive.chainId,
+    appConfig,
+  });
+
   // Plausible event props
   const formName = "Open Short";
   const chainId = hyperdrive.chainId;
@@ -369,7 +376,7 @@ export function OpenShortForm({
             bottomRightElement={
               vaultRateStatus === "success" && vaultRate ? (
                 <>
-                  {appConfig.yieldSources[hyperdrive.yieldSource].shortName} @{" "}
+                  {yieldSource.shortName} @{" "}
                   {isNewPool
                     ? "✨New✨"
                     : `${formatRate({ rate: vaultRate.netVaultRate })} APY`}
@@ -459,7 +466,7 @@ export function OpenShortForm({
           <PrimaryStat
             label="Exposure Multiplier"
             tooltipContent={`This represents how much exposure you get to ${
-              appConfig.yieldSources[hyperdrive.yieldSource].shortName
+              yieldSource.shortName
             } compared to what you pay to open the short.`}
             value={
               <span className="text-h3 font-bold">{exposureMultiplier}</span>

--- a/apps/hyperdrive-trading/src/ui/markets/PoolDetails.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PoolDetails.tsx
@@ -1,4 +1,8 @@
-import { appConfig, HyperdriveConfig } from "@delvtech/hyperdrive-appconfig";
+import {
+  appConfig,
+  findYieldSource,
+  HyperdriveConfig,
+} from "@delvtech/hyperdrive-appconfig";
 import { ArrowLeftIcon } from "@heroicons/react/16/solid";
 import { Link, useSearch } from "@tanstack/react-router";
 import classNames from "classnames";
@@ -31,6 +35,12 @@ export function PoolDetails({
     hyperdriveAddress: hyperdrive.address,
   });
 
+  const yieldSource = findYieldSource({
+    hyperdriveAddress: hyperdrive.address,
+    hyperdriveChainId: hyperdrive.chainId,
+    appConfig,
+  });
+
   return (
     <div className="flex w-[515px] flex-col gap-9">
       <div className="flex flex-col gap-4">
@@ -43,7 +53,7 @@ export function PoolDetails({
         </Link>
         <h1 className="flex items-center gap-2 text-h2">
           <AssetStack hyperdriveAddress={hyperdrive.address} />
-          {appConfig.yieldSources[hyperdrive.yieldSource].shortName}
+          {yieldSource.shortName}
         </h1>
         {marketState?.isPaused && (
           <CustomBanner description="This market has been paused. You may close your positions, but no new positions may be opened." />

--- a/apps/hyperdrive-trading/src/ui/markets/PoolRow/PoolRow.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PoolRow/PoolRow.tsx
@@ -3,6 +3,7 @@ import {
   appConfig,
   findBaseToken,
   findToken,
+  findYieldSource,
   HyperdriveConfig,
 } from "@delvtech/hyperdrive-appconfig";
 import { ClockIcon } from "@heroicons/react/16/solid";
@@ -25,7 +26,7 @@ export interface PoolRowProps {
 
 export function PoolRow({ hyperdrive }: PoolRowProps): ReactElement {
   const navigate = useNavigate();
-  const { yieldSources, chains } = appConfig;
+  const { chains } = appConfig;
   const chainInfo = chains[hyperdrive.chainId];
 
   const baseToken = findBaseToken({
@@ -66,6 +67,11 @@ export function PoolRow({ hyperdrive }: PoolRowProps): ReactElement {
       decimals: hyperdrive.decimals,
     })}`;
   }
+  const yieldSource = findYieldSource({
+    hyperdriveAddress: hyperdrive.address,
+    hyperdriveChainId: hyperdrive.chainId,
+    appConfig,
+  });
 
   return (
     <Well
@@ -95,9 +101,7 @@ export function PoolRow({ hyperdrive }: PoolRowProps): ReactElement {
             <AssetStack hyperdriveAddress={hyperdrive.address} />
           </div>
           <div className="flex flex-col gap-1.5">
-            <h4 className="text-left">
-              {yieldSources[hyperdrive.yieldSource].shortName}
-            </h4>
+            <h4 className="text-left">{yieldSource.shortName}</h4>
             <div className="flex flex-wrap gap-5 gap-y-20">
               <div className="flex items-center gap-1.5 text-sm">
                 <ClockIcon className="size-4 text-gray-400/60" />{" "}

--- a/packages/hyperdrive-appconfig/package.json
+++ b/packages/hyperdrive-appconfig/package.json
@@ -39,7 +39,6 @@
     "lodash.camelcase": "^4.3.0",
     "lodash.uniqby": "^4.7.0",
     "prettier-plugin-organize-imports": "3.2.4",
-    "ts-node": "^10.9.1",
     "tsconfig-paths": "^4.1.0",
     "tsup": "^7.2.0",
     "tsx": "^4.7.0",

--- a/packages/hyperdrive-appconfig/src/hyperdrives/HyperdriveConfig.ts
+++ b/packages/hyperdrive-appconfig/src/hyperdrives/HyperdriveConfig.ts
@@ -1,5 +1,5 @@
 import { PoolConfig } from "@delvtech/hyperdrive-viem";
-import { yieldSources } from "src/yieldSources/yieldSources";
+import { YieldSourceId } from "src/yieldSources/types";
 import { Address } from "viem";
 
 export interface HyperdriveConfig {
@@ -15,7 +15,7 @@ export interface HyperdriveConfig {
   /**
    * The yield source backing the pool,
    */
-  yieldSource: keyof typeof yieldSources;
+  yieldSource: YieldSourceId;
 
   depositOptions: {
     /**

--- a/packages/hyperdrive-appconfig/src/hyperdrives/selectors.ts
+++ b/packages/hyperdrive-appconfig/src/hyperdrives/selectors.ts
@@ -2,6 +2,7 @@ import { AppConfig } from "src/appconfig/AppConfig";
 import { HyperdriveConfig } from "src/hyperdrives/HyperdriveConfig";
 import { findToken } from "src/tokens/selectors";
 import { TokenConfig } from "src/tokens/types";
+import { YieldSourceConfig } from "src/yieldSources/types";
 import { Address, zeroAddress } from "viem";
 
 /**
@@ -30,6 +31,27 @@ export function findHyperdriveConfig({
   }
 
   return hyperdriveConfig;
+}
+
+/**
+ * Finds the YieldSourceConfig for a given hyperdrive
+ */
+export function findYieldSource({
+  hyperdriveChainId,
+  hyperdriveAddress,
+  appConfig,
+}: {
+  hyperdriveChainId: number;
+  hyperdriveAddress: Address;
+  appConfig: AppConfig;
+}): YieldSourceConfig {
+  const hyperdriveConfig = findHyperdriveConfig({
+    hyperdriveChainId: hyperdriveChainId,
+    hyperdriveAddress,
+    hyperdrives: appConfig.hyperdrives,
+  });
+
+  return appConfig.yieldSources[hyperdriveConfig.yieldSource];
 }
 
 /**

--- a/packages/hyperdrive-appconfig/src/hyperdrives/selectors.ts
+++ b/packages/hyperdrive-appconfig/src/hyperdrives/selectors.ts
@@ -31,6 +31,7 @@ export function findHyperdriveConfig({
 
   return hyperdriveConfig;
 }
+
 /**
  * Retrieves the base token associated with a specific Hyperdrive address. This
  * token is used to denominate both `vaultSharePrice` and `lpSharePrice`, and

--- a/packages/hyperdrive-appconfig/src/index.ts
+++ b/packages/hyperdrive-appconfig/src/index.ts
@@ -28,7 +28,7 @@ export {
 export type { TokenConfig } from "src/tokens/types";
 
 // yield sources
-export type { YieldSource, YieldSourceId } from "src/yieldSources/types";
+export type { YieldSourceConfig, YieldSourceId } from "src/yieldSources/types";
 export { yieldSources } from "src/yieldSources/yieldSources";
 
 // rewards

--- a/packages/hyperdrive-appconfig/src/index.ts
+++ b/packages/hyperdrive-appconfig/src/index.ts
@@ -22,13 +22,6 @@ export { findToken } from "src/tokens/selectors";
 export type { HyperdriveConfig } from "src/hyperdrives/HyperdriveConfig";
 
 // tokens
-export {
-  AERO_ICON_URL,
-  EETH_ICON_URL,
-  EURC_ICON_URL,
-  USDC_ICON_URL,
-  WELL_ICON_URL,
-} from "src/tokens/tokenIconsUrls";
 export type { TokenConfig } from "src/tokens/types";
 
 // yield sources

--- a/packages/hyperdrive-appconfig/src/index.ts
+++ b/packages/hyperdrive-appconfig/src/index.ts
@@ -11,7 +11,11 @@ export type { ChainConfig } from "src/chains/chains";
 export { isMainnetChain } from "src/chains/isMainnetChain";
 
 // appconfig selectors
-export { findBaseToken, findHyperdriveConfig } from "src/hyperdrives/selectors";
+export {
+  findBaseToken,
+  findHyperdriveConfig,
+  findYieldSource,
+} from "src/hyperdrives/selectors";
 export { findToken } from "src/tokens/selectors";
 
 // hyperdrive
@@ -29,7 +33,6 @@ export type { TokenConfig } from "src/tokens/types";
 
 // yield sources
 export type { YieldSourceConfig, YieldSourceId } from "src/yieldSources/types";
-export { yieldSources } from "src/yieldSources/yieldSources";
 
 // rewards
 export { getRewardsFn } from "src/rewards/selectors";

--- a/packages/hyperdrive-appconfig/src/rewards/selectors.ts
+++ b/packages/hyperdrive-appconfig/src/rewards/selectors.ts
@@ -11,13 +11,10 @@ export function getRewardsFn({
   yieldSourceId,
   appConfig,
 }: {
-  // TODO: change this type to YieldSourceId once YieldSourceId can be used outside
-  // of the appconfig package.k
-  yieldSourceId: string;
+  yieldSourceId: YieldSourceId;
   appConfig: AppConfig;
 }): RewardsResolver | undefined {
-  // casting this for now because YieldSourceId doesn't work outside of the appconfig package
-  const yieldSource = appConfig.yieldSources[yieldSourceId as YieldSourceId];
+  const yieldSource = appConfig.yieldSources[yieldSourceId];
   if (!yieldSource.rewardsFn) {
     return;
   }

--- a/packages/hyperdrive-appconfig/src/yieldSources/base.ts
+++ b/packages/hyperdrive-appconfig/src/yieldSources/base.ts
@@ -2,19 +2,6 @@ import { base } from "viem/chains";
 
 import { YieldSource } from "src/yieldSources/types";
 
-declare module "src/yieldSources/types" {
-  interface YieldSourceIdMap {
-    morphoCbethUsdc: "morphoCbethUsdc";
-    cbeth: "cbeth";
-    mwEth: "mwEth";
-    mwEurc: "mwEurc";
-    mwUsdc: "mwUsdc";
-    stkWell: "stkWell";
-    snars: "snars";
-    aeroUsdcAero: "aeroUsdcAero";
-  }
-}
-
 export const morphoCbethUsdc: YieldSource = {
   chainId: base.id,
   id: "morphoCbethUsdc",

--- a/packages/hyperdrive-appconfig/src/yieldSources/base.ts
+++ b/packages/hyperdrive-appconfig/src/yieldSources/base.ts
@@ -1,8 +1,8 @@
 import { base } from "viem/chains";
 
-import { YieldSource } from "src/yieldSources/types";
+import { YieldSourceConfig } from "src/yieldSources/types";
 
-export const morphoCbethUsdc: YieldSource = {
+export const morphoCbethUsdc: YieldSourceConfig = {
   chainId: base.id,
   id: "morphoCbethUsdc",
   shortName: "Morpho cbETH/USDC",
@@ -11,14 +11,14 @@ export const morphoCbethUsdc: YieldSource = {
   rewardsFn: "fetchMorphoCbethUsdcRewards",
 };
 
-export const cbeth: YieldSource = {
+export const cbeth: YieldSourceConfig = {
   chainId: base.id,
   id: "cbeth",
   shortName: "cbETH",
   protocol: "coinbase",
   historicalRatePeriod: 1,
 };
-export const mwEth: YieldSource = {
+export const mwEth: YieldSourceConfig = {
   chainId: base.id,
   id: "mwEth",
   shortName: "Moonwell Flagship ETH",
@@ -28,7 +28,7 @@ export const mwEth: YieldSource = {
   historicalRatePeriod: 1,
   rewardsFn: "fetchMorphoMwethRewards",
 };
-export const stkWell: YieldSource = {
+export const stkWell: YieldSourceConfig = {
   chainId: base.id,
   id: "stkWell",
   shortName: "Moonwell Staked WELL",
@@ -36,7 +36,7 @@ export const stkWell: YieldSource = {
   historicalRatePeriod: 1,
 };
 
-export const snars: YieldSource = {
+export const snars: YieldSourceConfig = {
   chainId: base.id,
   id: "snars",
   shortName: "Numun Staked nARS",
@@ -44,7 +44,7 @@ export const snars: YieldSource = {
   historicalRatePeriod: 1,
 };
 
-export const mwEurc: YieldSource = {
+export const mwEurc: YieldSourceConfig = {
   chainId: base.id,
   id: "mwEurc",
   shortName: "Moonwell Flagship EURC",
@@ -53,7 +53,7 @@ export const mwEurc: YieldSource = {
   rewardsFn: "fetchMorphoMweurcRewards",
 };
 
-export const mwUsdc: YieldSource = {
+export const mwUsdc: YieldSourceConfig = {
   chainId: base.id,
   id: "mwUsdc",
   shortName: "Moonwell Flagship USDC",
@@ -62,7 +62,7 @@ export const mwUsdc: YieldSource = {
   rewardsFn: "fetchMorphoMwusdcRewards",
 };
 
-export const aeroUsdcAero: YieldSource = {
+export const aeroUsdcAero: YieldSourceConfig = {
   chainId: base.id,
   id: "aeroUsdcAero",
   shortName: "Aerodrome USDC/AERO",

--- a/packages/hyperdrive-appconfig/src/yieldSources/gnosis.ts
+++ b/packages/hyperdrive-appconfig/src/yieldSources/gnosis.ts
@@ -1,7 +1,7 @@
-import { YieldSource } from "src/yieldSources/types";
+import { YieldSourceConfig } from "src/yieldSources/types";
 import { gnosis } from "viem/chains";
 
-export const gnosisWsteth: YieldSource = {
+export const gnosisWsteth: YieldSourceConfig = {
   chainId: gnosis.id,
   id: "gnosisWsteth",
   shortName: "Lido wstETH",
@@ -9,7 +9,7 @@ export const gnosisWsteth: YieldSource = {
   historicalRatePeriod: 1,
 };
 
-export const sxdai: YieldSource = {
+export const sxdai: YieldSourceConfig = {
   chainId: gnosis.id,
   id: "sxdai",
   shortName: "Savings xDAI",
@@ -17,7 +17,7 @@ export const sxdai: YieldSource = {
   historicalRatePeriod: 7,
 };
 
-export const gnosisSgyd: YieldSource = {
+export const gnosisSgyd: YieldSourceConfig = {
   chainId: gnosis.id,
   id: "gnosisSgyd",
   shortName: "Savings GYD",

--- a/packages/hyperdrive-appconfig/src/yieldSources/gnosis.ts
+++ b/packages/hyperdrive-appconfig/src/yieldSources/gnosis.ts
@@ -1,14 +1,6 @@
 import { YieldSource } from "src/yieldSources/types";
 import { gnosis } from "viem/chains";
 
-declare module "src/yieldSources/types" {
-  interface YieldSourceIdMap {
-    gnosisWsteth: "gnosisWsteth";
-    sxdai: "sxdai";
-    gnosisSgyd: "gnosisSgyd";
-  }
-}
-
 export const gnosisWsteth: YieldSource = {
   chainId: gnosis.id,
   id: "gnosisWsteth",

--- a/packages/hyperdrive-appconfig/src/yieldSources/linea.ts
+++ b/packages/hyperdrive-appconfig/src/yieldSources/linea.ts
@@ -1,7 +1,7 @@
-import { YieldSource } from "src/yieldSources/types";
+import { YieldSourceConfig } from "src/yieldSources/types";
 import { linea } from "viem/chains";
 
-export const rseth: YieldSource = {
+export const rseth: YieldSourceConfig = {
   chainId: linea.id,
   id: "rseth",
   shortName: "KelpDAO rsETH",
@@ -9,7 +9,7 @@ export const rseth: YieldSource = {
   historicalRatePeriod: 30,
   rewardsFn: "fetchLineaRewards",
 };
-export const lineaEzeth: YieldSource = {
+export const lineaEzeth: YieldSourceConfig = {
   chainId: linea.id,
   id: "lineaEzeth",
   shortName: "Renzo ezETH",

--- a/packages/hyperdrive-appconfig/src/yieldSources/linea.ts
+++ b/packages/hyperdrive-appconfig/src/yieldSources/linea.ts
@@ -1,13 +1,6 @@
 import { YieldSource } from "src/yieldSources/types";
 import { linea } from "viem/chains";
 
-declare module "src/yieldSources/types" {
-  interface YieldSourceIdMap {
-    rseth: "rseth";
-    lineaEzeth: "lineaEzeth";
-  }
-}
-
 export const rseth: YieldSource = {
   chainId: linea.id,
   id: "rseth",

--- a/packages/hyperdrive-appconfig/src/yieldSources/mainnet.ts
+++ b/packages/hyperdrive-appconfig/src/yieldSources/mainnet.ts
@@ -2,25 +2,6 @@ import { mainnet } from "viem/chains";
 
 import { YieldSource } from "src/yieldSources/types";
 
-declare module "src/yieldSources/types" {
-  interface YieldSourceIdMap {
-    makerDsr: "makerDsr";
-    lidoSteth: "lidoSteth";
-    morphoSusdeDai: "morphoSusdeDai";
-    morphoUsdeDai: "morphoUsdeDai";
-    morphoWstethUsdc: "morphoWstethUsdc";
-    morphoWstethUsda: "morphoWstethUsda";
-    reth: "reth";
-    ezeth: "ezeth";
-    stusd: "stusd";
-    eeth: "eeth";
-    usds: "usds";
-    susds: "susds";
-    susde: "susde";
-    sgyd: "sgyd";
-  }
-}
-
 export const makerDsr: YieldSource = {
   chainId: mainnet.id,
   id: "makerDsr",

--- a/packages/hyperdrive-appconfig/src/yieldSources/mainnet.ts
+++ b/packages/hyperdrive-appconfig/src/yieldSources/mainnet.ts
@@ -1,8 +1,8 @@
 import { mainnet } from "viem/chains";
 
-import { YieldSource } from "src/yieldSources/types";
+import { YieldSourceConfig } from "src/yieldSources/types";
 
-export const makerDsr: YieldSource = {
+export const makerDsr: YieldSourceConfig = {
   chainId: mainnet.id,
   id: "makerDsr",
   shortName: "Maker DSR",
@@ -10,7 +10,7 @@ export const makerDsr: YieldSource = {
   historicalRatePeriod: 1,
 };
 
-export const lidoSteth: YieldSource = {
+export const lidoSteth: YieldSourceConfig = {
   chainId: mainnet.id,
   id: "lidoSteth",
   shortName: "Lido stETH",
@@ -18,21 +18,21 @@ export const lidoSteth: YieldSource = {
   isSharesPeggedToBase: true,
   historicalRatePeriod: 1,
 };
-export const morphoSusdeDai: YieldSource = {
+export const morphoSusdeDai: YieldSourceConfig = {
   chainId: mainnet.id,
   id: "morphoSusdeDai",
   shortName: "Morpho sUSDe/DAI",
   protocol: "morpho",
   historicalRatePeriod: 1,
 };
-export const morphoUsdeDai: YieldSource = {
+export const morphoUsdeDai: YieldSourceConfig = {
   chainId: mainnet.id,
   id: "morphoUsdeDai",
   shortName: "Morpho USDe/DAI",
   protocol: "morpho",
   historicalRatePeriod: 1,
 };
-export const morphoWstethUsdc: YieldSource = {
+export const morphoWstethUsdc: YieldSourceConfig = {
   chainId: mainnet.id,
   id: "morphoWstethUsdc",
   shortName: "Morpho wstETH/USDC",
@@ -40,7 +40,7 @@ export const morphoWstethUsdc: YieldSource = {
   historicalRatePeriod: 1,
 };
 
-export const eeth: YieldSource = {
+export const eeth: YieldSourceConfig = {
   chainId: mainnet.id,
   id: "eeth",
   shortName: "Ether.fi Staked ETH",
@@ -49,7 +49,7 @@ export const eeth: YieldSource = {
   rewardsFn: "fetchEtherfiRewards",
 };
 
-export const morphoWstethUsda: YieldSource = {
+export const morphoWstethUsda: YieldSourceConfig = {
   chainId: mainnet.id,
   id: "morphoWstethUsda",
   shortName: "Morpho wstETH/USDA",
@@ -57,7 +57,7 @@ export const morphoWstethUsda: YieldSource = {
   historicalRatePeriod: 1,
 };
 
-export const reth: YieldSource = {
+export const reth: YieldSourceConfig = {
   chainId: mainnet.id,
   id: "reth",
   shortName: "Rocket Pool ETH",
@@ -65,7 +65,7 @@ export const reth: YieldSource = {
   historicalRatePeriod: 1,
 };
 
-export const ezeth: YieldSource = {
+export const ezeth: YieldSourceConfig = {
   chainId: mainnet.id,
   id: "ezeth",
   shortName: "Renzo ezETH",
@@ -73,7 +73,7 @@ export const ezeth: YieldSource = {
   historicalRatePeriod: 14,
 };
 
-export const stusd: YieldSource = {
+export const stusd: YieldSourceConfig = {
   chainId: mainnet.id,
   id: "stusd",
   shortName: "Angle stUSD",
@@ -81,7 +81,7 @@ export const stusd: YieldSource = {
   historicalRatePeriod: 1,
 };
 
-export const usds: YieldSource = {
+export const usds: YieldSourceConfig = {
   chainId: mainnet.id,
   id: "usds",
   shortName: "Savings USDS",
@@ -89,7 +89,7 @@ export const usds: YieldSource = {
   historicalRatePeriod: 1,
 };
 
-export const susds: YieldSource = {
+export const susds: YieldSourceConfig = {
   chainId: mainnet.id,
   id: "susds",
   shortName: "Staking USDS",
@@ -97,7 +97,7 @@ export const susds: YieldSource = {
   historicalRatePeriod: 1,
 };
 
-export const susde: YieldSource = {
+export const susde: YieldSourceConfig = {
   chainId: mainnet.id,
   id: "susde",
   shortName: "Ethena sUSDe",
@@ -105,7 +105,7 @@ export const susde: YieldSource = {
   historicalRatePeriod: 1,
 };
 
-export const sgyd: YieldSource = {
+export const sgyd: YieldSourceConfig = {
   chainId: mainnet.id,
   id: "sgyd",
   shortName: "Savings GYD",

--- a/packages/hyperdrive-appconfig/src/yieldSources/types.ts
+++ b/packages/hyperdrive-appconfig/src/yieldSources/types.ts
@@ -3,8 +3,9 @@ import { ProtocolId } from "src/protocols";
 import { rewardFunctions } from "src/rewards/rewards";
 
 /**
- * The comprehensive list of all yield source ids. These are used to reference a
- * HyperdriveConfig's yield source.
+ * The comprehensive list of all yield source ids. To add a new yield source,
+ * add the id to this union type, then create the YieldSource object in its
+ * respective file.
  */
 export type YieldSourceId =
   | "morphoCbethUsdc"
@@ -36,7 +37,7 @@ export type YieldSourceId =
   | "sgyd";
 
 // Base interface with common properties
-export interface YieldSource {
+export interface YieldSourceConfig {
   chainId: ChainId;
   id: YieldSourceId;
   shortName: string;

--- a/packages/hyperdrive-appconfig/src/yieldSources/types.ts
+++ b/packages/hyperdrive-appconfig/src/yieldSources/types.ts
@@ -1,16 +1,39 @@
-// This interface is intentionally empty to allow for declaration merging with
-
 import { ChainId } from "src/chains/chains";
 import { ProtocolId } from "src/protocols";
 import { rewardFunctions } from "src/rewards/rewards";
 
-export interface YieldSourceIdMap {
-  // This interface is intentionally empty to allow for declaration merging.
-  // DO NOT MODIFY THIS INTERFACE HERE.
-}
-
-// YieldSourceId is a union of all keys in YieldSourceIdMap
-export type YieldSourceId = keyof YieldSourceIdMap;
+/**
+ * The comprehensive list of all yield source ids. These are used to reference a
+ * HyperdriveConfig's yield source.
+ */
+export type YieldSourceId =
+  | "morphoCbethUsdc"
+  | "cbeth"
+  | "mwEth"
+  | "mwEurc"
+  | "mwUsdc"
+  | "stkWell"
+  | "snars"
+  | "aeroUsdcAero"
+  | "gnosisWsteth"
+  | "sxdai"
+  | "gnosisSgyd"
+  | "rseth"
+  | "lineaEzeth"
+  | "makerDsr"
+  | "lidoSteth"
+  | "morphoSusdeDai"
+  | "morphoUsdeDai"
+  | "morphoWstethUsdc"
+  | "morphoWstethUsda"
+  | "reth"
+  | "ezeth"
+  | "stusd"
+  | "eeth"
+  | "usds"
+  | "susds"
+  | "susde"
+  | "sgyd";
 
 // Base interface with common properties
 export interface YieldSource {

--- a/packages/hyperdrive-appconfig/src/yieldSources/yieldSources.ts
+++ b/packages/hyperdrive-appconfig/src/yieldSources/yieldSources.ts
@@ -26,9 +26,9 @@ import {
   susds,
   usds,
 } from "src/yieldSources/mainnet";
-import { YieldSource, YieldSourceId } from "src/yieldSources/types";
+import { YieldSourceConfig, YieldSourceId } from "src/yieldSources/types";
 
-export const yieldSources: Record<YieldSourceId, YieldSource> = {
+export const yieldSources: Record<YieldSourceId, YieldSourceConfig> = {
   eeth,
   makerDsr,
   lidoSteth,

--- a/packages/hyperdrive-appconfig/src/yieldSources/yieldSources.ts
+++ b/packages/hyperdrive-appconfig/src/yieldSources/yieldSources.ts
@@ -26,8 +26,9 @@ import {
   susds,
   usds,
 } from "src/yieldSources/mainnet";
+import { YieldSource, YieldSourceId } from "src/yieldSources/types";
 
-export const yieldSources = {
+export const yieldSources: Record<YieldSourceId, YieldSource> = {
   eeth,
   makerDsr,
   lidoSteth,
@@ -55,4 +56,4 @@ export const yieldSources = {
   susde,
   sgyd,
   gnosisSgyd,
-} as const;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -16239,7 +16239,7 @@ ts-interface-checker@^0.1.9:
   resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz#784fd3d679722bc103b1b4b8030bcddb5db2a699"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
 
-ts-node@^10.9.1, ts-node@^10.9.2:
+ts-node@^10.9.2:
   version "10.9.2"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.2.tgz#70f021c9e185bccdca820e26dc413805c101c71f"
   integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==


### PR DESCRIPTION
Closes #1637 

This creates a `YieldSourceId` that is strongly typed, avoids circular dependencies in appconfig, and can be used in consumer code without the type getting lost, as we found to be the case when using declaration merging with `tsup`.

While here I also added a `findYieldSource` selector to centralize the way we lookup this info in appconfig. This will make it easy to restructure appconfig as needed without needing to update all the consumers.