### PR TITLE
Unify names and arguments for appconfig selectors

### DIFF
--- a/apps/hyperdrive-trading/src/hyperdrive/getLpApy.ts
+++ b/apps/hyperdrive-trading/src/hyperdrive/getLpApy.ts
@@ -2,8 +2,8 @@ import { Block } from "@delvtech/drift";
 import { fixed } from "@delvtech/fixed-point-wasm";
 import {
   appConfig,
-  findYieldSource,
   getRewardsFn,
+  getYieldSource,
   HyperdriveConfig,
 } from "@delvtech/hyperdrive-appconfig";
 import { ReadHyperdrive } from "@delvtech/hyperdrive-js";
@@ -50,7 +50,7 @@ export async function getLpApy({
   const currentBlock = (await readHyperdrive.drift.getBlock()) as Block;
   const currentBlockNumber = currentBlock.blockNumber!;
   // Appconfig tells us how many days to look back for historical rates
-  const yieldSource = findYieldSource({
+  const yieldSource = getYieldSource({
     hyperdriveAddress: hyperdrive.address,
     hyperdriveChainId: hyperdrive.chainId,
     appConfig,

--- a/apps/hyperdrive-trading/src/hyperdrive/getYieldSourceRate.ts
+++ b/apps/hyperdrive-trading/src/hyperdrive/getYieldSourceRate.ts
@@ -2,9 +2,9 @@ import { Block } from "@delvtech/drift";
 import { fixed } from "@delvtech/fixed-point-wasm";
 import {
   AppConfig,
-  findHyperdriveConfig,
-  findYieldSource,
+  getHyperdriveConfig,
   getRewardsFn,
+  getYieldSource,
   HyperdriveConfig,
 } from "@delvtech/hyperdrive-appconfig";
 import { ReadHyperdrive } from "@delvtech/hyperdrive-js";
@@ -19,10 +19,10 @@ export async function getYieldSourceRate(
   appConfig: AppConfig,
 ): Promise<{ rate: bigint; ratePeriodDays: number; netRate: bigint }> {
   const hyperdriveChainId = await readHyperdrive.drift.getChainId();
-  const hyperdrive = findHyperdriveConfig({
+  const hyperdrive = getHyperdriveConfig({
     hyperdriveChainId,
     hyperdriveAddress: readHyperdrive.address,
-    hyperdrives: appConfig.hyperdrives,
+    appConfig,
   });
 
   const numBlocksForHistoricalRate = getNumBlocksForHistoricalRate({
@@ -67,10 +67,10 @@ export async function getYieldSourceRate(
 
   const netRate = await calcNetRate(rate, appConfig, hyperdrive);
 
-  const yieldSource = findYieldSource({
-    appConfig,
+  const yieldSource = getYieldSource({
     hyperdriveAddress: hyperdrive.address,
     hyperdriveChainId: hyperdrive.chainId,
+    appConfig,
   });
 
   return {
@@ -115,7 +115,7 @@ function getNumBlocksForHistoricalRate({
   hyperdrive: HyperdriveConfig;
 }) {
   const blocksPerDay = appConfig.chains[hyperdrive.chainId].dailyAverageBlocks;
-  const yieldSource = findYieldSource({
+  const yieldSource = getYieldSource({
     hyperdriveAddress: hyperdrive.address,
     hyperdriveChainId: hyperdrive.chainId,
     appConfig,

--- a/apps/hyperdrive-trading/src/token/getTokenFiatPrice.ts
+++ b/apps/hyperdrive-trading/src/token/getTokenFiatPrice.ts
@@ -1,5 +1,5 @@
 import { parseFixed } from "@delvtech/fixed-point-wasm";
-import { appConfig, findToken } from "@delvtech/hyperdrive-appconfig";
+import { appConfig, getToken } from "@delvtech/hyperdrive-appconfig";
 import { fetchCoinGeckoPrice } from "src/token/coingecko";
 import { ETH_MAGIC_NUMBER } from "src/token/ETH_MAGIC_NUMBER";
 import { Address } from "viem";
@@ -26,10 +26,10 @@ export async function getTokenFiatPrice({
   let price = data?.coins?.[defiLlamaTokenId]?.price;
   if (price === undefined) {
     // fallback to coingecko if defillama is not available
-    const tokenConfig = findToken({
+    const tokenConfig = getToken({
       chainId,
       tokenAddress,
-      tokens: appConfig.tokens,
+      appConfig,
     });
     price = await fetchCoinGeckoPrice(tokenConfig!.symbol);
   }

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/TransactionTable/TransactionsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/TransactionTable/TransactionsTable.tsx
@@ -3,7 +3,7 @@ import {
   AppConfig,
   HyperdriveConfig,
   appConfig,
-  findBaseToken,
+  getBaseToken,
   makeAddressUrl,
   makeTransactionUrl,
 } from "@delvtech/hyperdrive-appconfig";
@@ -182,7 +182,7 @@ export function TransactionTable({
 }
 
 function getColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
-  const baseToken = findBaseToken({
+  const baseToken = getBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
@@ -305,7 +305,7 @@ function formatTransactionTableMobileData(
   hyperdrive: HyperdriveConfig,
   appConfig: AppConfig,
 ) {
-  const baseToken = findBaseToken({
+  const baseToken = getBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/TransactionTable/useTransactionData.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/TransactionTable/useTransactionData.ts
@@ -1,7 +1,4 @@
-import {
-  appConfig,
-  findHyperdriveConfig,
-} from "@delvtech/hyperdrive-appconfig";
+import { appConfig, getHyperdriveConfig } from "@delvtech/hyperdrive-appconfig";
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { makeQueryKey } from "src/base/makeQueryKey";
@@ -37,10 +34,10 @@ export function useTransactionData({
     address: hyperdriveAddress,
   });
 
-  const { decimals } = findHyperdriveConfig({
+  const { decimals } = getHyperdriveConfig({
     hyperdriveAddress,
     hyperdriveChainId: chainId,
-    hyperdrives: appConfig.hyperdrives,
+    appConfig,
   });
 
   const { data: longs, status: longEventsStatus } = useQuery({

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useLpApy.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useLpApy.ts
@@ -1,7 +1,4 @@
-import {
-  appConfig,
-  findHyperdriveConfig,
-} from "@delvtech/hyperdrive-appconfig";
+import { appConfig, getHyperdriveConfig } from "@delvtech/hyperdrive-appconfig";
 import { useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { getLpApy, LpApyResult } from "src/hyperdrive/getLpApy";
@@ -25,10 +22,10 @@ export function useLpApy({
     chainId,
   });
 
-  const hyperdrive = findHyperdriveConfig({
+  const hyperdrive = getHyperdriveConfig({
     hyperdriveChainId: chainId,
     hyperdriveAddress,
-    hyperdrives: appConfig.hyperdrives,
+    appConfig,
   });
 
   const { data: blockNumber } = useBlockNumber({ chainId });

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/usePrepareSharesIn.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/usePrepareSharesIn.ts
@@ -1,8 +1,8 @@
 import {
   AppConfig,
   appConfig,
-  findHyperdriveConfig,
-  findYieldSource,
+  getHyperdriveConfig,
+  getYieldSource,
 } from "@delvtech/hyperdrive-appconfig";
 import { ReadHyperdrive } from "@delvtech/hyperdrive-js";
 import { useQuery } from "@tanstack/react-query";
@@ -67,16 +67,16 @@ export async function prepareSharesIn({
   sharesAmount: bigint;
   readHyperdrive: ReadHyperdrive;
 }): Promise<bigint> {
-  const hyperdriveConfig = findHyperdriveConfig({
+  const hyperdriveConfig = getHyperdriveConfig({
     hyperdriveChainId: chainId,
-    hyperdrives: appConfig.hyperdrives,
     hyperdriveAddress: readHyperdrive.address,
+    appConfig,
   });
 
   // If the shares token is pegged to its base token (e.g., stETH to ETH), then
   // we need to treat the amount as if it were base. To get the actual shares
   // amount then, we convert to the shares used by the pool (eg: lidoShares).
-  const yieldSource = findYieldSource({
+  const yieldSource = getYieldSource({
     hyperdriveAddress: hyperdriveConfig.address,
     hyperdriveChainId: hyperdriveConfig.chainId,
     appConfig,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/usePrepareSharesOut.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/usePrepareSharesOut.ts
@@ -1,8 +1,8 @@
 import {
   AppConfig,
   appConfig,
-  findHyperdriveConfig,
-  findYieldSource,
+  getHyperdriveConfig,
+  getYieldSource,
 } from "@delvtech/hyperdrive-appconfig";
 import { ReadHyperdrive } from "@delvtech/hyperdrive-js";
 import { useQuery } from "@tanstack/react-query";
@@ -71,10 +71,10 @@ export async function prepareSharesOut({
     return sharesAmount;
   }
 
-  const hyperdriveConfig = findHyperdriveConfig({
+  const hyperdriveConfig = getHyperdriveConfig({
     hyperdriveChainId: chainId,
-    hyperdrives: appConfig.hyperdrives,
     hyperdriveAddress: readHyperdrive.address,
+    appConfig,
   });
 
   // If the shares token is pegged to its base token (e.g., stETH to ETH), then
@@ -82,7 +82,7 @@ export async function prepareSharesOut({
   // amount then, we convert to base. For example, when preparing lido shares
   // received back from a steth hyperdrive, this will convert lido shares to
   // eth, and since 1 eth = 1 steth we return this as the shares value.
-  const yieldSource = findYieldSource({
+  const yieldSource = getYieldSource({
     hyperdriveAddress: hyperdriveConfig.address,
     hyperdriveChainId: hyperdriveConfig.chainId,
     appConfig,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useReadHyperdrive.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useReadHyperdrive.ts
@@ -1,7 +1,4 @@
-import {
-  appConfig,
-  findHyperdriveConfig,
-} from "@delvtech/hyperdrive-appconfig";
+import { appConfig, getHyperdriveConfig } from "@delvtech/hyperdrive-appconfig";
 import { getHyperdrive, ReadHyperdrive } from "@delvtech/hyperdrive-js";
 import { useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
@@ -26,10 +23,10 @@ export function useReadHyperdrive({
     enabled,
     queryFn: enabled
       ? () => {
-          const { initializationBlock } = findHyperdriveConfig({
+          const { initializationBlock } = getHyperdriveConfig({
             hyperdriveAddress: address,
             hyperdriveChainId: chainId,
-            hyperdrives: appConfig.hyperdrives,
+            appConfig,
           });
           return getHyperdrive({
             address,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useReadWriteHyperdrive.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useReadWriteHyperdrive.ts
@@ -1,7 +1,4 @@
-import {
-  appConfig,
-  findHyperdriveConfig,
-} from "@delvtech/hyperdrive-appconfig";
+import { appConfig, getHyperdriveConfig } from "@delvtech/hyperdrive-appconfig";
 import { getHyperdrive, ReadWriteHyperdrive } from "@delvtech/hyperdrive-js";
 import { useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
@@ -27,10 +24,10 @@ export function useReadWriteHyperdrive({
     enabled,
     queryFn: enabled
       ? () => {
-          const { initializationBlock } = findHyperdriveConfig({
+          const { initializationBlock } = getHyperdriveConfig({
             hyperdriveAddress: address,
             hyperdriveChainId: chainId,
-            hyperdrives: appConfig.hyperdrives,
+            appConfig,
           });
           return getHyperdrive({
             address,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useTradingVolume.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/useTradingVolume.ts
@@ -1,7 +1,4 @@
-import {
-  appConfig,
-  findHyperdriveConfig,
-} from "@delvtech/hyperdrive-appconfig";
+import { appConfig, getHyperdriveConfig } from "@delvtech/hyperdrive-appconfig";
 import { useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
@@ -17,10 +14,10 @@ export function useTradingVolume(
   shortVolume: bigint | undefined;
   tradingVolumeStatus: "loading" | "error" | "success";
 } {
-  const hyperdrive = findHyperdriveConfig({
+  const hyperdrive = getHyperdriveConfig({
     hyperdriveChainId: chainId,
     hyperdriveAddress,
-    hyperdrives: appConfig.hyperdrives,
+    appConfig,
   });
   const readHyperdrive = useReadHyperdrive({
     chainId,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongForm/CloseLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongForm/CloseLongForm.tsx
@@ -1,8 +1,8 @@
 import { fixed } from "@delvtech/fixed-point-wasm";
 import {
   appConfig,
-  findBaseToken,
-  findToken,
+  getBaseToken,
+  getToken,
   HyperdriveConfig,
   TokenConfig,
 } from "@delvtech/hyperdrive-appconfig";
@@ -40,7 +40,7 @@ export function CloseLongForm({
   const { address: account } = useAccount();
 
   const defaultItems: TokenConfig[] = [];
-  const baseToken = findBaseToken({
+  const baseToken = getBaseToken({
     hyperdriveAddress: hyperdrive.address,
     hyperdriveChainId: hyperdrive.chainId,
     appConfig,
@@ -49,10 +49,10 @@ export function CloseLongForm({
     defaultItems.push(baseToken);
   }
 
-  const sharesToken = findToken({
+  const sharesToken = getToken({
     chainId: hyperdrive.chainId,
     tokenAddress: hyperdrive.poolConfig.vaultSharesToken,
-    tokens: appConfig.tokens,
+    appConfig,
   });
   if (hyperdrive.withdrawOptions.isShareTokenWithdrawalEnabled) {
     // Safe to cast: sharesToken must be defined if its enabled for withdrawal

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongModalButton/CloseLongModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongModalButton/CloseLongModalButton.tsx
@@ -2,8 +2,8 @@ import {
   HyperdriveConfig,
   TokenConfig,
   appConfig,
-  findBaseToken,
-  findToken,
+  getBaseToken,
+  getToken,
 } from "@delvtech/hyperdrive-appconfig";
 import { Long } from "@delvtech/hyperdrive-js";
 import { ReactElement } from "react";
@@ -21,15 +21,15 @@ export function CloseLongModalButton({
   long,
   hyperdrive,
 }: CloseLongModalButtonProps): ReactElement {
-  const baseToken = findBaseToken({
+  const baseToken = getBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });
-  const sharesToken = findToken({
+  const sharesToken = getToken({
     chainId: hyperdrive.chainId,
     tokenAddress: hyperdrive.poolConfig.vaultSharesToken,
-    tokens: appConfig.tokens,
+    appConfig,
   });
 
   const subHeading = sharesToken

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
@@ -1,8 +1,8 @@
 import { fixed } from "@delvtech/fixed-point-wasm";
 import {
   appConfig,
-  findBaseToken,
-  findToken,
+  getBaseToken,
+  getToken,
   HyperdriveConfig,
 } from "@delvtech/hyperdrive-appconfig";
 import { adjustAmountByPercentage } from "@delvtech/hyperdrive-js";
@@ -71,7 +71,7 @@ export function OpenLongForm({
     hyperdriveAddress: hyperdrive.address,
     chainId: hyperdrive.chainId,
   });
-  const baseToken = findBaseToken({
+  const baseToken = getBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
@@ -97,10 +97,10 @@ export function OpenLongForm({
     });
   }
 
-  const sharesToken = findToken({
+  const sharesToken = getToken({
     chainId: hyperdrive.chainId,
-    tokens: appConfig.tokens,
     tokenAddress: hyperdrive.poolConfig.vaultSharesToken,
+    appConfig,
   });
 
   if (sharesToken && hyperdrive.depositOptions.isShareTokenDepositsEnabled) {

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongPreview.tsx
@@ -3,7 +3,7 @@ import {
   HyperdriveConfig,
   TokenConfig,
   appConfig,
-  findBaseToken,
+  getBaseToken,
 } from "@delvtech/hyperdrive-appconfig";
 import { ArrowRightIcon } from "@heroicons/react/16/solid";
 import { ChevronDownIcon } from "@heroicons/react/20/solid";
@@ -32,7 +32,7 @@ export function OpenLongPreview({
   spotRateAfterOpen,
   curveFee,
 }: OpenLongPreviewProps): ReactElement {
-  const baseToken = findBaseToken({
+  const baseToken = getBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongStats.tsx
@@ -1,8 +1,8 @@
 import { fixed } from "@delvtech/fixed-point-wasm";
 import {
   appConfig,
-  findBaseToken,
-  findYieldSource,
+  getBaseToken,
+  getYieldSource,
   HyperdriveConfig,
 } from "@delvtech/hyperdrive-appconfig";
 import { calculateAprFromPrice } from "@delvtech/hyperdrive-js";
@@ -34,7 +34,7 @@ export function OpenLongStats({
   asBase,
   vaultSharePrice,
 }: OpenLongStatsProps): JSX.Element {
-  const baseToken = findBaseToken({
+  const baseToken = getBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
@@ -48,7 +48,7 @@ export function OpenLongStats({
     hyperdriveAddress: hyperdrive.address,
   });
 
-  const yieldSource = findYieldSource({
+  const yieldSource = getYieldSource({
     hyperdriveAddress: hyperdrive.address,
     hyperdriveChainId: hyperdrive.chainId,
     appConfig,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/CurrentValueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/CurrentValueCell.tsx
@@ -1,7 +1,7 @@
 import {
   HyperdriveConfig,
   appConfig,
-  findBaseToken,
+  getBaseToken,
 } from "@delvtech/hyperdrive-appconfig";
 import { OpenLongPositionReceived } from "@delvtech/hyperdrive-js";
 import { ExclamationTriangleIcon } from "@heroicons/react/20/solid";
@@ -18,7 +18,7 @@ export function CurrentValueCell({
   row: OpenLongPositionReceived;
   hyperdrive: HyperdriveConfig;
 }): ReactElement {
-  const baseToken = findBaseToken({
+  const baseToken = getBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
@@ -1,8 +1,8 @@
 import {
   AppConfig,
   appConfig,
-  findBaseToken,
-  findToken,
+  getBaseToken,
+  getToken,
   HyperdriveConfig,
 } from "@delvtech/hyperdrive-appconfig";
 import {
@@ -101,15 +101,15 @@ export function OpenLongsContainer(): ReactElement {
             position.hyperdrive.address === hyperdrive.address &&
             position.hyperdrive.chainId === hyperdrive.chainId,
         )?.openLongs;
-        const baseToken = findBaseToken({
+        const baseToken = getBaseToken({
           hyperdriveChainId: hyperdrive.chainId,
           hyperdriveAddress: hyperdrive.address,
           appConfig,
         });
-        const sharesToken = findToken({
+        const sharesToken = getToken({
           chainId: hyperdrive.chainId,
-          tokens: appConfig.tokens,
           tokenAddress: hyperdrive.poolConfig.vaultSharesToken,
+          appConfig,
         });
         // Ensure this hyperdrive pool has open positions before rendering.
         if (openLongPositionsStatus === "success" && !openLongs?.length) {
@@ -318,7 +318,7 @@ function getColumns({
   hyperdrive: HyperdriveConfig;
   appConfig: AppConfig;
 }) {
-  const baseToken = findBaseToken({
+  const baseToken = getBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/TotalOpenLongsValue.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongsTable/TotalOpenLongsValue.tsx
@@ -1,7 +1,7 @@
 import { fixed } from "@delvtech/fixed-point-wasm";
 import {
   appConfig,
-  findBaseToken,
+  getBaseToken,
   HyperdriveConfig,
 } from "@delvtech/hyperdrive-appconfig";
 import { ReactElement } from "react";
@@ -31,7 +31,7 @@ export function TotalOpenLongsValue({
     enabled: openLongsStatus === "success",
     hyperdrive,
   });
-  const baseToken = findBaseToken({
+  const baseToken = getBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useFixedRate.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useFixedRate.ts
@@ -1,8 +1,5 @@
 import { BlockTag } from "@delvtech/drift";
-import {
-  appConfig,
-  findHyperdriveConfig,
-} from "@delvtech/hyperdrive-appconfig";
+import { appConfig, getHyperdriveConfig } from "@delvtech/hyperdrive-appconfig";
 import { getHprFromApr } from "@delvtech/hyperdrive-js";
 import { useQuery } from "@tanstack/react-query";
 
@@ -25,11 +22,10 @@ export function useFixedRate({
   fixedRoi: { roi: bigint; formatted: string } | undefined;
   fixedRateStatus: QueryStatusWithIdle;
 } {
-  const { hyperdrives } = appConfig;
-  const hyperdrive = findHyperdriveConfig({
+  const hyperdrive = getHyperdriveConfig({
     hyperdriveChainId: chainId,
-    hyperdrives,
     hyperdriveAddress,
+    appConfig,
   });
   const readHyperdrive = useReadHyperdrive({
     chainId,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
@@ -3,9 +3,9 @@ import {
   HyperdriveConfig,
   TokenConfig,
   appConfig,
-  findBaseToken,
-  findToken,
-  findYieldSource,
+  getBaseToken,
+  getToken,
+  getYieldSource,
 } from "@delvtech/hyperdrive-appconfig";
 import { adjustAmountByPercentage } from "@delvtech/hyperdrive-js";
 import classNames from "classnames";
@@ -66,14 +66,14 @@ export function AddLiquidityForm({
     chainId: hyperdrive.chainId,
   });
 
-  const baseToken = findBaseToken({
+  const baseToken = getBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });
-  const sharesToken = findToken({
+  const sharesToken = getToken({
     chainId: hyperdrive.chainId,
-    tokens: appConfig.tokens,
+    appConfig,
     tokenAddress: hyperdrive.poolConfig.vaultSharesToken,
   });
 
@@ -458,7 +458,7 @@ function YouReceiveStat({
     chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
   });
-  const baseToken = findBaseToken({
+  const baseToken = getBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
@@ -534,7 +534,7 @@ function LpApyStat({ hyperdrive }: { hyperdrive: HyperdriveConfig }) {
   });
 
   const showSkeleton = !lpApy && lpApyStatus === "loading";
-  const yieldSource = findYieldSource({
+  const yieldSource = getYieldSource({
     hyperdriveAddress: hyperdrive.address,
     hyperdriveChainId: hyperdrive.chainId,
     appConfig,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable.tsx
@@ -1,7 +1,7 @@
 import {
   AppConfig,
   appConfig,
-  findBaseToken,
+  getBaseToken,
   HyperdriveConfig,
 } from "@delvtech/hyperdrive-appconfig";
 import { Link } from "@tanstack/react-router";
@@ -278,10 +278,10 @@ function getColumns({
   hyperdrive: HyperdriveConfig;
   appConfig: AppConfig;
 }) {
-  const baseToken = findBaseToken({
-    appConfig,
+  const baseToken = getBaseToken({
     hyperdriveAddress: hyperdrive.address,
     hyperdriveChainId: hyperdrive.chainId,
+    appConfig,
   });
 
   return [

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/LpAndWithdrawalSharesTable/LpCurrentValueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/LpAndWithdrawalSharesTable/LpCurrentValueCell.tsx
@@ -1,7 +1,7 @@
 import { fixed, parseFixed } from "@delvtech/fixed-point-wasm";
 import {
   appConfig,
-  findBaseToken,
+  getBaseToken,
   HyperdriveConfig,
 } from "@delvtech/hyperdrive-appconfig";
 import classNames from "classnames";
@@ -23,10 +23,10 @@ export function LpCurrentValueCell({
 }): ReactElement {
   const { address: account } = useAccount();
 
-  const baseToken = findBaseToken({
-    appConfig,
+  const baseToken = getBaseToken({
     hyperdriveAddress: hyperdrive.address,
     hyperdriveChainId: hyperdrive.chainId,
+    appConfig,
   });
 
   const { baseAmountPaid, baseValue, openLpPositionStatus } = useOpenLpPosition(

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/LpAndWithdrawalSharesTable/ManageLpAndWithdrawalSharesButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/LpAndWithdrawalSharesTable/ManageLpAndWithdrawalSharesButton.tsx
@@ -1,7 +1,7 @@
 import {
   appConfig,
-  findBaseToken,
-  findToken,
+  getBaseToken,
+  getToken,
   HyperdriveConfig,
 } from "@delvtech/hyperdrive-appconfig";
 import { Cog8ToothIcon } from "@heroicons/react/24/solid";
@@ -31,15 +31,15 @@ export function ManageLpAndWithdrawalSharesButton({
   useClickAway(dropdownRef, () => setIsOpen(false));
   const { address: account } = useAccount();
 
-  const baseToken = findBaseToken({
+  const baseToken = getBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });
-  const sharesToken = findToken({
+  const sharesToken = getToken({
     chainId: hyperdrive.chainId,
     tokenAddress: hyperdrive.poolConfig.vaultSharesToken,
-    tokens: appConfig.tokens,
+    appConfig,
   });
   const { lpShares } = useLpShares({
     hyperdriveAddress: hyperdrive.address,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/LpAndWithdrawalSharesTable/SizeAndPoolShareCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/LpAndWithdrawalSharesTable/SizeAndPoolShareCell.tsx
@@ -1,7 +1,7 @@
 import { fixed } from "@delvtech/fixed-point-wasm";
 import {
   appConfig,
-  findBaseToken,
+  getBaseToken,
   HyperdriveConfig,
 } from "@delvtech/hyperdrive-appconfig";
 import { ReactElement } from "react";
@@ -23,7 +23,7 @@ export function SizeAndPoolShareCell({
       chainId: hyperdrive.chainId,
     });
 
-  const baseToken = findBaseToken({
+  const baseToken = getBaseToken({
     appConfig,
     hyperdriveAddress: hyperdrive.address,
     hyperdriveChainId: hyperdrive.chainId,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/LpAndWithdrawalSharesTable/TotalLpValue.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/LpAndWithdrawalSharesTable/TotalLpValue.tsx
@@ -1,7 +1,7 @@
 import { fixed } from "@delvtech/fixed-point-wasm";
 import {
   appConfig,
-  findBaseToken,
+  getBaseToken,
   HyperdriveConfig,
 } from "@delvtech/hyperdrive-appconfig";
 
@@ -20,7 +20,7 @@ export function TotalLpValue({
 }): ReactElement {
   const { address: account } = useAccount();
   const chainInfo = appConfig.chains[hyperdrive.chainId];
-  const baseToken = findBaseToken({
+  const baseToken = getBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/LpAndWithdrawalSharesTable/WithdrawalQueueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/LpAndWithdrawalSharesTable/WithdrawalQueueCell.tsx
@@ -1,6 +1,6 @@
 import {
   appConfig,
-  findBaseToken,
+  getBaseToken,
   HyperdriveConfig,
 } from "@delvtech/hyperdrive-appconfig";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
@@ -17,7 +17,7 @@ export function WithdrawalQueueCell({
 }): JSX.Element {
   const { address: account } = useAccount();
 
-  const baseToken = findBaseToken({
+  const baseToken = getBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/RemoveLiquidityForm/RemoveLiquidityForm.tsx
@@ -1,8 +1,8 @@
 import { fixed } from "@delvtech/fixed-point-wasm";
 import {
   appConfig,
-  findBaseToken,
-  findToken,
+  getBaseToken,
+  getToken,
   HyperdriveConfig,
 } from "@delvtech/hyperdrive-appconfig";
 import { adjustAmountByPercentage } from "@delvtech/hyperdrive-js";
@@ -47,16 +47,16 @@ export function RemoveLiquidityForm({
 }: RemoveLiquidityFormProps): ReactElement {
   const { address: account } = useAccount();
   const connectedChainId = useChainId();
-  const baseToken = findBaseToken({
+  const baseToken = getBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });
 
-  const sharesToken = findToken({
+  const sharesToken = getToken({
     chainId: hyperdrive.chainId,
-    tokens: appConfig.tokens,
     tokenAddress: hyperdrive.poolConfig.vaultSharesToken,
+    appConfig,
   });
 
   const { balance: baseTokenBalance } = useTokenBalance({

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useOpenLpPosition.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useOpenLpPosition.ts
@@ -1,7 +1,4 @@
-import {
-  appConfig,
-  findHyperdriveConfig,
-} from "@delvtech/hyperdrive-appconfig";
+import { appConfig, getHyperdriveConfig } from "@delvtech/hyperdrive-appconfig";
 import { useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
@@ -35,10 +32,10 @@ export function useOpenLpPosition({
     }),
     queryFn: queryEnabled
       ? () => {
-          const hyperdriveConfig = findHyperdriveConfig({
+          const hyperdriveConfig = getHyperdriveConfig({
             hyperdriveChainId: chainId,
-            hyperdrives: appConfig.hyperdrives,
             hyperdriveAddress,
+            appConfig,
           });
           return readHyperdrive.getOpenLpPosition({
             account,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/usePreviewRedeemWithdrawalShares.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/usePreviewRedeemWithdrawalShares.ts
@@ -1,7 +1,4 @@
-import {
-  appConfig,
-  findHyperdriveConfig,
-} from "@delvtech/hyperdrive-appconfig";
+import { appConfig, getHyperdriveConfig } from "@delvtech/hyperdrive-appconfig";
 import { MutationStatus, useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { prepareSharesOut } from "src/ui/hyperdrive/hooks/usePrepareSharesOut";
@@ -38,10 +35,10 @@ export function usePreviewRedeemWithdrawalShares({
     address: hyperdriveAddress,
   });
 
-  const hyperdriveConfig = findHyperdriveConfig({
+  const hyperdriveConfig = getHyperdriveConfig({
     hyperdriveChainId: chainId,
-    hyperdrives: appConfig.hyperdrives,
     hyperdriveAddress,
+    appConfig,
   });
   const queryEnabled =
     !!withdrawalSharesIn &&

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortForm/CloseShortForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortForm/CloseShortForm.tsx
@@ -1,8 +1,8 @@
 import { fixed } from "@delvtech/fixed-point-wasm";
 import {
   appConfig,
-  findBaseToken,
-  findToken,
+  getBaseToken,
+  getToken,
   HyperdriveConfig,
 } from "@delvtech/hyperdrive-appconfig";
 import { adjustAmountByPercentage, OpenShort } from "@delvtech/hyperdrive-js";
@@ -41,7 +41,7 @@ export function CloseShortForm({
   const { address: account } = useAccount();
   const connectedChainId = useChainId();
   const defaultItems = [];
-  const baseToken = findBaseToken({
+  const baseToken = getBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
@@ -49,10 +49,10 @@ export function CloseShortForm({
   if (hyperdrive.withdrawOptions.isBaseTokenWithdrawalEnabled) {
     defaultItems.push(baseToken);
   }
-  const sharesToken = findToken({
+  const sharesToken = getToken({
     chainId: hyperdrive.chainId,
     tokenAddress: hyperdrive.poolConfig.vaultSharesToken,
-    tokens: appConfig.tokens,
+    appConfig,
   });
   if (sharesToken && hyperdrive.withdrawOptions.isShareTokenWithdrawalEnabled) {
     defaultItems.push(sharesToken);

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortModalButton/CloseShortModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortModalButton/CloseShortModalButton.tsx
@@ -2,8 +2,8 @@ import {
   HyperdriveConfig,
   TokenConfig,
   appConfig,
-  findBaseToken,
-  findToken,
+  getBaseToken,
+  getToken,
 } from "@delvtech/hyperdrive-appconfig";
 import { OpenShort } from "@delvtech/hyperdrive-js";
 import { ReactElement } from "react";
@@ -21,15 +21,15 @@ export function CloseShortModalButton({
   short,
   hyperdrive,
 }: CloseShortModalButtonProps): ReactElement {
-  const baseToken = findBaseToken({
+  const baseToken = getBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });
-  const sharesToken = findToken({
+  const sharesToken = getToken({
     chainId: hyperdrive.chainId,
-    tokens: appConfig.tokens,
     tokenAddress: hyperdrive.poolConfig.vaultSharesToken,
+    appConfig,
   });
   const subHeading = sharesToken
     ? getSubHeadingLabel(baseToken, hyperdrive, sharesToken)

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/ClosedShortsTable/ClosedShortsTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/ClosedShortsTable/ClosedShortsTable.tsx
@@ -2,7 +2,7 @@ import {
   AppConfig,
   HyperdriveConfig,
   appConfig,
-  findBaseToken,
+  getBaseToken,
 } from "@delvtech/hyperdrive-appconfig";
 import { ClosedShort } from "@delvtech/hyperdrive-js";
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/16/solid";
@@ -35,7 +35,7 @@ function formatClosedShortMobileColumnData(
   hyperdrive: HyperdriveConfig,
   appConfig: AppConfig,
 ) {
-  const baseToken = findBaseToken({
+  const baseToken = getBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
@@ -112,7 +112,7 @@ function getMobileColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
 }
 
 function getColumns(hyperdrive: HyperdriveConfig, appConfig: AppConfig) {
-  const baseToken = findBaseToken({
+  const baseToken = getBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
@@ -3,9 +3,9 @@ import { adjustAmountByPercentage } from "@delvtech/hyperdrive-js";
 
 import {
   appConfig,
-  findBaseToken,
-  findToken,
-  findYieldSource,
+  getBaseToken,
+  getToken,
+  getYieldSource,
   HyperdriveConfig,
 } from "@delvtech/hyperdrive-appconfig";
 import { MouseEvent, ReactElement, useState } from "react";
@@ -69,7 +69,7 @@ export function OpenShortForm({
     chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
   });
-  const baseToken = findBaseToken({
+  const baseToken = getBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
@@ -108,9 +108,9 @@ export function OpenShortForm({
     });
   }
 
-  const sharesToken = findToken({
+  const sharesToken = getToken({
     chainId: hyperdrive.chainId,
-    tokens: appConfig.tokens,
+    appConfig,
     tokenAddress: hyperdrive.poolConfig.vaultSharesToken,
   });
 
@@ -285,7 +285,7 @@ export function OpenShortForm({
     Date.now() + Number(hyperdrive.poolConfig.positionDuration * 1000n),
   );
 
-  const yieldSource = findYieldSource({
+  const yieldSource = getYieldSource({
     hyperdriveAddress: hyperdrive.address,
     hyperdriveChainId: hyperdrive.chainId,
     appConfig,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
@@ -2,7 +2,7 @@ import { fixed, parseFixed } from "@delvtech/fixed-point-wasm";
 import {
   HyperdriveConfig,
   appConfig,
-  findBaseToken,
+  getBaseToken,
 } from "@delvtech/hyperdrive-appconfig";
 import { ArrowRightIcon } from "@heroicons/react/16/solid";
 import { ChevronDownIcon } from "@heroicons/react/20/solid";
@@ -37,7 +37,7 @@ export function OpenShortPreview({
 }: OpenShortPreviewProps): ReactElement {
   const [isOpen, setIsOpen] = useState(false);
 
-  const baseToken = findBaseToken({
+  const baseToken = getBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/AccruedYieldCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/AccruedYieldCell.tsx
@@ -1,7 +1,7 @@
 import {
   HyperdriveConfig,
   appConfig,
-  findBaseToken,
+  getBaseToken,
 } from "@delvtech/hyperdrive-appconfig";
 import { OpenShort } from "@delvtech/hyperdrive-js";
 import classNames from "classnames";
@@ -20,7 +20,7 @@ export function AccruedYieldCell({
   const { bondAmount, checkpointTime } = openShort;
   const isTailwindSmallScreen = useIsTailwindSmallScreen();
 
-  const baseToken = findBaseToken({
+  const baseToken = getBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/CurrentShortsValueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/CurrentShortsValueCell.tsx
@@ -1,6 +1,6 @@
 import {
   appConfig,
-  findBaseToken,
+  getBaseToken,
   HyperdriveConfig,
 } from "@delvtech/hyperdrive-appconfig";
 import { OpenShort } from "@delvtech/hyperdrive-js";
@@ -22,7 +22,7 @@ export function CurrentShortsValueCell({
 }): ReactElement {
   const isTailwindSmallScreen = useIsTailwindSmallScreen();
 
-  const baseToken = findBaseToken({
+  const baseToken = getBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/CurrentValueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/CurrentValueCell.tsx
@@ -1,7 +1,7 @@
 import {
   HyperdriveConfig,
   appConfig,
-  findBaseToken,
+  getBaseToken,
 } from "@delvtech/hyperdrive-appconfig";
 import { OpenShort } from "@delvtech/hyperdrive-js";
 import { ExclamationTriangleIcon } from "@heroicons/react/20/solid";
@@ -22,7 +22,7 @@ export function CurrentValueCell({
 }): ReactElement {
   const isTailwindSmallScreen = useIsTailwindSmallScreen();
 
-  const baseToken = findBaseToken({
+  const baseToken = getBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/OpenShortsTableDesktop.tsx
@@ -1,8 +1,8 @@
 import {
   AppConfig,
   appConfig,
-  findBaseToken,
-  findToken,
+  getBaseToken,
+  getToken,
   HyperdriveConfig,
 } from "@delvtech/hyperdrive-appconfig";
 import { OpenShort } from "@delvtech/hyperdrive-js";
@@ -93,15 +93,15 @@ export function OpenShortsContainer(): ReactElement {
   return (
     <div className="mt-10 flex w-[1036px] flex-col gap-10">
       {appConfig.hyperdrives.map((hyperdrive) => {
-        const baseToken = findBaseToken({
+        const baseToken = getBaseToken({
           hyperdriveChainId: hyperdrive.chainId,
           hyperdriveAddress: hyperdrive.address,
           appConfig,
         });
-        const sharesToken = findToken({
+        const sharesToken = getToken({
           chainId: hyperdrive.chainId,
-          tokens: appConfig.tokens,
           tokenAddress: hyperdrive.poolConfig.vaultSharesToken,
+          appConfig,
         });
         const openShorts = openShortPositions?.find(
           (position) =>
@@ -310,7 +310,7 @@ function getColumns({
   hyperdrive: HyperdriveConfig;
   appConfig: AppConfig;
 }) {
-  const baseToken = findBaseToken({
+  const baseToken = getBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/ShortRateAndSizeCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/ShortRateAndSizeCell.tsx
@@ -1,6 +1,6 @@
 import {
   appConfig,
-  findBaseToken,
+  getBaseToken,
   HyperdriveConfig,
 } from "@delvtech/hyperdrive-appconfig";
 import { OpenShort } from "@delvtech/hyperdrive-js";
@@ -18,7 +18,7 @@ export function ShortRateAndSizeCell({
   hyperdrive: HyperdriveConfig;
   short: OpenShort;
 }): ReactElement {
-  const baseToken = findBaseToken({
+  const baseToken = getBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/TotalOpenShortsValue.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortsTable/TotalOpenShortsValue.tsx
@@ -1,7 +1,7 @@
 import { fixed } from "@delvtech/fixed-point-wasm";
 import {
   appConfig,
-  findBaseToken,
+  getBaseToken,
   HyperdriveConfig,
 } from "@delvtech/hyperdrive-appconfig";
 import { ReactElement } from "react";
@@ -31,7 +31,7 @@ export function TotalOpenShortValue({
       shorts: openShorts,
       enabled: openShortsStatus === "success",
     });
-    const baseToken = findBaseToken({
+    const baseToken = getBaseToken({
       hyperdriveChainId: hyperdrive.chainId,
       hyperdriveAddress: hyperdrive.address,
       appConfig,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useShortRate.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useShortRate.ts
@@ -1,7 +1,4 @@
-import {
-  appConfig,
-  findHyperdriveConfig,
-} from "@delvtech/hyperdrive-appconfig";
+import { appConfig, getHyperdriveConfig } from "@delvtech/hyperdrive-appconfig";
 import { getHprFromApr } from "@delvtech/hyperdrive-js";
 import { useQuery } from "@tanstack/react-query";
 import { formatRate } from "src/base/formatRate";
@@ -62,10 +59,10 @@ export function useShortRate({
     enabled: queryEnabled,
     queryFn: queryEnabled
       ? async () => {
-          const hyperdrive = findHyperdriveConfig({
+          const hyperdrive = getHyperdriveConfig({
             hyperdriveChainId: chainId,
             hyperdriveAddress,
-            hyperdrives,
+            appConfig,
           });
           const shortApr = await readHyperdrive.getImpliedRate({
             bondAmount,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/withdrawalShares/OpenWithdrawalSharesCard/OpenWithdrawalSharesCard.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/withdrawalShares/OpenWithdrawalSharesCard/OpenWithdrawalSharesCard.tsx
@@ -1,7 +1,7 @@
 import {
   HyperdriveConfig,
   appConfig,
-  findBaseToken,
+  getBaseToken,
 } from "@delvtech/hyperdrive-appconfig";
 import { ReactElement } from "react";
 import Skeleton from "react-loading-skeleton";
@@ -26,7 +26,7 @@ export function OpenWithdrawalSharesCard({
 }: LpPortfolioCardProps): ReactElement {
   const { address: account } = useAccount();
 
-  const baseToken = findBaseToken({
+  const baseToken = getBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/withdrawalShares/RedeemWithdrawalSharesForm/RedeemWithdrawalSharesForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/withdrawalShares/RedeemWithdrawalSharesForm/RedeemWithdrawalSharesForm.tsx
@@ -1,8 +1,8 @@
 import { fixed } from "@delvtech/fixed-point-wasm";
 import {
   appConfig,
-  findBaseToken,
-  findToken,
+  getBaseToken,
+  getToken,
   HyperdriveConfig,
   TokenConfig,
 } from "@delvtech/hyperdrive-appconfig";
@@ -32,15 +32,15 @@ interface RedeemWithdrawalSharesFormProps {
 export function RedeemWithdrawalSharesForm({
   hyperdrive,
 }: RedeemWithdrawalSharesFormProps): ReactElement {
-  const baseToken = findBaseToken({
+  const baseToken = getBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });
-  const sharesToken = findToken({
+  const sharesToken = getToken({
     chainId: hyperdrive.chainId,
-    tokens: appConfig.tokens,
     tokenAddress: hyperdrive.poolConfig.vaultSharesToken,
+    appConfig,
   });
   const items: TokenConfig[] = [baseToken];
   if (sharesToken) {

--- a/apps/hyperdrive-trading/src/ui/markets/AssetStack.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/AssetStack.tsx
@@ -1,7 +1,7 @@
 import {
   appConfig,
-  findBaseToken,
-  findToken,
+  getBaseToken,
+  getToken,
 } from "@delvtech/hyperdrive-appconfig";
 import { ReactElement } from "react";
 import { Address } from "viem";
@@ -14,15 +14,15 @@ export function AssetStack({
   const hyperdrive = appConfig.hyperdrives.find(
     (hyperdrive) => hyperdrive.address === hyperdriveAddress,
   )!;
-  const baseToken = findBaseToken({
+  const baseToken = getBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });
-  const sharesToken = findToken({
+  const sharesToken = getToken({
     chainId: hyperdrive.chainId,
-    tokens: appConfig.tokens,
     tokenAddress: hyperdrive.poolConfig.vaultSharesToken,
+    appConfig,
   });
   return (
     <div

--- a/apps/hyperdrive-trading/src/ui/markets/Market.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/Market.tsx
@@ -1,7 +1,4 @@
-import {
-  appConfig,
-  findHyperdriveConfig,
-} from "@delvtech/hyperdrive-appconfig";
+import { appConfig, getHyperdriveConfig } from "@delvtech/hyperdrive-appconfig";
 import { useParams } from "@tanstack/react-router";
 import { ReactElement } from "react";
 import { Helmet } from "react-helmet";
@@ -12,10 +9,10 @@ import { Address } from "viem";
 export function Market(): ReactElement {
   const { address, chainId } = useParams({ from: MARKET_DETAILS_ROUTE });
 
-  const hyperdrive = findHyperdriveConfig({
+  const hyperdrive = getHyperdriveConfig({
     hyperdriveChainId: Number(chainId),
-    hyperdrives: appConfig.hyperdrives,
     hyperdriveAddress: address as Address,
+    appConfig,
   });
 
   return (

--- a/apps/hyperdrive-trading/src/ui/markets/PoolDetails.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PoolDetails.tsx
@@ -1,6 +1,6 @@
 import {
   appConfig,
-  findYieldSource,
+  getYieldSource,
   HyperdriveConfig,
 } from "@delvtech/hyperdrive-appconfig";
 import { ArrowLeftIcon } from "@heroicons/react/16/solid";
@@ -35,7 +35,7 @@ export function PoolDetails({
     hyperdriveAddress: hyperdrive.address,
   });
 
-  const yieldSource = findYieldSource({
+  const yieldSource = getYieldSource({
     hyperdriveAddress: hyperdrive.address,
     hyperdriveChainId: hyperdrive.chainId,
     appConfig,

--- a/apps/hyperdrive-trading/src/ui/markets/PoolRow/LpApyStat.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PoolRow/LpApyStat.tsx
@@ -1,8 +1,8 @@
 import { fixed } from "@delvtech/fixed-point-wasm";
 import {
   appConfig,
-  findHyperdriveConfig,
-  findToken,
+  getHyperdriveConfig,
+  getToken,
 } from "@delvtech/hyperdrive-appconfig";
 import { SparklesIcon } from "@heroicons/react/16/solid";
 import { ChartBarIcon } from "@heroicons/react/24/solid";
@@ -21,10 +21,10 @@ export function LpApyStat({
   hyperdriveAddress: Address;
   chainId: number;
 }): ReactNode {
-  const hyperdrive = findHyperdriveConfig({
-    hyperdrives: appConfig.hyperdrives,
+  const hyperdrive = getHyperdriveConfig({
     hyperdriveAddress: hyperdriveAddress,
     hyperdriveChainId: chainId,
+    appConfig,
   });
   const { rewards: appConfigRewards } = useRewards(hyperdrive);
   const { lpApy } = useLpApy({ chainId, hyperdriveAddress });
@@ -99,10 +99,10 @@ export function LpApyStat({
                 );
               }
               if (reward.type === "transferableToken") {
-                const token = findToken({
+                const token = getToken({
                   tokenAddress: reward.tokenAddress,
                   chainId: reward.chainId,
-                  tokens: appConfig.tokens,
+                  appConfig,
                 })!;
 
                 return (
@@ -133,10 +133,10 @@ export function LpApyStat({
               }
 
               if (reward.type === "nonTransferableToken") {
-                const token = findToken({
+                const token = getToken({
                   tokenAddress: reward.tokenAddress,
                   chainId: reward.chainId,
-                  tokens: appConfig.tokens,
+                  appConfig,
                 })!;
                 return (
                   <div

--- a/apps/hyperdrive-trading/src/ui/markets/PoolRow/PoolRow.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PoolRow/PoolRow.tsx
@@ -1,9 +1,9 @@
 import { fixed } from "@delvtech/fixed-point-wasm";
 import {
   appConfig,
-  findBaseToken,
-  findToken,
-  findYieldSource,
+  getBaseToken,
+  getToken,
+  getYieldSource,
   HyperdriveConfig,
 } from "@delvtech/hyperdrive-appconfig";
 import { ClockIcon } from "@heroicons/react/16/solid";
@@ -29,15 +29,15 @@ export function PoolRow({ hyperdrive }: PoolRowProps): ReactElement {
   const { chains } = appConfig;
   const chainInfo = chains[hyperdrive.chainId];
 
-  const baseToken = findBaseToken({
+  const baseToken = getBaseToken({
     hyperdriveChainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
     appConfig,
   });
 
-  const sharesToken = findToken({
+  const sharesToken = getToken({
     chainId: hyperdrive.chainId,
-    tokens: appConfig.tokens,
+    appConfig,
     tokenAddress: hyperdrive.poolConfig.vaultSharesToken,
   });
 
@@ -67,7 +67,7 @@ export function PoolRow({ hyperdrive }: PoolRowProps): ReactElement {
       decimals: hyperdrive.decimals,
     })}`;
   }
-  const yieldSource = findYieldSource({
+  const yieldSource = getYieldSource({
     hyperdriveAddress: hyperdrive.address,
     hyperdriveChainId: hyperdrive.chainId,
     appConfig,

--- a/apps/hyperdrive-trading/src/ui/markets/PoolRow/YieldMultiplierStat.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PoolRow/YieldMultiplierStat.tsx
@@ -1,8 +1,8 @@
 import { fixed } from "@delvtech/fixed-point-wasm";
 import {
   appConfig,
-  findHyperdriveConfig,
-  findToken,
+  getHyperdriveConfig,
+  getToken,
 } from "@delvtech/hyperdrive-appconfig";
 import { SparklesIcon } from "@heroicons/react/16/solid";
 import { ChartBarIcon } from "@heroicons/react/24/solid";
@@ -21,10 +21,10 @@ export function YieldMultiplierStat({
   hyperdriveAddress: Address;
   chainId: number;
 }): ReactNode {
-  const hyperdrive = findHyperdriveConfig({
-    hyperdrives: appConfig.hyperdrives,
+  const hyperdrive = getHyperdriveConfig({
     hyperdriveAddress: hyperdriveAddress,
     hyperdriveChainId: chainId,
+    appConfig,
   });
   const { rewards: appConfigRewards } = useRewards(hyperdrive);
   const { vaultRate: yieldSourceRate } = useYieldSourceRate({
@@ -108,10 +108,10 @@ export function YieldMultiplierStat({
                 );
               }
               if (reward.type === "transferableToken") {
-                const token = findToken({
+                const token = getToken({
                   tokenAddress: reward.tokenAddress,
                   chainId: reward.chainId,
-                  tokens: appConfig.tokens,
+                  appConfig,
                 })!;
 
                 return (
@@ -142,10 +142,10 @@ export function YieldMultiplierStat({
               }
 
               if (reward.type === "nonTransferableToken") {
-                const token = findToken({
+                const token = getToken({
                   tokenAddress: reward.tokenAddress,
                   chainId: reward.chainId,
-                  tokens: appConfig.tokens,
+                  appConfig,
                 })!;
                 return (
                   <div

--- a/apps/hyperdrive-trading/src/ui/markets/PoolsList.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PoolsList.tsx
@@ -1,8 +1,8 @@
 import {
   appConfig,
   ChainConfig,
-  findBaseToken,
-  findToken,
+  getBaseToken,
+  getToken,
   HyperdriveConfig,
   TokenConfig,
 } from "@delvtech/hyperdrive-appconfig";
@@ -366,7 +366,7 @@ function usePoolsList(): {
 function getDepositAssets(hyperdrive: HyperdriveConfig): TokenConfig[] {
   const depositAssets: TokenConfig[] = [];
   if (hyperdrive.depositOptions.isBaseTokenDepositEnabled) {
-    const baseToken = findBaseToken({
+    const baseToken = getBaseToken({
       hyperdriveChainId: hyperdrive.chainId,
       hyperdriveAddress: hyperdrive.address,
       appConfig,
@@ -375,10 +375,10 @@ function getDepositAssets(hyperdrive: HyperdriveConfig): TokenConfig[] {
   }
 
   if (hyperdrive.depositOptions.isShareTokenDepositsEnabled) {
-    const sharesToken = findToken({
+    const sharesToken = getToken({
       chainId: hyperdrive.chainId,
       tokenAddress: hyperdrive.poolConfig.vaultSharesToken,
-      tokens: appConfig.tokens,
+      appConfig,
     });
     if (sharesToken && sharesToken.address !== ZERO_ADDRESS) {
       depositAssets.push(sharesToken);

--- a/apps/hyperdrive-trading/src/ui/token/hooks/useApproveToken.tsx
+++ b/apps/hyperdrive-trading/src/ui/token/hooks/useApproveToken.tsx
@@ -4,7 +4,7 @@ import { queryClient } from "src/network/queryClient";
 import { waitForTransactionAndInvalidateCache } from "src/network/waitForTransactionAndInvalidateCache";
 import { usePublicClient, useWriteContract } from "wagmi";
 
-import { appConfig, findToken } from "@delvtech/hyperdrive-appconfig";
+import { appConfig, getToken } from "@delvtech/hyperdrive-appconfig";
 import { useState } from "react";
 import { MAX_UINT256 } from "src/base/constants";
 import { QueryStatusWithIdle } from "src/base/queryStatus";
@@ -36,10 +36,10 @@ export function useApproveToken({
   const publicClient = usePublicClient({ chainId: tokenChainId });
   const [isTransactionMined, setIsTransactionMined] = useState(false);
   const queryEnabled = !!spender && !!enabled && !!publicClient;
-  const token = findToken({
+  const token = getToken({
     tokenAddress,
-    tokens: appConfig.tokens,
     chainId: tokenChainId,
+    appConfig,
   });
 
   // Pad the approval amount if on sepolia

--- a/packages/hyperdrive-appconfig/src/appconfig/getMainnetAndTestnetAppConfigs.ts
+++ b/packages/hyperdrive-appconfig/src/appconfig/getMainnetAndTestnetAppConfigs.ts
@@ -1,6 +1,6 @@
 import { AppConfig } from "src/appconfig/AppConfig";
 import { isTestnetChain } from "src/chains/isTestnetChain";
-import { findToken } from "src/tokens/selectors";
+import { getToken } from "src/tokens/selectors";
 
 export function getMainnetAndTestnetAppConfigs(appConfig: AppConfig): {
   mainnetConfig: AppConfig;
@@ -58,20 +58,20 @@ export function getMainnetAndTestnetAppConfigs(appConfig: AppConfig): {
       continue;
     }
 
-    const fallbackBaseToken = findToken({
+    const fallbackBaseToken = getToken({
       chainId: hyperdrive.baseTokenFallback.chainId,
       tokenAddress: hyperdrive.baseTokenFallback.address,
-      tokens: appConfig.tokens,
+      appConfig,
     })!;
 
     const targetAppConfig = isTestnetChain(hyperdrive.chainId)
       ? testnetConfig
       : mainnetConfig;
 
-    const fallbackBaseTokenAlreadyExists = !!findToken({
+    const fallbackBaseTokenAlreadyExists = !!getToken({
       chainId: fallbackBaseToken.chainId,
       tokenAddress: fallbackBaseToken.address,
-      tokens: targetAppConfig.tokens,
+      appConfig: targetAppConfig,
     });
 
     if (!fallbackBaseTokenAlreadyExists) {

--- a/packages/hyperdrive-appconfig/src/hyperdrives/selectors.ts
+++ b/packages/hyperdrive-appconfig/src/hyperdrives/selectors.ts
@@ -1,6 +1,6 @@
 import { AppConfig } from "src/appconfig/AppConfig";
 import { HyperdriveConfig } from "src/hyperdrives/HyperdriveConfig";
-import { findToken } from "src/tokens/selectors";
+import { getToken } from "src/tokens/selectors";
 import { TokenConfig } from "src/tokens/types";
 import { YieldSourceConfig } from "src/yieldSources/types";
 import { Address, zeroAddress } from "viem";
@@ -9,16 +9,16 @@ import { Address, zeroAddress } from "viem";
  * Returns a strongly typed HyperdriveConfig for the hyperdrive address and
  * chain id
  */
-export function findHyperdriveConfig({
+export function getHyperdriveConfig({
   hyperdriveChainId,
   hyperdriveAddress,
-  hyperdrives,
+  appConfig,
 }: {
   hyperdriveChainId: number;
   hyperdriveAddress: Address;
-  hyperdrives: HyperdriveConfig[];
+  appConfig: AppConfig;
 }): HyperdriveConfig {
-  const hyperdriveConfig = hyperdrives.find(
+  const hyperdriveConfig = appConfig.hyperdrives.find(
     (hyperdriveConfig) =>
       hyperdriveConfig.address === hyperdriveAddress &&
       hyperdriveConfig.chainId === hyperdriveChainId,
@@ -34,9 +34,9 @@ export function findHyperdriveConfig({
 }
 
 /**
- * Finds the YieldSourceConfig for a given hyperdrive
+ * Gets the YieldSourceConfig for a given hyperdrive
  */
-export function findYieldSource({
+export function getYieldSource({
   hyperdriveChainId,
   hyperdriveAddress,
   appConfig,
@@ -45,10 +45,10 @@ export function findYieldSource({
   hyperdriveAddress: Address;
   appConfig: AppConfig;
 }): YieldSourceConfig {
-  const hyperdriveConfig = findHyperdriveConfig({
+  const hyperdriveConfig = getHyperdriveConfig({
     hyperdriveChainId: hyperdriveChainId,
     hyperdriveAddress,
-    hyperdrives: appConfig.hyperdrives,
+    appConfig,
   });
 
   return appConfig.yieldSources[hyperdriveConfig.yieldSource];
@@ -61,7 +61,7 @@ export function findYieldSource({
  * pool's configuration does not specify a base token (e.g., it is set to the
  * zero address), the function will attempt to return a fallback base token.
  */
-export function findBaseToken({
+export function getBaseToken({
   hyperdriveChainId,
   hyperdriveAddress,
   appConfig,
@@ -70,26 +70,26 @@ export function findBaseToken({
   hyperdriveAddress: Address;
   appConfig: AppConfig;
 }): TokenConfig {
-  const hyperdriveConfig = findHyperdriveConfig({
+  const hyperdriveConfig = getHyperdriveConfig({
     hyperdriveChainId: hyperdriveChainId,
     hyperdriveAddress,
-    hyperdrives: appConfig.hyperdrives,
+    appConfig,
   });
 
   let baseToken: TokenConfig | undefined;
 
   // If there's no base token on pool config, see if there's a fallback
   if (hyperdriveConfig.poolConfig.baseToken !== zeroAddress) {
-    baseToken = findToken({
+    baseToken = getToken({
       chainId: hyperdriveConfig.chainId,
       tokenAddress: hyperdriveConfig.poolConfig.baseToken,
-      tokens: appConfig.tokens,
+      appConfig,
     });
   } else if (hyperdriveConfig.baseTokenFallback) {
-    baseToken = findToken({
+    baseToken = getToken({
       chainId: hyperdriveConfig.baseTokenFallback.chainId,
       tokenAddress: hyperdriveConfig.baseTokenFallback.address,
-      tokens: appConfig.tokens,
+      appConfig,
     });
   }
 

--- a/packages/hyperdrive-appconfig/src/index.ts
+++ b/packages/hyperdrive-appconfig/src/index.ts
@@ -12,11 +12,11 @@ export { isMainnetChain } from "src/chains/isMainnetChain";
 
 // appconfig selectors
 export {
-  findBaseToken,
-  findHyperdriveConfig,
-  findYieldSource,
+  getBaseToken,
+  getHyperdriveConfig,
+  getYieldSource,
 } from "src/hyperdrives/selectors";
-export { findToken } from "src/tokens/selectors";
+export { getToken } from "src/tokens/selectors";
 
 // hyperdrive
 export type { HyperdriveConfig } from "src/hyperdrives/HyperdriveConfig";

--- a/packages/hyperdrive-appconfig/src/scripts/generate.ts
+++ b/packages/hyperdrive-appconfig/src/scripts/generate.ts
@@ -21,7 +21,7 @@ import {
 } from "src/registries";
 import { knownTokenConfigs } from "src/rewards/knownTokenConfigs";
 import { rewardFunctions } from "src/rewards/rewards";
-import { findToken } from "src/tokens/selectors";
+import { getToken } from "src/tokens/selectors";
 import { yieldSources } from "src/yieldSources/yieldSources";
 import { Address, Chain, createPublicClient, http, PublicClient } from "viem";
 import { base, gnosis, linea, mainnet, sepolia } from "viem/chains";
@@ -191,10 +191,10 @@ async function addRewardTokenConfigs({ appConfig }: { appConfig: AppConfig }) {
             reward.type === "transferableToken" ||
             reward.type === "nonTransferableToken"
           ) {
-            const alreadyExists = !!findToken({
+            const alreadyExists = !!getToken({
               chainId: reward.chainId,
               tokenAddress: reward.tokenAddress,
-              tokens: appConfig.tokens,
+              appConfig,
             });
             if (alreadyExists) {
               return;

--- a/packages/hyperdrive-appconfig/src/tokens/selectors.ts
+++ b/packages/hyperdrive-appconfig/src/tokens/selectors.ts
@@ -1,19 +1,20 @@
+import { AppConfig } from "src/appconfig/AppConfig";
 import { TokenConfig } from "src/tokens/types";
 import { Address } from "viem";
 
 /**
  * Returns a strongly typed TokenConfig for the token address if it exists.
  */
-export function findToken({
+export function getToken({
   chainId,
   tokenAddress,
-  tokens,
+  appConfig,
 }: {
   chainId: number;
   tokenAddress: Address;
-  tokens: TokenConfig[];
+  appConfig: AppConfig;
 }): TokenConfig | undefined {
-  const token = tokens.find(
+  const token = appConfig.tokens.find(
     (token) =>
       token.address.toLowerCase() == tokenAddress.toLowerCase() &&
       token.chainId === chainId,


### PR DESCRIPTION
This PR addresses inconsistencies in our appConfig selectors by standardizing their structure:

- **Unified naming convention**: All selectors now use the `getFoo` prefix, replacing the mixed usage of `getFoo` and `findFoo`.
- **Argument consistency**: Selectors now accept the entire `appConfig` object as an argument, eliminating the need for consumers to pass specific slices of `appConfig`.