### PR TITLE
fixes flex issue on lp

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
@@ -167,7 +167,7 @@ export function AddLiquidityForm({
   const lpSharePrice = !isBaseActiveToken
     ? fixed(poolInfo?.lpSharePrice || 0n, baseToken.decimals).div(
         poolInfo?.vaultSharePrice || 0n,
-        baseToken.decimals,
+        baseToken.decimals
       ).bigint
     : poolInfo?.lpSharePrice || 0n;
 
@@ -253,7 +253,7 @@ export function AddLiquidityForm({
                   balance:
                     activeTokenPrice && depositAmountAsBigInt
                       ? fixed(depositAmountAsBigInt, activeToken.decimals).mul(
-                          activeTokenPrice,
+                          activeTokenPrice
                         ).bigint
                       : 0n,
                   decimals: activeToken.decimals,
@@ -336,19 +336,23 @@ export function AddLiquidityForm({
       }
       primaryStats={
         <div className="flex flex-row justify-between px-4 py-8">
-          <YouReceiveStat
-            addLiquidityPreviewStatus={addLiquidityPreviewStatus}
-            lpSharesOut={lpSharesOut}
-            hyperdrive={hyperdrive}
-          />
+          <div className="flex-1">
+            <YouReceiveStat
+              addLiquidityPreviewStatus={addLiquidityPreviewStatus}
+              lpSharesOut={lpSharesOut}
+              hyperdrive={hyperdrive}
+            />
+          </div>
           <div className="daisy-divider daisy-divider-horizontal mx-0" />
-          <LpApyStat hyperdrive={hyperdrive} />
+          <div className="flex-1">
+            <LpApyStat hyperdrive={hyperdrive} />
+          </div>
         </div>
       }
       disclaimer={(() => {
         if (
           previewAddLiquidityError?.message.includes(
-            "Not enough lp shares minted.",
+            "Not enough lp shares minted."
           )
         ) {
           return (


### PR DESCRIPTION
This PR fixes an overflow bug that we have on Morpho pools when a user LP's. It used to run over into the LP apy primary stat but now properly flexes.

https://github.com/user-attachments/assets/6bbf5da0-f6a4-429b-90ea-da57bea58a46

Closes #1569 