### PR TITLE
Fix missing TVL on cbETH and wstETH

### DIFF
--- a/apps/hyperdrive-trading/src/ui/markets/PoolRow/PoolRow.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PoolRow/PoolRow.tsx
@@ -50,7 +50,7 @@ export function PoolRow({ hyperdrive }: PoolRowProps): ReactElement {
   const isFiatSupported = !isTestnetChain(chainInfo.id);
   const { fiatPrice } = useTokenFiatPrice({
     chainId: baseToken.chainId,
-    tokenAddress: isFiatSupported ? hyperdrive.poolConfig.baseToken : undefined,
+    tokenAddress: isFiatSupported ? baseToken.address : undefined,
   });
   let tvlLabel = `${formatCompact({
     value: presentValue || 0n,


### PR DESCRIPTION
Closes #1652 

These two pools use a baseTokenFallback to calculate TVL, but we were calling the priceOracle function with the poolConfig's baseToken which is set to the zero address.