### PR TITLE
Improve caching of rewards resolver functions and token fiat price

### DIFF
--- a/apps/hyperdrive-trading/src/hyperdrive/getYieldSourceRate.ts
+++ b/apps/hyperdrive-trading/src/hyperdrive/getYieldSourceRate.ts
@@ -8,11 +8,10 @@ import {
   HyperdriveConfig,
 } from "@delvtech/hyperdrive-appconfig";
 import { ReadHyperdrive } from "@delvtech/hyperdrive-js";
-import { getPublicClient } from "@wagmi/core";
 import { convertMillisecondsToDays } from "src/base/convertMillisecondsToDays";
 import { isForkChain } from "src/chains/isForkChain";
-import { wagmiConfig } from "src/network/wagmiClient";
-import { PublicClient } from "viem";
+import { queryClient } from "src/network/queryClient";
+import { makeRewardsQuery } from "src/ui/rewards/useRewards";
 
 export async function getYieldSourceRate({
   readHyperdrive,
@@ -94,10 +93,12 @@ async function calcNetRate(
     appConfig,
   });
   if (rewardsFn) {
-    const publicClient = getPublicClient(wagmiConfig as any, {
-      chainId: hyperdrive.chainId,
-    }) as PublicClient;
-    const rewards = await rewardsFn(publicClient);
+    const rewards = await queryClient.fetchQuery(
+      makeRewardsQuery({
+        chainId: hyperdrive.chainId,
+        hyperdriveAddress: hyperdrive.address,
+      }),
+    );
     rewards?.forEach((reward) => {
       if (reward.type === "apy") {
         netRate = fixed(reward.apy).add(

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/usePresentValue.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/hooks/usePresentValue.ts
@@ -10,9 +10,10 @@ import { getPublicClient } from "@wagmi/core";
 import { ZERO_ADDRESS } from "src/base/constants";
 import { makeQueryKey2 } from "src/base/makeQueryKey";
 import { isTestnetChain } from "src/chains/isTestnetChain";
+import { queryClient } from "src/network/queryClient";
 import { wagmiConfig } from "src/network/wagmiClient";
 import { useReadHyperdrive } from "src/ui/hyperdrive/hooks/useReadHyperdrive";
-import { getTokenFiatPrice } from "src/ui/token/hooks/useTokenFiatPrice";
+import { makeTokenFiatPriceQuery } from "src/ui/token/hooks/useTokenFiatPrice";
 import { Address, PublicClient } from "viem";
 
 export function usePresentValue({
@@ -88,11 +89,14 @@ export function getPresentValue({
   const isFiatSupported =
     !isTestnetChain(chainId) && baseToken.address !== ZERO_ADDRESS;
   const fiatPricePromise = isFiatSupported
-    ? getTokenFiatPrice({
-        chainId: baseToken.chainId,
-        publicClient,
-        tokenAddress: baseToken.address,
-      }).catch(() => undefined)
+    ? queryClient
+        .fetchQuery(
+          makeTokenFiatPriceQuery({
+            chainId: baseToken.chainId,
+            tokenAddress: baseToken.address,
+          }),
+        )
+        .catch(() => undefined)
     : Promise.resolve(undefined);
 
   return Promise.all([readHyperdrive.getPresentValue(), fiatPricePromise]).then(

--- a/apps/hyperdrive-trading/src/ui/rewards/useRewards.ts
+++ b/apps/hyperdrive-trading/src/ui/rewards/useRewards.ts
@@ -1,48 +1,69 @@
 import {
   AnyReward,
   appConfig,
+  getHyperdriveConfig,
   getRewardsFn,
   HyperdriveConfig,
 } from "@delvtech/hyperdrive-appconfig";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, UseQueryOptions } from "@tanstack/react-query";
 import { getPublicClient } from "@wagmi/core";
 import { makeQueryKey2 } from "src/base/makeQueryKey";
 import { wagmiConfig } from "src/network/wagmiClient";
-import { PublicClient } from "viem";
+import { Address, PublicClient } from "viem";
 
 export function useRewards(hyperdriveConfig: HyperdriveConfig): {
   rewards: AnyReward[] | undefined;
   status: "error" | "success" | "loading";
 } {
+  const { data: rewards, status } = useQuery(
+    makeRewardsQuery({
+      hyperdriveAddress: hyperdriveConfig.address,
+      chainId: hyperdriveConfig.chainId,
+    }),
+  );
+
+  return {
+    rewards,
+    status,
+  };
+}
+
+export function makeRewardsQuery({
+  hyperdriveAddress,
+  chainId,
+}: {
+  hyperdriveAddress: Address;
+  chainId: number;
+}): UseQueryOptions<AnyReward[]> {
+  const hyperdriveConfig = getHyperdriveConfig({
+    hyperdriveChainId: chainId,
+    hyperdriveAddress,
+    appConfig,
+  });
   const rewardsFn = getRewardsFn({
     yieldSourceId: hyperdriveConfig.yieldSource,
     appConfig,
   });
 
   const queryEnabled = !!rewardsFn;
-
-  const { data: rewards, status } = useQuery({
+  return {
     queryKey: makeQueryKey2({
       namespace: "rewards",
       queryId: "rewards",
       params: {
-        chainId: hyperdriveConfig.chainId,
-        hyperdriveAddress: hyperdriveConfig.address,
+        chainId,
+        hyperdriveAddress,
       },
     }),
     enabled: queryEnabled,
+    staleTime: Infinity,
     queryFn: queryEnabled
       ? async () => {
           const publicClient = getPublicClient(wagmiConfig as any, {
-            chainId: hyperdriveConfig.chainId,
+            chainId,
           }) as PublicClient;
           return rewardsFn(publicClient);
         }
       : undefined,
-  });
-
-  return {
-    rewards,
-    status,
   };
 }


### PR DESCRIPTION
These functions were being called lots of extra times since the were never properly cached. This should cut down on requests to external apis.