### PR TITLE
Group Open LP Positions by Yield Source and Chain Id

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useTotalOpenLpPositions.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useTotalOpenLpPositions.ts
@@ -45,14 +45,14 @@ export function useTotalOpenLpPositions({
     enabled: queryEnabled,
     queryFn: queryEnabled
       ? async () => {
-          const previews = await Promise.all(
+          const openLpPositionValues = await Promise.all(
             openLpPositions.map(async (position) => {
               const readHyperdrive = await getHyperdrive({
                 address: position.hyperdrive.address,
                 drift: getDrift({ chainId: position.hyperdrive.chainId }),
                 earliestBlock: position.hyperdrive.initializationBlock,
               });
-              const preview = await readHyperdrive.getOpenLpPosition({
+              const openLpPosition = await readHyperdrive.getOpenLpPosition({
                 account,
                 asBase: getHyperdriveConfig({
                   hyperdriveChainId: position.hyperdrive.chainId,
@@ -61,14 +61,14 @@ export function useTotalOpenLpPositions({
                 }).withdrawOptions.isBaseTokenWithdrawalEnabled,
               });
               return {
-                baseValue: preview.baseValue,
+                baseValue: openLpPosition.baseValue,
               };
             }),
           );
 
           let total = 0n;
-          previews.forEach((preview) => {
-            total += preview.baseValue || 0n;
+          openLpPositionValues.forEach((openLpPositionValue) => {
+            total += openLpPositionValue.baseValue || 0n;
           });
 
           return total;

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useTotalOpenLpPositions.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useTotalOpenLpPositions.ts
@@ -11,7 +11,7 @@ import { Address } from "viem";
 export function useTotalOpenLpPositions({
   account,
   openLpPositions,
-  enabled,
+  enabled = true,
 }: {
   account: Address | undefined;
   openLpPositions:

--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesContainer.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesContainer.tsx
@@ -4,16 +4,15 @@ import { ReactElement } from "react";
 import { ExternalLink } from "src/ui/analytics/ExternalLink";
 import LoadingState from "src/ui/base/components/LoadingState";
 import { NonIdealState } from "src/ui/base/components/NonIdealState";
+import { OpenLpTableDesktopTwo } from "src/ui/portfolio/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable";
 import { usePortfolioLpData } from "src/ui/portfolio/lp/usePortfolioLpData";
 import { NoWalletConnected } from "src/ui/portfolio/NoWalletConnected";
 import { PositionContainer } from "src/ui/portfolio/PositionContainer";
 import { useAccount } from "wagmi";
-import { OpenLpTableDesktopTwo } from "./LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable";
 
 export function LpAndWithdrawalSharesContainer(): ReactElement {
   const { openLpPositions, openLpPositionStatus } = usePortfolioLpData();
   const { address: account } = useAccount();
-
   if (!account) {
     return <NoWalletConnected />;
   }
@@ -28,7 +27,6 @@ export function LpAndWithdrawalSharesContainer(): ReactElement {
       </PositionContainer>
     );
   }
-
   if (openLpPositionStatus === "error") {
     return (
       <PositionContainer className="my-28">

--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesContainer.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesContainer.tsx
@@ -14,6 +14,7 @@ export function LpAndWithdrawalSharesContainer(): ReactElement {
   const { openLpPositions, openLpPositionStatus } = usePortfolioLpData();
   const { address: account } = useAccount();
 
+  // Initialize an empty object to group hyperdrives by chainId and yieldSource
   const hyperdrivesByChainAndYieldSource: Record<string, HyperdriveConfig[]> =
     {};
 

--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesContainer.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesContainer.tsx
@@ -1,16 +1,14 @@
-import { appConfig } from "@delvtech/hyperdrive-appconfig";
+import { appConfig, HyperdriveConfig } from "@delvtech/hyperdrive-appconfig";
 import { Link } from "@tanstack/react-router";
 import { ReactElement } from "react";
 import { ExternalLink } from "src/ui/analytics/ExternalLink";
 import LoadingState from "src/ui/base/components/LoadingState";
 import { NonIdealState } from "src/ui/base/components/NonIdealState";
-import { OpenLpTableDesktop } from "src/ui/portfolio/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable";
-import { TotalLpValue } from "src/ui/portfolio/lp/LpAndWithdrawalSharesTable/TotalLpValue";
 import { usePortfolioLpData } from "src/ui/portfolio/lp/usePortfolioLpData";
 import { NoWalletConnected } from "src/ui/portfolio/NoWalletConnected";
 import { PositionContainer } from "src/ui/portfolio/PositionContainer";
-import { PositionTableHeading } from "src/ui/portfolio/PositionTableHeading";
 import { useAccount } from "wagmi";
+import { OpenLpTableDesktopTwo } from "./LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable";
 
 export function LpAndWithdrawalSharesContainer(): ReactElement {
   const { openLpPositions, openLpPositionStatus } = usePortfolioLpData();
@@ -71,9 +69,27 @@ export function LpAndWithdrawalSharesContainer(): ReactElement {
     );
   }
 
+  const hyperdrivesByYieldSource: Record<string, HyperdriveConfig[]> = {};
+  for (const hyperdrive of appConfig.hyperdrives) {
+    const source = hyperdrive.yieldSource;
+    hyperdrivesByYieldSource[source] = hyperdrivesByYieldSource[source] || [];
+    hyperdrivesByYieldSource[source].push(hyperdrive);
+  }
+
   return (
     <PositionContainer className="mt-10">
-      {appConfig.hyperdrives.map((hyperdrive) => {
+      {Object.entries(hyperdrivesByYieldSource).map(
+        ([yieldSource, hyperdrives]) => (
+          <>
+            <h1>{yieldSource}</h1>
+            <OpenLpTableDesktopTwo
+              hyperdrives={hyperdrives}
+              key={yieldSource}
+            />
+          </>
+        ),
+      )}
+      {/* {appConfig.hyperdrives.map((hyperdrive) => {
         const openLpPosition = openLpPositions?.find(
           (position) =>
             position.hyperdrive.address === hyperdrive.address &&
@@ -110,7 +126,7 @@ export function LpAndWithdrawalSharesContainer(): ReactElement {
             />
           </div>
         );
-      })}
+      })} */}
     </PositionContainer>
   );
 }

--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesContainer.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesContainer.tsx
@@ -1,5 +1,6 @@
-import { appConfig, HyperdriveConfig } from "@delvtech/hyperdrive-appconfig";
+import { appConfig } from "@delvtech/hyperdrive-appconfig";
 import { Link } from "@tanstack/react-router";
+import groupBy from "lodash.groupby";
 import { ReactElement } from "react";
 import { ExternalLink } from "src/ui/analytics/ExternalLink";
 import LoadingState from "src/ui/base/components/LoadingState";
@@ -9,22 +10,14 @@ import { usePortfolioLpData } from "src/ui/portfolio/lp/usePortfolioLpData";
 import { NoWalletConnected } from "src/ui/portfolio/NoWalletConnected";
 import { PositionContainer } from "src/ui/portfolio/PositionContainer";
 import { useAccount } from "wagmi";
-
 export function LpAndWithdrawalSharesContainer(): ReactElement {
   const { openLpPositions, openLpPositionStatus } = usePortfolioLpData();
   const { address: account } = useAccount();
 
-  // Initialize an empty object to group hyperdrives by chainId and yieldSource
-  const hyperdrivesByChainAndYieldSource: Record<string, HyperdriveConfig[]> =
-    {};
-
-  for (const hyperdrive of appConfig.hyperdrives) {
-    const key = `${hyperdrive.chainId}-${hyperdrive.yieldSource}`;
-    if (!hyperdrivesByChainAndYieldSource[key]) {
-      hyperdrivesByChainAndYieldSource[key] = [];
-    }
-    hyperdrivesByChainAndYieldSource[key].push(hyperdrive);
-  }
+  const hyperdrivesByChainAndYieldSource = groupBy(
+    appConfig.hyperdrives,
+    (hyperdrive) => `${hyperdrive.chainId}-${hyperdrive.yieldSource}`,
+  );
 
   if (!account) {
     return <NoWalletConnected />;

--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesContainer.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesContainer.tsx
@@ -4,7 +4,7 @@ import { ReactElement } from "react";
 import { ExternalLink } from "src/ui/analytics/ExternalLink";
 import LoadingState from "src/ui/base/components/LoadingState";
 import { NonIdealState } from "src/ui/base/components/NonIdealState";
-import { OpenLpTableDesktopTwo } from "src/ui/portfolio/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable";
+import { OpenLpTableDesktop } from "src/ui/portfolio/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable";
 import { usePortfolioLpData } from "src/ui/portfolio/lp/usePortfolioLpData";
 import { NoWalletConnected } from "src/ui/portfolio/NoWalletConnected";
 import { PositionContainer } from "src/ui/portfolio/PositionContainer";
@@ -13,6 +13,18 @@ import { useAccount } from "wagmi";
 export function LpAndWithdrawalSharesContainer(): ReactElement {
   const { openLpPositions, openLpPositionStatus } = usePortfolioLpData();
   const { address: account } = useAccount();
+
+  const hyperdrivesByChainAndYieldSource: Record<string, HyperdriveConfig[]> =
+    {};
+
+  for (const hyperdrive of appConfig.hyperdrives) {
+    const key = `${hyperdrive.chainId}-${hyperdrive.yieldSource}`;
+    if (!hyperdrivesByChainAndYieldSource[key]) {
+      hyperdrivesByChainAndYieldSource[key] = [];
+    }
+    hyperdrivesByChainAndYieldSource[key].push(hyperdrive);
+  }
+
   if (!account) {
     return <NoWalletConnected />;
   }
@@ -69,22 +81,11 @@ export function LpAndWithdrawalSharesContainer(): ReactElement {
     );
   }
 
-  const hyperdrivesByChainAndYieldSource: Record<string, HyperdriveConfig[]> =
-    {};
-
-  for (const hyperdrive of appConfig.hyperdrives) {
-    const key = `${hyperdrive.chainId}-${hyperdrive.yieldSource}`;
-    if (!hyperdrivesByChainAndYieldSource[key]) {
-      hyperdrivesByChainAndYieldSource[key] = [];
-    }
-    hyperdrivesByChainAndYieldSource[key].push(hyperdrive);
-  }
-
   return (
     <PositionContainer className="mt-10">
       {Object.entries(hyperdrivesByChainAndYieldSource).map(
         ([key, hyperdrives]) => (
-          <OpenLpTableDesktopTwo hyperdrives={hyperdrives} key={key} />
+          <OpenLpTableDesktop hyperdrives={hyperdrives} key={key} />
         ),
       )}
     </PositionContainer>

--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesContainer.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesContainer.tsx
@@ -81,7 +81,6 @@ export function LpAndWithdrawalSharesContainer(): ReactElement {
       {Object.entries(hyperdrivesByYieldSource).map(
         ([yieldSource, hyperdrives]) => (
           <>
-            <h1>{yieldSource}</h1>
             <OpenLpTableDesktopTwo
               hyperdrives={hyperdrives}
               key={yieldSource}

--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesContainer.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesContainer.tsx
@@ -13,6 +13,7 @@ import { OpenLpTableDesktopTwo } from "./LpAndWithdrawalSharesTable/LpAndWithdra
 export function LpAndWithdrawalSharesContainer(): ReactElement {
   const { openLpPositions, openLpPositionStatus } = usePortfolioLpData();
   const { address: account } = useAccount();
+
   if (!account) {
     return <NoWalletConnected />;
   }
@@ -27,6 +28,7 @@ export function LpAndWithdrawalSharesContainer(): ReactElement {
       </PositionContainer>
     );
   }
+
   if (openLpPositionStatus === "error") {
     return (
       <PositionContainer className="my-28">
@@ -69,63 +71,24 @@ export function LpAndWithdrawalSharesContainer(): ReactElement {
     );
   }
 
-  const hyperdrivesByYieldSource: Record<string, HyperdriveConfig[]> = {};
+  const hyperdrivesByChainAndYieldSource: Record<string, HyperdriveConfig[]> =
+    {};
+
   for (const hyperdrive of appConfig.hyperdrives) {
-    const source = hyperdrive.yieldSource;
-    hyperdrivesByYieldSource[source] = hyperdrivesByYieldSource[source] || [];
-    hyperdrivesByYieldSource[source].push(hyperdrive);
+    const key = `${hyperdrive.chainId}-${hyperdrive.yieldSource}`;
+    if (!hyperdrivesByChainAndYieldSource[key]) {
+      hyperdrivesByChainAndYieldSource[key] = [];
+    }
+    hyperdrivesByChainAndYieldSource[key].push(hyperdrive);
   }
 
   return (
     <PositionContainer className="mt-10">
-      {Object.entries(hyperdrivesByYieldSource).map(
-        ([yieldSource, hyperdrives]) => (
-          <>
-            <OpenLpTableDesktopTwo
-              hyperdrives={hyperdrives}
-              key={yieldSource}
-            />
-          </>
+      {Object.entries(hyperdrivesByChainAndYieldSource).map(
+        ([key, hyperdrives]) => (
+          <OpenLpTableDesktopTwo hyperdrives={hyperdrives} key={key} />
         ),
       )}
-      {/* {appConfig.hyperdrives.map((hyperdrive) => {
-        const openLpPosition = openLpPositions?.find(
-          (position) =>
-            position.hyperdrive.address === hyperdrive.address &&
-            position.hyperdrive.chainId === hyperdrive.chainId,
-        ) ?? {
-          lpShares: 0n,
-          withdrawalShares: 0n,
-        };
-
-        // Check if this hyperdrive pool has open positions before rendering
-        if (
-          openLpPosition.lpShares === 0n &&
-          openLpPosition.withdrawalShares === 0n
-        ) {
-          return null;
-        }
-
-        return (
-          <div className="flex flex-col gap-6" key={hyperdrive.address}>
-            <PositionTableHeading
-              hyperdrive={hyperdrive}
-              rightElement={<TotalLpValue hyperdrive={hyperdrive} />}
-              hyperdriveName={
-                // This regex removes the term (eg: "30d") from the hyperdrive
-                // name since it's already shown in the table.
-                // https://regex101.com/r/f4A3th/1
-                hyperdrive.name.replace(/\d{1,3}d/, "")
-              }
-            />
-            <OpenLpTableDesktop
-              hyperdrive={hyperdrive}
-              openLpPosition={openLpPosition}
-              openLpPositionStatus={openLpPositionStatus}
-            />
-          </div>
-        );
-      })} */}
     </PositionContainer>
   );
 }

--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable.tsx
@@ -13,7 +13,6 @@ import {
 import classNames from "classnames";
 import { ReactElement, useMemo } from "react";
 import { convertMillisecondsToDays } from "src/base/convertMillisecondsToDays";
-import LoadingState from "src/ui/base/components/LoadingState";
 import { NonIdealState } from "src/ui/base/components/NonIdealState";
 import { TableSkeleton } from "src/ui/base/components/TableSkeleton";
 import { ConnectWalletButton } from "src/ui/compliance/ConnectWallet";
@@ -22,21 +21,21 @@ import { ManageLpAndWithdrawalSharesButton } from "src/ui/portfolio/lp/LpAndWith
 import { SizeAndPoolShareCell } from "src/ui/portfolio/lp/LpAndWithdrawalSharesTable/SizeAndPoolShareCell";
 import { TotalLpValue } from "src/ui/portfolio/lp/LpAndWithdrawalSharesTable/TotalLpValue";
 import { WithdrawalQueueCell } from "src/ui/portfolio/lp/LpAndWithdrawalSharesTable/WithdrawalQueueCell";
-import { usePortfolioLpDataTwo } from "src/ui/portfolio/lp/usePortfolioLpData";
+import { usePortfolioLpDataFromHyperdrives } from "src/ui/portfolio/lp/usePortfolioLpData";
 import { PositionTableHeading } from "src/ui/portfolio/PositionTableHeading";
 import { useAccount } from "wagmi";
 
-export function OpenLpTableDesktopTwo({
+export function OpenLpTableDesktop({
   hyperdrives,
 }: {
   hyperdrives: HyperdriveConfig[];
 }): ReactElement | null {
   const { address: account } = useAccount();
   const { openLpPositions, openLpPositionStatus } =
-    usePortfolioLpDataTwo(hyperdrives);
+    usePortfolioLpDataFromHyperdrives(hyperdrives);
 
   const columns = useMemo(
-    () => getColumnsTwo({ hyperdrives, appConfig }),
+    () => getColumns({ hyperdrives, appConfig }),
     [hyperdrives],
   );
 
@@ -174,141 +173,13 @@ export function OpenLpTableDesktopTwo({
   );
 }
 
-export function OpenLpTableDesktop({
-  hyperdrive,
-  openLpPosition,
-  openLpPositionStatus,
-}: {
-  hyperdrive: HyperdriveConfig;
-  openLpPosition: { lpShares: bigint; withdrawalShares: bigint };
-  openLpPositionStatus?: "loading" | "success" | "error";
-}): ReactElement {
-  const { address: account } = useAccount();
-
-  const columns = useMemo(
-    () => getColumns({ hyperdrive, appConfig }),
-    [hyperdrive],
-  );
-  const data = useMemo(() => [openLpPosition], [openLpPosition]);
-  const tableInstance = useReactTable({
-    columns,
-    data,
-    getCoreRowModel: getCoreRowModel(),
-  });
-
-  if (!account) {
-    return (
-      <div className="my-28">
-        <NonIdealState
-          heading="No wallet connected"
-          text="Connect your wallet to view your LP Positions"
-          action={<ConnectWalletButton />}
-        />
-      </div>
-    );
-  }
-  if (openLpPositionStatus === "loading" || !openLpPosition) {
-    return (
-      <div className="my-28">
-        <LoadingState
-          heading="Loading your LP Positions..."
-          text="Searching for LP events, calculating current value and PnL..."
-        />
-      </div>
-    );
-  }
-
-  return (
-    <div className="daisy-card overflow-x-clip rounded-box bg-gray-750 pt-3">
-      <table className="daisy-table daisy-table-lg">
-        <thead>
-          {tableInstance.getHeaderGroups().map((headerGroup) => (
-            <tr className="border-b-0" key={headerGroup.id}>
-              {headerGroup.headers.map((header, headerIndex) => (
-                <th
-                  key={header.id}
-                  className={classNames(
-                    "relative z-10 text-sm font-normal text-neutral-content/70",
-                  )}
-                >
-                  <div
-                    className={classNames({
-                      "px-4": headerIndex === 0,
-                      // Right align the headers in the Size, Value, and Withdrawal Queue columns
-                      "flex justify-end": [1, 2, 3].includes(headerIndex),
-                    })}
-                  >
-                    {flexRender(
-                      header.column.columnDef.header,
-                      header.getContext(),
-                    )}
-                  </div>
-                  {/* Custom border with inset for the first and last header cells */}
-                  <span
-                    className={classNames(
-                      "absolute bottom-0 border-b border-neutral-content/20",
-                      {
-                        "left-6 right-0": headerIndex === 0, // Inset border only on the left side for the first header cell
-                        "left-0 right-6":
-                          headerIndex === headerGroup.headers.length - 1, // Inset border only on the right side for the last header cell
-                        "left-0 right-0":
-                          headerIndex !== 0 &&
-                          headerIndex !== headerGroup.headers.length - 1, // Full-width border for other header cells
-                      },
-                    )}
-                  />
-                </th>
-              ))}
-            </tr>
-          ))}
-        </thead>
-        <tbody>
-          {tableInstance.getRowModel().rows.map((row, index) => (
-            <tr
-              key={row.id}
-              className={classNames("h-32 !border-b-0 font-dmMono")}
-            >
-              {row.getVisibleCells().map((cell, cellIndex) => (
-                <td
-                  key={cell.id}
-                  className={classNames("text-xs md:text-md", {
-                    "px-10 pb-10": cellIndex === 0, // Add padding only to the first cell to align with header and the top row data of the next column over
-                    "rounded-b-none":
-                      index === tableInstance.getRowModel().rows.length - 1,
-                    "rounded-bl-box":
-                      index === tableInstance.getRowModel().rows.length - 1 &&
-                      cellIndex === 0,
-                    "rounded-br-box":
-                      index === tableInstance.getRowModel().rows.length - 1 &&
-                      cellIndex === row.getVisibleCells().length - 1,
-                    // Right align the values in the Size, Value, and Withdrawal Queue columns
-                    "text-end":
-                      [1, 2, 3].includes(cellIndex) && cellIndex !== 0,
-                  })}
-                >
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </td>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-  );
-}
-
 const columnHelper = createColumnHelper<{
-  lpShares: bigint;
-  withdrawalShares: bigint;
-}>();
-
-const columnHelperTwo = createColumnHelper<{
   hyperdrive: HyperdriveConfig;
   lpShares: bigint;
   withdrawalShares: bigint;
 }>();
 
-function getColumnsTwo({
+function getColumns({
   hyperdrives,
   appConfig,
 }: {
@@ -321,7 +192,7 @@ function getColumnsTwo({
     appConfig,
   });
   return [
-    columnHelperTwo.accessor("hyperdrive.poolConfig.positionDuration", {
+    columnHelper.accessor("hyperdrive.poolConfig.positionDuration", {
       id: "maturationDate",
       header: `Term`,
       cell: ({ row }) => {
@@ -337,76 +208,12 @@ function getColumnsTwo({
         );
       },
     }),
-    columnHelperTwo.accessor("lpShares", {
-      id: "size",
-      header: `Size (${baseToken?.symbol}-LP)`,
-      cell: ({ row }) => (
-        <SizeAndPoolShareCell
-          hyperdrive={row.original.hyperdrive}
-          lpShares={row.original.lpShares}
-        />
-      ),
-    }),
-    columnHelperTwo.accessor("lpShares", {
-      id: "value",
-      header: `Value (${baseToken?.symbol})`,
-      cell: ({ row }) => (
-        <LpCurrentValueCell
-          hyperdrive={row.original.hyperdrive}
-          lpShares={row.original.lpShares}
-        />
-      ),
-    }),
-    columnHelperTwo.accessor("withdrawalShares", {
-      id: "withdrawalQueue",
-      header: `Withdrawal Queue`,
-      cell: ({ row }) => (
-        <WithdrawalQueueCell hyperdrive={row.original.hyperdrive} />
-      ),
-    }),
-    columnHelperTwo.display({
-      id: "manage",
-      cell: ({ row }) => (
-        <ManageLpAndWithdrawalSharesButton
-          hyperdrive={row.original.hyperdrive}
-        />
-      ),
-    }),
-  ];
-}
-
-function getColumns({
-  hyperdrive,
-  appConfig,
-}: {
-  hyperdrive: HyperdriveConfig;
-  appConfig: AppConfig;
-}) {
-  const baseToken = getBaseToken({
-    hyperdriveAddress: hyperdrive.address,
-    hyperdriveChainId: hyperdrive.chainId,
-    appConfig,
-  });
-
-  return [
-    columnHelper.accessor("lpShares", {
-      id: "maturationDate",
-      header: `Term`,
-      cell: () => (
-        <div>
-          {convertMillisecondsToDays(
-            Number(hyperdrive.poolConfig.positionDuration * 1000n),
-          )}
-          {"-"}Day
-        </div>
-      ),
-    }),
     columnHelper.accessor("lpShares", {
       id: "size",
       header: `Size (${baseToken?.symbol}-LP)`,
       cell: ({ row }) => (
         <SizeAndPoolShareCell
-          hyperdrive={hyperdrive}
+          hyperdrive={row.original.hyperdrive}
           lpShares={row.original.lpShares}
         />
       ),
@@ -416,7 +223,7 @@ function getColumns({
       header: `Value (${baseToken?.symbol})`,
       cell: ({ row }) => (
         <LpCurrentValueCell
-          hyperdrive={hyperdrive}
+          hyperdrive={row.original.hyperdrive}
           lpShares={row.original.lpShares}
         />
       ),
@@ -424,11 +231,17 @@ function getColumns({
     columnHelper.accessor("withdrawalShares", {
       id: "withdrawalQueue",
       header: `Withdrawal Queue`,
-      cell: () => <WithdrawalQueueCell hyperdrive={hyperdrive} />,
+      cell: ({ row }) => (
+        <WithdrawalQueueCell hyperdrive={row.original.hyperdrive} />
+      ),
     }),
     columnHelper.display({
       id: "manage",
-      cell: () => <ManageLpAndWithdrawalSharesButton hyperdrive={hyperdrive} />,
+      cell: ({ row }) => (
+        <ManageLpAndWithdrawalSharesButton
+          hyperdrive={row.original.hyperdrive}
+        />
+      ),
     }),
   ];
 }

--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable.tsx
@@ -75,7 +75,7 @@ export function OpenLpTableDesktop({
   }
 
   return (
-    <>
+    <div className="flex flex-col gap-6">
       <PositionTableHeading
         // We only need the first hyperdrive to get the name and yield source metadata
         hyperdrive={hyperdrives[0]}
@@ -167,7 +167,7 @@ export function OpenLpTableDesktop({
           </tbody>
         </table>
       </div>
-    </>
+    </div>
   );
 }
 

--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable.tsx
@@ -15,6 +15,7 @@ import { ReactElement, useMemo } from "react";
 import { convertMillisecondsToDays } from "src/base/convertMillisecondsToDays";
 import LoadingState from "src/ui/base/components/LoadingState";
 import { NonIdealState } from "src/ui/base/components/NonIdealState";
+import { TableSkeleton } from "src/ui/base/components/TableSkeleton";
 import { ConnectWalletButton } from "src/ui/compliance/ConnectWallet";
 import { LpCurrentValueCell } from "src/ui/portfolio/lp/LpAndWithdrawalSharesTable/LpCurrentValueCell";
 import { ManageLpAndWithdrawalSharesButton } from "src/ui/portfolio/lp/LpAndWithdrawalSharesTable/ManageLpAndWithdrawalSharesButton";
@@ -64,14 +65,7 @@ export function OpenLpTableDesktopTwo({
     );
   }
   if (openLpPositionStatus === "loading" || !openLpPositions) {
-    return (
-      <div className="my-28">
-        <LoadingState
-          heading="Loading your LP Positions..."
-          text="Searching for LP events, calculating current value and PnL..."
-        />
-      </div>
-    );
+    return <TableSkeleton numColumns={columns.length} numRows={5} />;
   }
 
   // If openLpPositions for LpShares and WithdrawalShares are 0, don't render the table

--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable.tsx
@@ -80,6 +80,7 @@ export function OpenLpTableDesktop({
   return (
     <>
       <PositionTableHeading
+        // We only need the first hyperdrive to get the name and yield source metadata
         hyperdrive={hyperdrives[0]}
         rightElement={
           <TotalLpValue

--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable.tsx
@@ -21,6 +21,7 @@ import { ManageLpAndWithdrawalSharesButton } from "src/ui/portfolio/lp/LpAndWith
 import { SizeAndPoolShareCell } from "src/ui/portfolio/lp/LpAndWithdrawalSharesTable/SizeAndPoolShareCell";
 import { WithdrawalQueueCell } from "src/ui/portfolio/lp/LpAndWithdrawalSharesTable/WithdrawalQueueCell";
 import { usePortfolioLpDataTwo } from "src/ui/portfolio/lp/usePortfolioLpData";
+import { PositionTableHeading } from "src/ui/portfolio/PositionTableHeading";
 import { useAccount } from "wagmi";
 
 export function OpenLpTableDesktopTwo({
@@ -37,11 +38,17 @@ export function OpenLpTableDesktopTwo({
     [hyperdrives],
   );
 
+  const tableData = useMemo(
+    () =>
+      (openLpPositions ?? []).filter(
+        (position) => position.lpShares > 0n || position.withdrawalShares > 0n,
+      ),
+    [openLpPositions],
+  );
+
   const tableInstance = useReactTable({
     columns,
-    data: (openLpPositions ?? []).filter(
-      (position) => position.lpShares > 0n || position.withdrawalShares > 0n,
-    ),
+    data: tableData,
     getCoreRowModel: getCoreRowModel(),
   });
   if (!account) {
@@ -77,81 +84,93 @@ export function OpenLpTableDesktopTwo({
   }
 
   return (
-    <div className="daisy-card overflow-x-clip rounded-box bg-gray-750 pt-3">
-      <table className="daisy-table daisy-table-lg">
-        <thead>
-          {tableInstance.getHeaderGroups().map((headerGroup) => (
-            <tr className="border-b-0" key={headerGroup.id}>
-              {headerGroup.headers.map((header, headerIndex) => (
-                <th
-                  key={header.id}
-                  className={classNames(
-                    "relative z-10 text-sm font-normal text-neutral-content/70",
-                  )}
-                >
-                  <div
-                    className={classNames({
-                      "px-4": headerIndex === 0,
-                      // Right align the headers in the Size, Value, and Withdrawal Queue columns
-                      "flex justify-end": [1, 2, 3].includes(headerIndex),
+    <>
+      <PositionTableHeading
+        hyperdrive={hyperdrives[0]}
+        rightElement={null}
+        hyperdriveName={
+          // This regex removes the term (eg: "30d") from the hyperdrive
+          // name since it's already shown in the table.
+          // https://regex101.com/r/f4A3th/1
+          hyperdrives[0].name.replace(/\d{1,3}d/, "")
+        }
+      />
+      <div className="daisy-card overflow-x-clip rounded-box bg-gray-750 pt-3">
+        <table className="daisy-table daisy-table-lg">
+          <thead>
+            {tableInstance.getHeaderGroups().map((headerGroup) => (
+              <tr className="border-b-0" key={headerGroup.id}>
+                {headerGroup.headers.map((header, headerIndex) => (
+                  <th
+                    key={header.id}
+                    className={classNames(
+                      "relative z-10 text-sm font-normal text-neutral-content/70",
+                    )}
+                  >
+                    <div
+                      className={classNames({
+                        "px-4": headerIndex === 0,
+                        // Right align the headers in the Size, Value, and Withdrawal Queue columns
+                        "flex justify-end": [1, 2, 3].includes(headerIndex),
+                      })}
+                    >
+                      {flexRender(
+                        header.column.columnDef.header,
+                        header.getContext(),
+                      )}
+                    </div>
+                    {/* Custom border with inset for the first and last header cells */}
+                    <span
+                      className={classNames(
+                        "absolute bottom-0 border-b border-neutral-content/20",
+                        {
+                          "left-6 right-0": headerIndex === 0, // Inset border only on the left side for the first header cell
+                          "left-0 right-6":
+                            headerIndex === headerGroup.headers.length - 1, // Inset border only on the right side for the last header cell
+                          "left-0 right-0":
+                            headerIndex !== 0 &&
+                            headerIndex !== headerGroup.headers.length - 1, // Full-width border for other header cells
+                        },
+                      )}
+                    />
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {tableInstance.getRowModel().rows.map((row, index) => (
+              <tr
+                key={row.id}
+                className={classNames("h-32 !border-b-0 font-dmMono")}
+              >
+                {row.getVisibleCells().map((cell, cellIndex) => (
+                  <td
+                    key={cell.id}
+                    className={classNames("text-xs md:text-md", {
+                      "px-10 pb-10": cellIndex === 0, // Add padding only to the first cell to align with header and the top row data of the next column over
+                      "rounded-b-none":
+                        index === tableInstance.getRowModel().rows.length - 1,
+                      "rounded-bl-box":
+                        index === tableInstance.getRowModel().rows.length - 1 &&
+                        cellIndex === 0,
+                      "rounded-br-box":
+                        index === tableInstance.getRowModel().rows.length - 1 &&
+                        cellIndex === row.getVisibleCells().length - 1,
+                      // Right align the values in the Size, Value, and Withdrawal Queue columns
+                      "text-end":
+                        [1, 2, 3].includes(cellIndex) && cellIndex !== 0,
                     })}
                   >
-                    {flexRender(
-                      header.column.columnDef.header,
-                      header.getContext(),
-                    )}
-                  </div>
-                  {/* Custom border with inset for the first and last header cells */}
-                  <span
-                    className={classNames(
-                      "absolute bottom-0 border-b border-neutral-content/20",
-                      {
-                        "left-6 right-0": headerIndex === 0, // Inset border only on the left side for the first header cell
-                        "left-0 right-6":
-                          headerIndex === headerGroup.headers.length - 1, // Inset border only on the right side for the last header cell
-                        "left-0 right-0":
-                          headerIndex !== 0 &&
-                          headerIndex !== headerGroup.headers.length - 1, // Full-width border for other header cells
-                      },
-                    )}
-                  />
-                </th>
-              ))}
-            </tr>
-          ))}
-        </thead>
-        <tbody>
-          {tableInstance.getRowModel().rows.map((row, index) => (
-            <tr
-              key={row.id}
-              className={classNames("h-32 !border-b-0 font-dmMono")}
-            >
-              {row.getVisibleCells().map((cell, cellIndex) => (
-                <td
-                  key={cell.id}
-                  className={classNames("text-xs md:text-md", {
-                    "px-10 pb-10": cellIndex === 0, // Add padding only to the first cell to align with header and the top row data of the next column over
-                    "rounded-b-none":
-                      index === tableInstance.getRowModel().rows.length - 1,
-                    "rounded-bl-box":
-                      index === tableInstance.getRowModel().rows.length - 1 &&
-                      cellIndex === 0,
-                    "rounded-br-box":
-                      index === tableInstance.getRowModel().rows.length - 1 &&
-                      cellIndex === row.getVisibleCells().length - 1,
-                    // Right align the values in the Size, Value, and Withdrawal Queue columns
-                    "text-end":
-                      [1, 2, 3].includes(cellIndex) && cellIndex !== 0,
-                  })}
-                >
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </td>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
   );
 }
 

--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable.tsx
@@ -20,11 +20,11 @@ import { ConnectWalletButton } from "src/ui/compliance/ConnectWallet";
 import { LpCurrentValueCell } from "src/ui/portfolio/lp/LpAndWithdrawalSharesTable/LpCurrentValueCell";
 import { ManageLpAndWithdrawalSharesButton } from "src/ui/portfolio/lp/LpAndWithdrawalSharesTable/ManageLpAndWithdrawalSharesButton";
 import { SizeAndPoolShareCell } from "src/ui/portfolio/lp/LpAndWithdrawalSharesTable/SizeAndPoolShareCell";
+import { TotalLpValue } from "src/ui/portfolio/lp/LpAndWithdrawalSharesTable/TotalLpValue";
 import { WithdrawalQueueCell } from "src/ui/portfolio/lp/LpAndWithdrawalSharesTable/WithdrawalQueueCell";
 import { usePortfolioLpDataTwo } from "src/ui/portfolio/lp/usePortfolioLpData";
 import { PositionTableHeading } from "src/ui/portfolio/PositionTableHeading";
 import { useAccount } from "wagmi";
-import { TotalLpValueTwo } from "./TotalLpValue";
 
 export function OpenLpTableDesktopTwo({
   hyperdrives,
@@ -83,7 +83,7 @@ export function OpenLpTableDesktopTwo({
       <PositionTableHeading
         hyperdrive={hyperdrives[0]}
         rightElement={
-          <TotalLpValueTwo
+          <TotalLpValue
             hyperdrive={hyperdrives[0]}
             openLpPositions={openLpPositions}
           />

--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable.tsx
@@ -52,6 +52,7 @@ export function OpenLpTableDesktop({
     data: tableData,
     getCoreRowModel: getCoreRowModel(),
   });
+
   if (!account) {
     return (
       <div className="my-28">
@@ -63,17 +64,13 @@ export function OpenLpTableDesktop({
       </div>
     );
   }
+
   if (openLpPositionStatus === "loading" || !openLpPositions) {
     return <TableSkeleton numColumns={columns.length} numRows={5} />;
   }
 
-  // If openLpPositions for LpShares and WithdrawalShares are 0, don't render the table
-  if (
-    openLpPositions.every(
-      (position) =>
-        position.lpShares === 0n && position.withdrawalShares === 0n,
-    )
-  ) {
+  // Check if there is no data after filtering
+  if (tableData.length === 0) {
     return null;
   }
 

--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable.tsx
@@ -20,7 +20,128 @@ import { LpCurrentValueCell } from "src/ui/portfolio/lp/LpAndWithdrawalSharesTab
 import { ManageLpAndWithdrawalSharesButton } from "src/ui/portfolio/lp/LpAndWithdrawalSharesTable/ManageLpAndWithdrawalSharesButton";
 import { SizeAndPoolShareCell } from "src/ui/portfolio/lp/LpAndWithdrawalSharesTable/SizeAndPoolShareCell";
 import { WithdrawalQueueCell } from "src/ui/portfolio/lp/LpAndWithdrawalSharesTable/WithdrawalQueueCell";
+import { usePortfolioLpDataTwo } from "src/ui/portfolio/lp/usePortfolioLpData";
 import { useAccount } from "wagmi";
+
+export function OpenLpTableDesktopTwo({
+  hyperdrives,
+}: {
+  hyperdrives: HyperdriveConfig[];
+}): ReactElement {
+  const { address: account } = useAccount();
+  const yieldSource = hyperdrives[0].yieldSource;
+  const { openLpPositions, openLpPositionStatus } =
+    usePortfolioLpDataTwo(hyperdrives);
+
+  const columns = useMemo(
+    () => getColumnsTwo({ hyperdrives, appConfig }),
+    [hyperdrives],
+  );
+
+  const tableInstance = useReactTable({
+    columns,
+    data: openLpPositions ?? [],
+    getCoreRowModel: getCoreRowModel(),
+  });
+  if (!account) {
+    return (
+      <div className="my-28">
+        <NonIdealState
+          heading="No wallet connected"
+          text="Connect your wallet to view your LP Positions"
+          action={<ConnectWalletButton />}
+        />
+      </div>
+    );
+  }
+  if (openLpPositionStatus === "loading" || !openLpPositions) {
+    return (
+      <div className="my-28">
+        <LoadingState
+          heading="Loading your LP Positions..."
+          text="Searching for LP events, calculating current value and PnL..."
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="daisy-card overflow-x-clip rounded-box bg-gray-750 pt-3">
+      <table className="daisy-table daisy-table-lg">
+        <thead>
+          {tableInstance.getHeaderGroups().map((headerGroup) => (
+            <tr className="border-b-0" key={headerGroup.id}>
+              {headerGroup.headers.map((header, headerIndex) => (
+                <th
+                  key={header.id}
+                  className={classNames(
+                    "relative z-10 text-sm font-normal text-neutral-content/70",
+                  )}
+                >
+                  <div
+                    className={classNames({
+                      "px-4": headerIndex === 0,
+                      // Right align the headers in the Size, Value, and Withdrawal Queue columns
+                      "flex justify-end": [1, 2, 3].includes(headerIndex),
+                    })}
+                  >
+                    {flexRender(
+                      header.column.columnDef.header,
+                      header.getContext(),
+                    )}
+                  </div>
+                  {/* Custom border with inset for the first and last header cells */}
+                  <span
+                    className={classNames(
+                      "absolute bottom-0 border-b border-neutral-content/20",
+                      {
+                        "left-6 right-0": headerIndex === 0, // Inset border only on the left side for the first header cell
+                        "left-0 right-6":
+                          headerIndex === headerGroup.headers.length - 1, // Inset border only on the right side for the last header cell
+                        "left-0 right-0":
+                          headerIndex !== 0 &&
+                          headerIndex !== headerGroup.headers.length - 1, // Full-width border for other header cells
+                      },
+                    )}
+                  />
+                </th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+      </table>
+      <tbody>
+        {tableInstance.getRowModel().rows.map((row, index) => (
+          <tr
+            key={row.id}
+            className={classNames("h-32 !border-b-0 font-dmMono")}
+          >
+            {row.getVisibleCells().map((cell, cellIndex) => (
+              <td
+                key={cell.id}
+                className={classNames("text-xs md:text-md", {
+                  "px-10 pb-10": cellIndex === 0, // Add padding only to the first cell to align with header and the top row data of the next column over
+                  "rounded-b-none":
+                    index === tableInstance.getRowModel().rows.length - 1,
+                  "rounded-bl-box":
+                    index === tableInstance.getRowModel().rows.length - 1 &&
+                    cellIndex === 0,
+                  "rounded-br-box":
+                    index === tableInstance.getRowModel().rows.length - 1 &&
+                    cellIndex === row.getVisibleCells().length - 1,
+                  // Right align the values in the Size, Value, and Withdrawal Queue columns
+                  "text-end": [1, 2, 3].includes(cellIndex) && cellIndex !== 0,
+                })}
+              >
+                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </div>
+  );
+}
 
 export function OpenLpTableDesktop({
   hyperdrive,
@@ -149,6 +270,39 @@ const columnHelper = createColumnHelper<{
   lpShares: bigint;
   withdrawalShares: bigint;
 }>();
+
+const columnHelperTwo = createColumnHelper<{
+  hyperdrive: HyperdriveConfig;
+  lpShares: bigint;
+  withdrawalShares: bigint;
+}>();
+
+function getColumnsTwo({
+  hyperdrives,
+  appConfig,
+}: {
+  hyperdrives: HyperdriveConfig[];
+  appConfig: AppConfig;
+}) {
+  return [
+    columnHelperTwo.accessor("hyperdrive.poolConfig.positionDuration", {
+      id: "maturationDate",
+      header: `Term`,
+      cell: ({ row }) => {
+        return (
+          <div>
+            {convertMillisecondsToDays(
+              Number(
+                row.original.hyperdrive.poolConfig.positionDuration * 1000n,
+              ),
+            )}
+            {"-"}Day
+          </div>
+        );
+      },
+    }),
+  ];
+}
 
 function getColumns({
   hyperdrive,

--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable.tsx
@@ -23,6 +23,7 @@ import { WithdrawalQueueCell } from "src/ui/portfolio/lp/LpAndWithdrawalSharesTa
 import { usePortfolioLpDataTwo } from "src/ui/portfolio/lp/usePortfolioLpData";
 import { PositionTableHeading } from "src/ui/portfolio/PositionTableHeading";
 import { useAccount } from "wagmi";
+import { TotalLpValueTwo } from "./TotalLpValue";
 
 export function OpenLpTableDesktopTwo({
   hyperdrives,
@@ -87,7 +88,7 @@ export function OpenLpTableDesktopTwo({
     <>
       <PositionTableHeading
         hyperdrive={hyperdrives[0]}
-        rightElement={null}
+        rightElement={<TotalLpValueTwo openLpPositions={openLpPositions} />}
         hyperdriveName={
           // This regex removes the term (eg: "30d") from the hyperdrive
           // name since it's already shown in the table.

--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable.tsx
@@ -88,7 +88,12 @@ export function OpenLpTableDesktopTwo({
     <>
       <PositionTableHeading
         hyperdrive={hyperdrives[0]}
-        rightElement={<TotalLpValueTwo openLpPositions={openLpPositions} />}
+        rightElement={
+          <TotalLpValueTwo
+            hyperdrive={hyperdrives[0]}
+            openLpPositions={openLpPositions}
+          />
+        }
         hyperdriveName={
           // This regex removes the term (eg: "30d") from the hyperdrive
           // name since it's already shown in the table.

--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/TotalLpValue.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/TotalLpValue.tsx
@@ -9,9 +9,31 @@ import { ReactElement } from "react";
 import Skeleton from "react-loading-skeleton";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { useOpenLpPosition } from "src/ui/hyperdrive/lp/hooks/useOpenLpPosition";
+import { useTotalOpenLpPositions } from "src/ui/hyperdrive/lp/hooks/useTotalOpenLpPositions";
 import { useTokenFiatPrice } from "src/ui/token/hooks/useTokenFiatPrice";
 import { useAccount } from "wagmi";
 import { sepolia } from "wagmi/chains";
+
+export function TotalLpValueTwo({
+  openLpPositions,
+}: {
+  openLpPositions:
+    | {
+        hyperdrive: HyperdriveConfig;
+        lpShares: bigint;
+        withdrawalShares: bigint;
+      }[]
+    | undefined;
+}): ReactElement {
+  const { address: account } = useAccount();
+  const { totalOpenLpPositions, isLoading } = useTotalOpenLpPositions({
+    account,
+    openLpPositions,
+    enabled: !!openLpPositions,
+  });
+  console.log("totalOpenLpPositions", totalOpenLpPositions);
+  return <></>;
+}
 
 export function TotalLpValue({
   hyperdrive,

--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/TotalLpValue.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/TotalLpValue.tsx
@@ -15,8 +15,10 @@ import { useAccount } from "wagmi";
 import { sepolia } from "wagmi/chains";
 
 export function TotalLpValueTwo({
+  hyperdrive,
   openLpPositions,
 }: {
+  hyperdrive: HyperdriveConfig;
   openLpPositions:
     | {
         hyperdrive: HyperdriveConfig;
@@ -26,13 +28,50 @@ export function TotalLpValueTwo({
     | undefined;
 }): ReactElement {
   const { address: account } = useAccount();
-  const { totalOpenLpPositions, isLoading } = useTotalOpenLpPositions({
-    account,
-    openLpPositions,
-    enabled: !!openLpPositions,
+  const { totalOpenLpPositions, isLoading: isLoadingTotalOpenLpPositions } =
+    useTotalOpenLpPositions({
+      account,
+      openLpPositions,
+      enabled: !!openLpPositions,
+    });
+  const chainInfo = appConfig.chains[hyperdrive.chainId];
+  const baseToken = getBaseToken({
+    hyperdriveChainId: hyperdrive.chainId,
+    hyperdriveAddress: hyperdrive.address,
+    appConfig,
   });
-  console.log("totalOpenLpPositions", totalOpenLpPositions);
-  return <></>;
+  const { fiatPrice } = useTokenFiatPrice({
+    chainId: baseToken.chainId,
+    tokenAddress: baseToken.address,
+  });
+  const isFiatPriceEnabled = chainInfo.id !== sepolia.id;
+  return (
+    <div className="flex items-center gap-2">
+      <img src={chainInfo.iconUrl} className="size-7 rounded-full" />
+      <p className="flex gap-2 font-dmMono text-h4">
+        {isLoadingTotalOpenLpPositions ? (
+          <Skeleton className="w-24" />
+        ) : isFiatPriceEnabled ? (
+          `$${formatBalance({
+            balance: fiatPrice
+              ? fixed(totalOpenLpPositions ?? 0n, baseToken.decimals).mul(
+                  fiatPrice,
+                  baseToken.decimals,
+                ).bigint
+              : 0n,
+            decimals: hyperdrive.decimals,
+            places: baseToken?.places,
+          })}`
+        ) : (
+          `${formatBalance({
+            balance: totalOpenLpPositions ?? 0n,
+            decimals: hyperdrive.decimals,
+            places: baseToken?.places,
+          })} ${baseToken.symbol}`
+        )}{" "}
+      </p>
+    </div>
+  );
 }
 
 export function TotalLpValue({

--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/TotalLpValue.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/TotalLpValue.tsx
@@ -8,13 +8,12 @@ import {
 import { ReactElement } from "react";
 import Skeleton from "react-loading-skeleton";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
-import { useOpenLpPosition } from "src/ui/hyperdrive/lp/hooks/useOpenLpPosition";
 import { useTotalOpenLpPositions } from "src/ui/hyperdrive/lp/hooks/useTotalOpenLpPositions";
 import { useTokenFiatPrice } from "src/ui/token/hooks/useTokenFiatPrice";
 import { useAccount } from "wagmi";
 import { sepolia } from "wagmi/chains";
 
-export function TotalLpValueTwo({
+export function TotalLpValue({
   hyperdrive,
   openLpPositions,
 }: {
@@ -65,59 +64,6 @@ export function TotalLpValueTwo({
         ) : (
           `${formatBalance({
             balance: totalOpenLpPositions ?? 0n,
-            decimals: hyperdrive.decimals,
-            places: baseToken?.places,
-          })} ${baseToken.symbol}`
-        )}{" "}
-      </p>
-    </div>
-  );
-}
-
-export function TotalLpValue({
-  hyperdrive,
-}: {
-  hyperdrive: HyperdriveConfig;
-}): ReactElement {
-  const { address: account } = useAccount();
-  const chainInfo = appConfig.chains[hyperdrive.chainId];
-  const baseToken = getBaseToken({
-    hyperdriveChainId: hyperdrive.chainId,
-    hyperdriveAddress: hyperdrive.address,
-    appConfig,
-  });
-  const { baseValue, openLpPositionStatus } = useOpenLpPosition({
-    hyperdriveAddress: hyperdrive.address,
-    account,
-    chainId: hyperdrive.chainId,
-  });
-
-  const { fiatPrice } = useTokenFiatPrice({
-    chainId: baseToken.chainId,
-    tokenAddress: baseToken.address,
-  });
-  const isFiatPriceEnabled = chainInfo.id !== sepolia.id;
-
-  return (
-    <div className="flex items-center gap-2">
-      <img src={chainInfo.iconUrl} className="size-7 rounded-full" />
-      <p className="flex gap-2 font-dmMono text-h4">
-        {openLpPositionStatus === "loading" ? (
-          <Skeleton className="w-24" />
-        ) : isFiatPriceEnabled ? (
-          `$${formatBalance({
-            balance: fiatPrice
-              ? fixed(baseValue, baseToken.decimals).mul(
-                  fiatPrice,
-                  baseToken.decimals,
-                ).bigint
-              : 0n,
-            decimals: hyperdrive.decimals,
-            places: baseToken?.places,
-          })}`
-        ) : (
-          `${formatBalance({
-            balance: baseValue,
             decimals: hyperdrive.decimals,
             places: baseToken?.places,
           })} ${baseToken.symbol}`

--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/usePortfolioLpData.ts
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/usePortfolioLpData.ts
@@ -12,7 +12,9 @@ type LpPosition = {
   withdrawalShares: bigint;
 };
 
-export function usePortfolioLpDataTwo(hyperdrives: HyperdriveConfig[]): {
+export function usePortfolioLpDataFromHyperdrives(
+  hyperdrives: HyperdriveConfig[],
+): {
   openLpPositions: LpPosition[] | undefined;
   openLpPositionStatus: "error" | "success" | "loading";
 } {

--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/usePortfolioLpData.ts
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/usePortfolioLpData.ts
@@ -62,6 +62,7 @@ export function usePortfolioLpDataFromHyperdrives(
   };
 }
 
+// TODO: This eventually will need to be removed but it's currently being used at the top level of the LP Portfolio container to determine if there are any LP positions to display.
 export function usePortfolioLpData(): {
   openLpPositions: LpPosition[] | undefined;
   openLpPositionStatus: "error" | "success" | "loading";

--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/usePortfolioLpData.ts
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/usePortfolioLpData.ts
@@ -23,6 +23,7 @@ export function usePortfolioLpDataTwo(hyperdrives: HyperdriveConfig[]): {
       account,
       hyperdrives: hyperdrives.map((h) => ({
         chainId: h.chainId.toString(),
+        address: h.address,
       })),
     }),
     queryFn: queryEnabled


### PR DESCRIPTION
This PR refactors the Open LP position tables on the portfolio to take an array of Hyperdrives grouped by yield source. Previously, each Hyperdrive instance rendered one table with one row if there was an open LP position. By grouping these positions by yield source we can add open position totals to the top of each table. 
<img width="1063" alt="Screenshot 2024-12-04 at 5 13 56 PM" src="https://github.com/user-attachments/assets/05a763a3-7b9a-4a33-9405-b67f68a92d5b">
