### PR TITLE
Fix react-query warning about missing queryFn

### DIFF
--- a/apps/hyperdrive-trading/src/ui/token/hooks/useTokenFiatPrice.ts
+++ b/apps/hyperdrive-trading/src/ui/token/hooks/useTokenFiatPrice.ts
@@ -18,14 +18,14 @@ export function useTokenFiatPrice({
   fiatPrice: bigint | undefined;
 } {
   const { data } = useQuery(
-    makeTokenFiatPriceQuery({ chainId, tokenAddress, enabled })
+    makeTokenFiatPriceQuery({ chainId, tokenAddress, enabled }),
   );
   return { fiatPrice: data };
 }
 export function makeTokenFiatPriceQuery({
   chainId,
   tokenAddress,
-  enabled,
+  enabled = true,
 }: {
   chainId: number;
   tokenAddress: Address | undefined;


### PR DESCRIPTION
We were getting a flood of react query warnings when fetching due to a missing `enabled: true`.