### PR TITLE
Wire up Rewards Multiplier on Points Markets page

### DIFF
--- a/apps/hyperdrive-trading/src/ui/base/components/Well/Well.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/Well/Well.tsx
@@ -55,7 +55,7 @@ export function Well<T extends ElementType = "div">({
     return (
       <Component
         className={classNames(
-          "group relative z-10 flex w-full cursor-pointer items-center overflow-hidden rounded-xl p-[1.5px] transition duration-300 hover:-translate-y-0.5 hover:scale-[1.01] hover:shadow-xl hover:shadow-primary/5",
+          "group relative z-10 flex cursor-pointer items-center overflow-hidden rounded-xl p-[1.5px] transition duration-300 hover:-translate-y-0.5 hover:scale-[1.01] hover:shadow-xl hover:shadow-primary/5",
         )}
         onClick={onClick}
         disabled={disabled}

--- a/apps/hyperdrive-trading/src/ui/markets/PointsMarkets/PointsMarkets.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PointsMarkets/PointsMarkets.tsx
@@ -49,8 +49,8 @@ export function PointsMarkets(): ReactElement | null {
           Points Markets
         </h1>
         <p className="font-inter text-lg leading-bodyText text-neutral-content">
-          Maximize your returns on DeFi&apos;s top yield sources and boost your
-          exposure to points and rewards.
+          Boost your exposure to points and rewards on DeFi&apos;s top yield
+          sources.
         </p>
       </div>
       <div className="flex w-full flex-wrap gap-8">

--- a/apps/hyperdrive-trading/src/ui/markets/PointsMarkets/PointsMarkets.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PointsMarkets/PointsMarkets.tsx
@@ -3,7 +3,7 @@ import {
   getYieldSource,
   HyperdriveConfig,
 } from "@delvtech/hyperdrive-appconfig";
-import { Link, useSearch } from "@tanstack/react-router";
+import { Link, useNavigate, useSearch } from "@tanstack/react-router";
 import { ReactElement, ReactNode } from "react";
 import Skeleton from "react-loading-skeleton";
 import { formatRate } from "src/base/formatRate";
@@ -43,7 +43,7 @@ export function PointsMarkets(): ReactElement | null {
     : [];
 
   return (
-    <div className="mx-[2vw] mt-4 space-y-8 lg:w-[1064px]">
+    <div className="mx-[2vw] mt-4 space-y-8 lg:w-[1080px]">
       <div className="space-y-4">
         <h1 className="gradient-text text-h4 font-medium md:text-h4">
           Points Markets
@@ -53,7 +53,7 @@ export function PointsMarkets(): ReactElement | null {
           exposure to points and rewards.
         </p>
       </div>
-      <div className="flex flex-wrap gap-8">
+      <div className="flex w-full flex-wrap gap-8">
         {poolsWithPoints.map((hyperdrive) => (
           <PointsMarketCard key={hyperdrive.address} hyperdrive={hyperdrive} />
         ))}
@@ -67,8 +67,24 @@ function PointsMarketCard({
 }: {
   hyperdrive: HyperdriveConfig;
 }): ReactElement {
+  const navigate = useNavigate();
   return (
-    <Well as="div" className="w-[514px] shrink-0 gap-6">
+    <Well
+      as="div"
+      className="w-[514px] shrink-0 gap-6"
+      onClick={() => {
+        // Clicking on the card will navigate you to the LP tab by default
+        navigate({
+          to: MARKET_DETAILS_ROUTE,
+          resetScroll: true,
+          params: {
+            address: hyperdrive.address,
+            chainId: hyperdrive.chainId.toString(),
+          },
+          search: { position: "lp" },
+        });
+      }}
+    >
       <PointsMarketCardHeader hyperdrive={hyperdrive} />
       <PointsMarketCardBanner hyperdrive={hyperdrive} />
       <PointsMarketTable hyperdrive={hyperdrive} />

--- a/apps/hyperdrive-trading/src/ui/markets/PointsMarkets/usePointsMultipliers.ts
+++ b/apps/hyperdrive-trading/src/ui/markets/PointsMarkets/usePointsMultipliers.ts
@@ -1,0 +1,41 @@
+import { parseFixed } from "@delvtech/fixed-point-wasm";
+import {
+  HyperdriveConfig,
+  PointMultiplierReward,
+} from "@delvtech/hyperdrive-appconfig";
+import { calculateMarketYieldMultiplier } from "src/hyperdrive/calculateMarketYieldMultiplier";
+import { useCurrentLongPrice } from "src/ui/hyperdrive/longs/hooks/useCurrentLongPrice";
+import { useRewards } from "src/ui/rewards/useRewards";
+
+export function usePointsMultipliers({
+  hyperdrive,
+}: {
+  hyperdrive: HyperdriveConfig;
+}): { multiplier: string; label: string }[] | undefined {
+  const { rewards } = useRewards(hyperdrive);
+  const { longPrice } = useCurrentLongPrice({
+    chainId: hyperdrive.chainId,
+    hyperdriveAddress: hyperdrive.address,
+  });
+  const pointRewards = rewards?.filter(
+    ({ type }) => type === "pointMultiplier",
+  ) as PointMultiplierReward[] | undefined;
+
+  if (!longPrice || !pointRewards) {
+    return;
+  }
+
+  const multipliers = pointRewards.map(
+    ({ pointMultiplier, pointTokenLabel }) => {
+      const capitalMultiplier = calculateMarketYieldMultiplier(longPrice);
+      return {
+        multiplier: capitalMultiplier
+          .mul(parseFixed(pointMultiplier))
+          .format({ decimals: 0 }),
+        label: pointTokenLabel,
+      };
+    },
+  );
+
+  return multipliers;
+}


### PR DESCRIPTION
The rewards multiplier is now wired up in both the banner and the Rewards Multiplier row.

<img width="1112" alt="image" src="https://github.com/user-attachments/assets/bce904c9-077e-4893-9fcd-0bfe7f9219b6" />
