### PR TITLE
ensure primary stat text aligned to baseline

### DIFF
--- a/apps/hyperdrive-trading/src/ui/base/components/PrimaryStat.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/PrimaryStat.tsx
@@ -49,12 +49,12 @@ export function PrimaryStat({
         {valueLoading ? (
           <Skeleton width={100} className="h-8" />
         ) : (
-          <>
+          <div className="flex flex-wrap items-baseline">
             {value}
             {valueUnit ? (
               <div className={`ml-1 ${unitClassName}`}>{valueUnit}</div>
             ) : null}
-          </>
+          </div>
         )}
       </div>
       {subValue && (

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongStats.tsx
@@ -102,14 +102,11 @@ export function OpenLongStats({
             <Skeleton width={100} />
           ) : (
             <span
-              className={classNames("flex text-h3 font-bold", {
+              className={classNames("flex items-baseline text-h3 font-bold", {
                 "text-base-content/80": !amountPaid,
               })}
             >
-              <img
-                src={baseToken.iconUrl}
-                className="mr-1 h-9 rounded-full p-1"
-              />
+              <img src={baseToken.iconUrl} className="mr-1 h-8 rounded-full" />
               {`${formatBalance({
                 balance: amountPaidInBase + yieldAtMaturity,
                 decimals: baseToken.decimals,
@@ -119,7 +116,6 @@ export function OpenLongStats({
           )
         }
         valueUnit={`${baseToken.symbol}`}
-        valueContainerClassName="flex items-end flex-wrap"
         subValue={
           // Defillama fetches the token price via {chain}:{tokenAddress}. Since the token address differs on testnet, term length is displayed instead.
 

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
@@ -491,7 +491,7 @@ export function OpenShortForm({
             }
             valueContainerClassName="flex items-end"
             valueUnit="APR"
-            unitClassName="text-xs mb-1 font-bold"
+            unitClassName="mb-1 font-bold"
             subValue={
               <>
                 1 hy{baseToken.symbol} ≈{" "}


### PR DESCRIPTION
This PR ensures all values and valueUnits are aligned to a single baseline and wrapped properly. It also ensures consistency in font sizes for all value units with the exception of the short multiplier. 
![Screenshot 2024-12-02 at 11 42 48 AM](https://github.com/user-attachments/assets/af2a8c3a-9d17-46e8-9ef3-e25e7495d18d)
See design:
https://www.figma.com/design/zyvr6cjxpcXZlrQJCrBrpy/Hyperdrive-Trading-UI?node-id=88-12&m=dev&t=iT6zj1ywQXQYuOhN-1

Closes #1563 