### PR TITLE
Fix abi encoding errors in `useTokenAllowance` & `useTokenBalance`

### DIFF
--- a/apps/hyperdrive-trading/src/ui/token/hooks/useTokenAllowance.ts
+++ b/apps/hyperdrive-trading/src/ui/token/hooks/useTokenAllowance.ts
@@ -26,7 +26,7 @@ export function useTokenAllowance({
 
   const { data, status } = useReadContract({
     query: {
-      enabled,
+      enabled: queryEnabled,
     },
     address: tokenAddress,
     chainId: tokenChainId,

--- a/apps/hyperdrive-trading/src/ui/token/hooks/useTokenBalance.ts
+++ b/apps/hyperdrive-trading/src/ui/token/hooks/useTokenBalance.ts
@@ -49,7 +49,7 @@ export function useTokenBalance({
     functionName: "balanceOf",
     args: account ? [account] : undefined,
     query: {
-      enabled: account && !isEth && !isZeroAddress,
+      enabled: !!account && !isEth && !isZeroAddress,
     },
   });
 


### PR DESCRIPTION
When not connected, `enabled` was resolving to `undefined` so the query was firing, but with no address argument.