### PR TITLE
Update OpenShortForm to show variable apy and multiplier together 

### DIFF
--- a/apps/hyperdrive-trading/src/ui/base/components/AccordionSection/AccordionSection.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/AccordionSection/AccordionSection.tsx
@@ -4,6 +4,7 @@ import {
   DisclosurePanel,
 } from "@headlessui/react";
 import { ChevronDownIcon } from "@heroicons/react/16/solid";
+import classNames from "classnames";
 import { PropsWithChildren, ReactElement, ReactNode } from "react";
 
 /**
@@ -29,7 +30,9 @@ export function AccordionSection({
         className="min-h-0"
       />
       <div className="daisy-collapse-title mb-3 min-h-0 p-0 font-medium">
-        <div className="flex items-center gap-4">{heading}</div>
+        <div className="flex items-center gap-4 hover:text-white">
+          {heading}
+        </div>
       </div>
       <div className="daisy-collapse-content space-y-2 px-0">{children}</div>
     </div>
@@ -39,10 +42,12 @@ export function AccordionSection({
 export function AccordionSection2({
   heading,
   children,
+  underlined = true,
   onChange,
 }: PropsWithChildren<{
   heading: ReactNode;
   isExpanded?: boolean;
+  underlined?: boolean;
   onChange?: (isOpen?: boolean) => void;
 }>): ReactElement {
   return (
@@ -50,7 +55,9 @@ export function AccordionSection2({
       {({ open }) => (
         <>
           <DisclosureButton
-            className="group flex justify-between border-b border-base-content/10 p-0 pb-2"
+            className={classNames("group flex justify-between p-0 pb-2", {
+              "border-b border-base-content/10": underlined,
+            })}
             onClick={() => onChange?.(!open)}
           >
             {heading}

--- a/apps/hyperdrive-trading/src/ui/base/components/AccordionSection/AccordionSection.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/AccordionSection/AccordionSection.tsx
@@ -30,9 +30,7 @@ export function AccordionSection({
         className="min-h-0"
       />
       <div className="daisy-collapse-title mb-3 min-h-0 p-0 font-medium">
-        <div className="flex items-center gap-4 hover:text-white">
-          {heading}
-        </div>
+        {heading}
       </div>
       <div className="daisy-collapse-content space-y-2 px-0">{children}</div>
     </div>

--- a/apps/hyperdrive-trading/src/ui/base/components/PrimaryStat.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/PrimaryStat.tsx
@@ -5,6 +5,7 @@ import Skeleton from "react-loading-skeleton";
 
 export function PrimaryStat({
   label,
+  alignment = "left",
   value,
   valueUnit,
   subValue,
@@ -14,7 +15,8 @@ export function PrimaryStat({
   unitClassName,
   valueLoading = false,
 }: {
-  label: string;
+  alignment?: "left" | "right";
+  label: ReactNode;
   value: ReactNode;
   valueUnit?: ReactNode;
   subValue?: ReactNode;
@@ -25,7 +27,12 @@ export function PrimaryStat({
   valueLoading?: boolean;
 }): JSX.Element {
   return (
-    <div className="flex min-w-0 flex-1 shrink-0 flex-col justify-between gap-1">
+    <div
+      className={classNames(
+        "flex min-w-0 flex-1 shrink-0 flex-col justify-between gap-1",
+        { "items-end": alignment === "right" },
+      )}
+    >
       <div className="flex gap-1">
         <p className="max-w-40 text-sm text-neutral-content">{label}</p>
         {tooltipContent && (

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongStats.tsx
@@ -61,7 +61,7 @@ export function OpenLongStats({
   return (
     <div className="flex flex-row justify-between px-4 py-8">
       <PrimaryStat
-        label="Your Fixed Rate"
+        label="Your Fixed APR"
         value={
           openLongPreviewStatus === "loading" ? (
             <Skeleton width={100} />
@@ -84,7 +84,6 @@ export function OpenLongStats({
             </span>
           )
         }
-        valueUnit="APR"
         subValue={
           openLongPreviewStatus === "loading" ? (
             <Skeleton width={100} />
@@ -96,6 +95,7 @@ export function OpenLongStats({
       />
       <div className="daisy-divider daisy-divider-horizontal mx-0" />
       <PrimaryStat
+        alignment="right"
         label="Receive at Maturity"
         value={
           openLongPreviewStatus === "loading" ? (

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongStats.tsx
@@ -61,7 +61,7 @@ export function OpenLongStats({
   return (
     <div className="flex flex-row justify-between px-4 py-8">
       <PrimaryStat
-        label="Your Fixed APR"
+        label="Fixed APR"
         value={
           openLongPreviewStatus === "loading" ? (
             <Skeleton width={100} />

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
@@ -548,6 +548,7 @@ function LpApyStat({ hyperdrive }: { hyperdrive: HyperdriveConfig }) {
   });
   return (
     <PrimaryStat
+      alignment="right"
       label="LP APY"
       value={(() => {
         if (showSkeleton) {

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortPreview/OpenShortPreview.tsx
@@ -5,19 +5,19 @@ import {
   getBaseToken,
 } from "@delvtech/hyperdrive-appconfig";
 import { ArrowRightIcon } from "@heroicons/react/16/solid";
-import { ChevronDownIcon } from "@heroicons/react/20/solid";
 import { ClockIcon } from "@heroicons/react/24/outline";
 import classNames from "classnames";
 import { ReactElement, useState } from "react";
 import Skeleton from "react-loading-skeleton";
 import { formatRate } from "src/base/formatRate";
 import { QueryStatusWithIdle } from "src/base/queryStatus";
-import { AccordionSection } from "src/ui/base/components/AccordionSection/AccordionSection";
+import { AccordionSection2 } from "src/ui/base/components/AccordionSection/AccordionSection";
 import { LabelValue } from "src/ui/base/components/LabelValue";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { formatDate } from "src/ui/base/formatting/formatDate";
 import { useFixedRate } from "src/ui/hyperdrive/longs/hooks/useFixedRate";
 import { useShortRate } from "src/ui/hyperdrive/shorts/hooks/useShortRate";
+import { formatTermLength2 } from "src/ui/markets/formatTermLength";
 import { useYieldSourceRate } from "src/ui/vaults/useYieldSourceRate";
 import { useAccount } from "wagmi";
 
@@ -61,7 +61,7 @@ export function OpenShortPreview({
     bondAmount: shortSize || defaultBondAmount,
     hyperdriveAddress: hyperdrive.address,
     timestamp: BigInt(Math.floor(Date.now() / 1000)),
-    variableApy: vaultRate?.vaultRate,
+    variableApy: vaultRate?.netVaultRate,
   });
   const termLengthMS = Number(hyperdrive.poolConfig.positionDuration * 1000n);
 
@@ -86,118 +86,122 @@ export function OpenShortPreview({
 
   return (
     <div className="flex flex-col gap-3.5 px-2">
-      <AccordionSection
+      <AccordionSection2
+        underlined={false}
         heading={
           <div className="flex w-full items-center justify-between text-neutral-content">
-            <p>Transaction Details</p>
-            <div className="flex items-center gap-1">
+            <p className="hover:text-base-content/80 group-data-[open]:text-white">
+              Transaction Details
+            </p>
+            <div className="mx-1 flex items-center gap-1">
               {!isOpen ? (
                 <>
                   <ClockIcon className="size-5 text-gray-500" />
                   <p>{formatDate(Date.now() + termLengthMS)}</p>
                 </>
               ) : undefined}
-              <ChevronDownIcon className="ml-1 size-6" />
             </div>
           </div>
         }
         onChange={handleChange}
       >
-        <LabelValue
-          label="Maturity"
-          size="small"
-          value={
-            <div className="flex gap-1">
-              <ClockIcon className="size-5 text-gray-500" />
-              <p className="text-neutral-content">
-                {formatDate(Date.now() + termLengthMS)}
-              </p>
-            </div>
-          }
-        />
-        <LabelValue
-          label="Pool fee"
-          size="small"
-          value={
-            openShortPreviewStatus === "loading" ? (
-              <Skeleton width={100} />
-            ) : (
-              <span
-                className={classNames({
-                  "text-base-content/80": !curveFee,
-                })}
-              >
-                {curveFee
-                  ? `${formatBalance({
-                      balance: curveFee,
-                      decimals: baseToken.decimals,
-                      places: baseToken.places,
-                    })} hy${baseToken.symbol}`
-                  : `0 hy${baseToken.symbol}`}
-              </span>
-            )
-          }
-        />
-        <LabelValue
-          label="Short APR"
-          tooltipContent="Your annualized return on this position assuming the current yield source rate stays the same for one year"
-          tooltipPosition="right"
-          tooltipSize="small"
-          size="small"
-          value={
-            shortRateStatus === "loading" ? (
-              <Skeleton width={100} />
-            ) : (
-              <span className="text-base-content">
-                {shortApr ? `${shortApr.formatted}` : "-"}
-              </span>
-            )
-          }
-        />
-        <LabelValue
-          size="small"
-          label="Fixed APR after open"
-          value={
-            openShortPreviewStatus === "loading" ? (
-              <Skeleton width={100} />
-            ) : (
-              <span
-                className={classNames({
-                  "text-base-content/80": !shortSize,
-                })}
-              >
-                {spotRateAfterOpen ? (
-                  <span className="flex gap-2 text-base-content">
-                    <span className="text-neutral-content">{`${fixedApr?.formatted} `}</span>
-                    <ArrowRightIcon className="h-4 text-neutral-content" />
-                    {formatRate({ rate: spotRateAfterOpen })}
-                  </span>
-                ) : (
-                  "-"
-                )}
-              </span>
-            )
-          }
-        />
-        <LabelValue
-          size="small"
-          label="Fixed APR impact"
-          value={
-            openShortPreviewStatus === "loading" ? (
-              <Skeleton width={100} />
-            ) : (
-              <span
-                className={classNames({
-                  "text-base-content/80": !spotRateAfterOpen,
-                  "text-success": spotRateAfterOpen,
-                })}
-              >
-                {getMarketImpactLabel(fixedApr?.apr, spotRateAfterOpen)}
-              </span>
-            )
-          }
-        />
-      </AccordionSection>
+        <div className="flex flex-col gap-2">
+          <LabelValue
+            label="Maturity"
+            value={
+              <div className="flex gap-1">
+                <ClockIcon className="size-5 text-gray-500" />
+                <p className="text-neutral-content">
+                  {formatDate(Date.now() + termLengthMS)}
+                  <span className="daisy-badge daisy-badge-md ml-2 bg-base-200 p-2.5 text-neutral-content">
+                    {formatTermLength2(
+                      Number(hyperdrive.poolConfig.positionDuration * 1000n),
+                    )}
+                  </span>{" "}
+                </p>
+              </div>
+            }
+          />
+          <LabelValue
+            label="Pool fee"
+            value={
+              openShortPreviewStatus === "loading" ? (
+                <Skeleton width={100} />
+              ) : (
+                <span
+                  className={classNames({
+                    "text-base-content/80": !curveFee,
+                  })}
+                >
+                  {curveFee
+                    ? `${formatBalance({
+                        balance: curveFee,
+                        decimals: baseToken.decimals,
+                        places: baseToken.places,
+                      })} hy${baseToken.symbol}`
+                    : `0 hy${baseToken.symbol}`}
+                </span>
+              )
+            }
+          />
+          <LabelValue
+            label="Short APR"
+            tooltipContent="Your annualized return on this position assuming the current yield source rate stays the same for one year"
+            tooltipPosition="right"
+            tooltipSize="small"
+            value={
+              shortRateStatus === "loading" ? (
+                <Skeleton width={100} />
+              ) : (
+                <span className="text-base-content">
+                  {shortApr ? `${shortApr.formatted}` : "-"}
+                </span>
+              )
+            }
+          />
+          <LabelValue
+            label="Fixed APR after open"
+            value={
+              openShortPreviewStatus === "loading" ? (
+                <Skeleton width={100} />
+              ) : (
+                <span
+                  className={classNames({
+                    "text-base-content/80": !shortSize,
+                  })}
+                >
+                  {spotRateAfterOpen ? (
+                    <span className="flex gap-2 text-base-content">
+                      <span className="text-neutral-content">{`${fixedApr?.formatted} `}</span>
+                      <ArrowRightIcon className="h-4 text-neutral-content" />
+                      {formatRate({ rate: spotRateAfterOpen })}
+                    </span>
+                  ) : (
+                    "-"
+                  )}
+                </span>
+              )
+            }
+          />
+          <LabelValue
+            label="Fixed APR impact"
+            value={
+              openShortPreviewStatus === "loading" ? (
+                <Skeleton width={100} />
+              ) : (
+                <span
+                  className={classNames({
+                    "text-base-content/80": !spotRateAfterOpen,
+                    "text-success": spotRateAfterOpen,
+                  })}
+                >
+                  {getMarketImpactLabel(fixedApr?.apr, spotRateAfterOpen)}
+                </span>
+              )
+            }
+          />
+        </div>
+      </AccordionSection2>
     </div>
   );
 }

--- a/apps/hyperdrive-trading/src/ui/markets/PointsMarkets/PointsMarkets.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PointsMarkets/PointsMarkets.tsx
@@ -7,7 +7,7 @@ import { Link } from "@tanstack/react-router";
 import { ReactElement, ReactNode } from "react";
 import { useAppConfigForConnectedChain } from "src/ui/appconfig/useAppConfigForConnectedChain";
 import { Well } from "src/ui/base/components/Well/Well";
-import { useLpApy } from "src/ui/hyperdrive/hooks/useLpApy";
+import { useLpApy } from "src/ui/hyperdrive/lp/hooks/useLpApy";
 import { AssetStack } from "src/ui/markets/AssetStack";
 import { MARKET_DETAILS_ROUTE } from "src/ui/markets/routes";
 import { useYieldSourceRate } from "src/ui/vaults/useYieldSourceRate";

--- a/apps/hyperdrive-trading/src/ui/markets/PoolRow/VariableApyStat.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PoolRow/VariableApyStat.tsx
@@ -8,6 +8,7 @@ import { SparklesIcon } from "@heroicons/react/16/solid";
 import { ChartBarIcon } from "@heroicons/react/24/solid";
 import * as Tooltip from "@radix-ui/react-tooltip";
 import { ReactNode } from "react";
+import Skeleton from "react-loading-skeleton";
 import { formatRate } from "src/base/formatRate";
 import { calculateMarketYieldMultiplier } from "src/hyperdrive/calculateMarketYieldMultiplier";
 import { GradientBadge } from "src/ui/base/components/GradientBadge";
@@ -30,10 +31,11 @@ export function VariableApyStat({
     appConfig,
   });
   const { rewards: appConfigRewards } = useRewards(hyperdrive);
-  const { vaultRate: yieldSourceRate } = useYieldSourceRate({
-    chainId,
-    hyperdriveAddress,
-  });
+  const { vaultRate: yieldSourceRate, vaultRateStatus: yieldSourceRateStatus } =
+    useYieldSourceRate({
+      chainId,
+      hyperdriveAddress,
+    });
   const isNewPool = useIsNewPool({ hyperdrive });
   const { longPrice, longPriceStatus } = useCurrentLongPrice({
     chainId: hyperdrive.chainId,
@@ -64,16 +66,16 @@ export function VariableApyStat({
     <Tooltip.Provider>
       <Tooltip.Root>
         <Tooltip.Trigger className="flex items-center gap-2 whitespace-nowrap">
-          {yieldSourceRate ? (
+          {yieldSourceRateStatus === "success" ? (
             <PercentLabel
               value={formatRate({
-                rate: yieldSourceRate.netVaultRate,
+                rate: yieldSourceRate?.netVaultRate ?? 0n,
                 includePercentSign: false,
               })}
               className="text-h4"
             />
           ) : (
-            "-"
+            <Skeleton width={100} />
           )}
           <GradientBadge>{multiplierLabel}</GradientBadge>⚡
         </Tooltip.Trigger>

--- a/apps/hyperdrive-trading/src/version.output.ts
+++ b/apps/hyperdrive-trading/src/version.output.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "b5dc061cfcbee70aea7c667e526ad54913086916";
+export const APP_VERSION = "02c400d45dbb40894c9a74402ac0dc77c570c29e";


### PR DESCRIPTION
Closes #1674 

Matching the latest design for the Open Short form.

Additionally:
- fixed the right alignment of the second Primary stats on each open position form
- Added loading state skeleton to PoolRow to replace "-" character on Variable APY
 
<img width="594" alt="image" src="https://github.com/user-attachments/assets/0a58e573-5230-4a67-83ef-565748a2796c" />
