### PR TITLE
Wire up the RewardsTooltip to new rewards from appconfig

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
@@ -35,7 +35,7 @@ import { useLpSharesTotalSupply } from "src/ui/hyperdrive/lp/hooks/useLpSharesTo
 import { usePreviewAddLiquidity } from "src/ui/hyperdrive/lp/hooks/usePreviewAddLiquidity";
 import { PositionPicker } from "src/ui/markets/PositionPicker";
 import { RewardsTooltip } from "src/ui/rewards/RewardsTooltip/RewardsTooltip";
-import { useRewards } from "src/ui/rewards/useRewards";
+import { useAddLiquidityRewards } from "src/ui/rewards/hooks/useAddLiquidityRewards";
 import { ApproveTokenChoices } from "src/ui/token/ApproveTokenChoices";
 import { SlippageSettings } from "src/ui/token/SlippageSettings";
 import { TokenInput } from "src/ui/token/TokenInput";
@@ -537,7 +537,7 @@ function LpApyStat({ hyperdrive }: { hyperdrive: HyperdriveConfig }) {
     chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
   });
-  const { rewards } = useRewards(hyperdrive);
+  const { rewards } = useAddLiquidityRewards({ hyperdriveConfig: hyperdrive });
 
   const { vaultRate, vaultRateStatus } = useYieldSourceRate({
     hyperdriveAddress: hyperdrive.address,
@@ -560,6 +560,7 @@ function LpApyStat({ hyperdrive }: { hyperdrive: HyperdriveConfig }) {
               "✨New✨"
             ) : rewards?.length ? (
               <RewardsTooltip
+                position="addLiquidity"
                 showMiles
                 hyperdriveAddress={hyperdrive.address}
                 baseRate={lpApy?.lpApy}

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
@@ -38,7 +38,7 @@ import { useOpenShort } from "src/ui/hyperdrive/shorts/hooks/useOpenShort";
 import { usePreviewOpenShort } from "src/ui/hyperdrive/shorts/hooks/usePreviewOpenShort";
 import { PositionPicker } from "src/ui/markets/PositionPicker";
 import { RewardsTooltip } from "src/ui/rewards/RewardsTooltip/RewardsTooltip";
-import { useRewards } from "src/ui/rewards/useRewards";
+import { useOpenShortRewards } from "src/ui/rewards/hooks/useOpenShortRewards";
 import { ApproveTokenChoices } from "src/ui/token/ApproveTokenChoices";
 import { SlippageSettings } from "src/ui/token/SlippageSettings";
 import { TokenInput } from "src/ui/token/TokenInput";
@@ -70,7 +70,7 @@ export function OpenShortForm({
     chainId: hyperdrive.chainId,
   });
 
-  const { rewards } = useRewards(hyperdrive);
+  const { rewards } = useOpenShortRewards({ hyperdriveConfig: hyperdrive });
   const { poolInfo } = usePoolInfo({
     chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
@@ -478,6 +478,7 @@ export function OpenShortForm({
                 ) : rewards?.length ? (
                   <RewardsTooltip
                     hyperdriveAddress={hyperdrive.address}
+                    position="openShort"
                     baseRate={vaultRate?.vaultRate}
                     netRate={vaultRate?.netVaultRate}
                     chainId={hyperdrive.chainId}

--- a/apps/hyperdrive-trading/src/ui/markets/PointsMarkets/usePointsMultipliers.ts
+++ b/apps/hyperdrive-trading/src/ui/markets/PointsMarkets/usePointsMultipliers.ts
@@ -5,14 +5,14 @@ import {
 } from "@delvtech/hyperdrive-appconfig";
 import { calculateMarketYieldMultiplier } from "src/hyperdrive/calculateMarketYieldMultiplier";
 import { useCurrentLongPrice } from "src/ui/hyperdrive/longs/hooks/useCurrentLongPrice";
-import { useRewards } from "src/ui/rewards/useRewards";
+import { useAddLiquidityRewards } from "src/ui/rewards/hooks/useAddLiquidityRewards";
 
 export function usePointsMultipliers({
   hyperdrive,
 }: {
   hyperdrive: HyperdriveConfig;
 }): { multiplier: string; label: string }[] | undefined {
-  const { rewards } = useRewards(hyperdrive);
+  const { rewards } = useAddLiquidityRewards({ hyperdriveConfig: hyperdrive });
   const { longPrice } = useCurrentLongPrice({
     chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,

--- a/apps/hyperdrive-trading/src/ui/markets/PoolRow/LpApyCta.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PoolRow/LpApyCta.tsx
@@ -30,8 +30,8 @@ export function LpApyCta({ hyperdrive }: LpApyCtaProps): ReactElement {
         <RewardsTooltipContent
           chainId={hyperdrive.chainId}
           hyperdriveAddress={hyperdrive.address}
+          position="addLiquidity"
           baseRate={lpApy?.lpApy}
-          showMiles
           netRate={lpApy?.netLpApy}
         />
       }

--- a/apps/hyperdrive-trading/src/ui/markets/PoolRow/LpApyStat.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PoolRow/LpApyStat.tsx
@@ -18,7 +18,7 @@ export function LpApyStat({
     hyperdriveChainId: chainId,
     appConfig,
   });
-  const { rewards: appConfigRewards } = useAddLiquidityRewards({
+  const { rewards } = useAddLiquidityRewards({
     hyperdriveConfig: hyperdrive,
   });
   const { lpApy } = useLpApy({ chainId, hyperdriveAddress });
@@ -33,7 +33,7 @@ export function LpApyStat({
         })
       : null;
 
-  if (!appConfigRewards?.length && netApyLabel) {
+  if (!rewards?.length && netApyLabel) {
     return <PercentLabel value={netApyLabel} />;
   }
 

--- a/apps/hyperdrive-trading/src/ui/markets/PoolRow/LpApyStat.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PoolRow/LpApyStat.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from "react";
 import { formatRate } from "src/base/formatRate";
 import { useLpApy } from "src/ui/hyperdrive/lp/hooks/useLpApy";
 import { PercentLabel } from "src/ui/markets/PoolRow/PercentLabel";
-import { useRewards } from "src/ui/rewards/useRewards";
+import { useAddLiquidityRewards } from "src/ui/rewards/hooks/useAddLiquidityRewards";
 import { Address } from "viem";
 
 export function LpApyStat({
@@ -18,7 +18,9 @@ export function LpApyStat({
     hyperdriveChainId: chainId,
     appConfig,
   });
-  const { rewards: appConfigRewards } = useRewards(hyperdrive);
+  const { rewards: appConfigRewards } = useAddLiquidityRewards({
+    hyperdriveConfig: hyperdrive,
+  });
   const { lpApy } = useLpApy({ chainId, hyperdriveAddress });
 
   // Explicit check against undefined, since we still want to show zero if the

--- a/apps/hyperdrive-trading/src/ui/markets/PoolRow/VariableApyCta.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PoolRow/VariableApyCta.tsx
@@ -5,8 +5,8 @@ import { calculateMarketYieldMultiplier } from "src/hyperdrive/calculateMarketYi
 import { useCurrentLongPrice } from "src/ui/hyperdrive/longs/hooks/useCurrentLongPrice";
 import { PoolStat } from "src/ui/markets/PoolRow/PoolStat";
 import { VariableApyStat } from "src/ui/markets/PoolRow/VariableApyStat";
+import { useOpenShortRewards } from "src/ui/rewards/hooks/useOpenShortRewards";
 import { RewardsTooltipContent } from "src/ui/rewards/RewardsTooltip/RewardsTooltipContent";
-import { useRewards } from "src/ui/rewards/useRewards";
 import { useYieldSourceRate } from "src/ui/vaults/useYieldSourceRate";
 import { useAccount } from "wagmi";
 
@@ -27,7 +27,7 @@ export function VariableApyCta({
     chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
   });
-  const { rewards } = useRewards(hyperdrive);
+  const { rewards } = useOpenShortRewards({ hyperdriveConfig: hyperdrive });
 
   const label = yieldSourceRate
     ? `Variable APY (${yieldSourceRate.ratePeriodDays}d)`
@@ -44,6 +44,7 @@ export function VariableApyCta({
         rewards?.length ? (
           <RewardsTooltipContent
             chainId={hyperdrive.chainId}
+            position="openShort"
             hyperdriveAddress={hyperdrive.address}
             baseRate={yieldSourceRate?.vaultRate}
             netRate={yieldSourceRate?.netVaultRate}

--- a/apps/hyperdrive-trading/src/ui/markets/PoolRow/VariableApyStat.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PoolRow/VariableApyStat.tsx
@@ -6,7 +6,7 @@ import { calculateMarketYieldMultiplier } from "src/hyperdrive/calculateMarketYi
 import { GradientBadge } from "src/ui/base/components/GradientBadge";
 import { useCurrentLongPrice } from "src/ui/hyperdrive/longs/hooks/useCurrentLongPrice";
 import { PercentLabel } from "src/ui/markets/PoolRow/PercentLabel";
-import { useRewards } from "src/ui/rewards/useRewards";
+import { useOpenShortRewards } from "src/ui/rewards/hooks/useOpenShortRewards";
 import { useYieldSourceRate } from "src/ui/vaults/useYieldSourceRate";
 import { Address } from "viem";
 export function VariableApyStat({
@@ -21,7 +21,7 @@ export function VariableApyStat({
     hyperdriveChainId: chainId,
     appConfig,
   });
-  const { rewards } = useRewards(hyperdrive);
+  const { rewards } = useOpenShortRewards({ hyperdriveConfig: hyperdrive });
   const { vaultRate: yieldSourceRate, vaultRateStatus: yieldSourceRateStatus } =
     useYieldSourceRate({
       chainId,

--- a/apps/hyperdrive-trading/src/ui/rewards/hooks/getRewardResolverQuery.ts
+++ b/apps/hyperdrive-trading/src/ui/rewards/hooks/getRewardResolverQuery.ts
@@ -9,6 +9,20 @@ import { makeQueryKey2 } from "src/base/makeQueryKey";
 import { wagmiConfig } from "src/network/wagmiClient";
 import { PublicClient } from "viem";
 
+/**
+ * Takes a given rewards resolver id from appConfig and returns the query object
+ * for requesting the rewards.
+ *
+ * For example:
+ * const { data } = useQuery(
+ *   getRewardResolverQuery({
+ *     resolverId: 'fetchLineaRewards',
+ *     chainId: linea.id,
+ *     appConfig
+ *   })
+ * );
+ * ```
+ */
 export function getRewardResolverQuery({
   resolverId,
   chainId,

--- a/apps/hyperdrive-trading/src/ui/rewards/hooks/getRewardResolverQuery.ts
+++ b/apps/hyperdrive-trading/src/ui/rewards/hooks/getRewardResolverQuery.ts
@@ -1,40 +1,29 @@
 import {
   AnyReward,
-  appConfig,
-  getHyperdriveConfig,
-  getRewardsFn,
+  getRewardsFn2,
+  RewardResolverKey,
 } from "@delvtech/hyperdrive-appconfig";
 import { UseQueryOptions } from "@tanstack/react-query";
 import { getPublicClient } from "@wagmi/core";
 import { makeQueryKey2 } from "src/base/makeQueryKey";
 import { wagmiConfig } from "src/network/wagmiClient";
-import { Address, PublicClient } from "viem";
+import { PublicClient } from "viem";
 
-export function makeRewardsQuery({
-  hyperdriveAddress,
+export function getRewardResolverQuery({
+  resolverId,
   chainId,
 }: {
-  hyperdriveAddress: Address;
   chainId: number;
+  resolverId: RewardResolverKey;
 }): UseQueryOptions<AnyReward[]> {
-  const hyperdriveConfig = getHyperdriveConfig({
-    hyperdriveChainId: chainId,
-    hyperdriveAddress,
-    appConfig,
-  });
-  const rewardsFn = getRewardsFn({
-    yieldSourceId: hyperdriveConfig.yieldSource,
-    appConfig,
-  });
-
-  const queryEnabled = !!rewardsFn;
+  const resolver = getRewardsFn2({ rewardFn: resolverId });
+  const queryEnabled = !!resolver;
   return {
     queryKey: makeQueryKey2({
       namespace: "rewards",
-      queryId: "rewards",
+      queryId: "rewardResolver",
       params: {
-        chainId,
-        hyperdriveAddress,
+        resolverId,
       },
     }),
     enabled: queryEnabled,
@@ -44,7 +33,7 @@ export function makeRewardsQuery({
           const publicClient = getPublicClient(wagmiConfig as any, {
             chainId,
           }) as PublicClient;
-          return rewardsFn(publicClient);
+          return resolver(publicClient);
         }
       : undefined,
   };

--- a/apps/hyperdrive-trading/src/ui/rewards/hooks/useAddLiquidityRewards.ts
+++ b/apps/hyperdrive-trading/src/ui/rewards/hooks/useAddLiquidityRewards.ts
@@ -1,0 +1,63 @@
+import {
+  AnyReward,
+  appConfig,
+  getAddLiquidityRewardResolverIds,
+  HyperdriveConfig,
+} from "@delvtech/hyperdrive-appconfig";
+import { useQuery } from "@tanstack/react-query";
+import { makeQueryKey2 } from "src/base/makeQueryKey";
+import { queryClient } from "src/network/queryClient";
+import { getRewardResolverQuery } from "src/ui/rewards/hooks/getRewardResolverQuery";
+
+export function useAddLiquidityRewards({
+  hyperdriveConfig,
+  enabled = true,
+}: {
+  hyperdriveConfig: HyperdriveConfig;
+  enabled?: boolean;
+}): {
+  rewards: AnyReward[] | undefined;
+  status: "error" | "success" | "loading";
+} {
+  const resolverIds = getAddLiquidityRewardResolverIds({
+    hyperdriveAddress: hyperdriveConfig.address,
+    chainId: hyperdriveConfig.chainId,
+    appConfig,
+  });
+
+  const queryEnabled = !!resolverIds?.length && enabled;
+  const { data: rewards, status } = useQuery({
+    queryKey: makeQueryKey2({
+      namespace: "rewards",
+      queryId: "addLiquidityRewards",
+      params: {
+        chainId: hyperdriveConfig.chainId,
+        hyperdriveAddress: hyperdriveConfig.address,
+      },
+    }),
+    enabled: queryEnabled,
+    staleTime: Infinity,
+    queryFn: queryEnabled
+      ? async () => {
+          // TODO: We might be re-inventing useQueries here..
+          return (
+            await Promise.all(
+              resolverIds.map((resolver) =>
+                queryClient.fetchQuery(
+                  getRewardResolverQuery({
+                    resolverId: resolver,
+                    chainId: hyperdriveConfig.chainId,
+                  }),
+                ),
+              ),
+            )
+          ).flat();
+        }
+      : undefined,
+  });
+
+  return {
+    rewards,
+    status,
+  };
+}

--- a/apps/hyperdrive-trading/src/ui/rewards/hooks/useOpenShortRewards.ts
+++ b/apps/hyperdrive-trading/src/ui/rewards/hooks/useOpenShortRewards.ts
@@ -1,0 +1,63 @@
+import {
+  AnyReward,
+  appConfig,
+  getOpenShortRewardResolverIds,
+  HyperdriveConfig,
+} from "@delvtech/hyperdrive-appconfig";
+import { useQuery } from "@tanstack/react-query";
+import { makeQueryKey2 } from "src/base/makeQueryKey";
+import { queryClient } from "src/network/queryClient";
+import { getRewardResolverQuery } from "src/ui/rewards/hooks/getRewardResolverQuery";
+
+export function useOpenShortRewards({
+  hyperdriveConfig,
+  enabled = true,
+}: {
+  hyperdriveConfig: HyperdriveConfig;
+  enabled?: boolean;
+}): {
+  rewards: AnyReward[] | undefined;
+  status: "error" | "success" | "loading";
+} {
+  const resolverIds = getOpenShortRewardResolverIds({
+    hyperdriveAddress: hyperdriveConfig.address,
+    chainId: hyperdriveConfig.chainId,
+    appConfig,
+  });
+
+  const queryEnabled = !!resolverIds?.length && enabled;
+  const { data: rewards, status } = useQuery({
+    queryKey: makeQueryKey2({
+      namespace: "rewards",
+      queryId: "openShortRewards",
+      params: {
+        chainId: hyperdriveConfig.chainId,
+        hyperdriveAddress: hyperdriveConfig.address,
+      },
+    }),
+    enabled: queryEnabled,
+    staleTime: Infinity,
+    queryFn: queryEnabled
+      ? async () => {
+          // TODO: We might be re-inventing useQueries here..
+          return (
+            await Promise.all(
+              resolverIds.map((resolver) =>
+                queryClient.fetchQuery(
+                  getRewardResolverQuery({
+                    resolverId: resolver,
+                    chainId: hyperdriveConfig.chainId,
+                  }),
+                ),
+              ),
+            )
+          ).flat();
+        }
+      : undefined,
+  });
+
+  return {
+    rewards,
+    status,
+  };
+}

--- a/apps/hyperdrive-trading/src/ui/rewards/queryKeys.ts
+++ b/apps/hyperdrive-trading/src/ui/rewards/queryKeys.ts
@@ -14,6 +14,9 @@ interface RewardsQueryKeys {
   rewardResolver: {
     resolverId: RewardResolverKey;
   };
+
+  // TODO: We may not openShortRewards and addLiquidityRewards, as these queries
+  // are just list wrappers around the `rewardResolver` query above
   openShortRewards: {
     chainId: number;
     hyperdriveAddress: Address;

--- a/apps/hyperdrive-trading/src/ui/rewards/queryKeys.ts
+++ b/apps/hyperdrive-trading/src/ui/rewards/queryKeys.ts
@@ -1,8 +1,24 @@
+import { RewardResolverKey } from "@delvtech/hyperdrive-appconfig";
 import "src/base/makeQueryKey";
 import { Address } from "viem";
 
 interface RewardsQueryKeys {
+  /**
+   * @deprecated
+   */
   rewards: {
+    chainId: number;
+    hyperdriveAddress: Address;
+  };
+
+  rewardResolver: {
+    resolverId: RewardResolverKey;
+  };
+  openShortRewards: {
+    chainId: number;
+    hyperdriveAddress: Address;
+  };
+  addLiquidityRewards: {
     chainId: number;
     hyperdriveAddress: Address;
   };

--- a/packages/hyperdrive-appconfig/src/index.ts
+++ b/packages/hyperdrive-appconfig/src/index.ts
@@ -30,9 +30,10 @@ export type { TokenConfig } from "src/tokens/types";
 export type { YieldSourceConfig, YieldSourceId } from "src/yieldSources/types";
 
 // rewards
+export type { RewardResolverKey } from "src/rewards/resolvers";
 export {
-  getAddLiquidityRewardResolvers,
-  getOpenShortRewardResolvers,
+  getAddLiquidityRewardResolverIds,
+  getOpenShortRewardResolverIds,
   getYieldSourceRewardsFn as getRewardsFn,
   getRewardsFn2,
   getYieldSourceRewardResolvers,

--- a/packages/hyperdrive-appconfig/src/rewards/selectors.ts
+++ b/packages/hyperdrive-appconfig/src/rewards/selectors.ts
@@ -56,7 +56,7 @@ export function getYieldSourceRewardResolvers({
   return resolvers.map((resolver) => rewardResolvers[resolver]);
 }
 
-export function getOpenShortRewardResolvers({
+export function getOpenShortRewardResolverIds({
   hyperdriveAddress,
   chainId,
   appConfig,
@@ -64,21 +64,16 @@ export function getOpenShortRewardResolvers({
   hyperdriveAddress: Address;
   chainId: number;
   appConfig: AppConfig;
-}): RewardsResolver[] | undefined {
+}): RewardResolverKey[] | undefined {
   const openShortRewardId = getOpenShortRewardId({
     chainId,
     hyperdriveAddress,
   });
 
-  const resolvers = appConfig.rewards[openShortRewardId];
-  if (!resolvers) {
-    return;
-  }
-
-  return resolvers.map((resolver) => rewardResolvers[resolver]);
+  return appConfig.rewards[openShortRewardId];
 }
 
-export function getAddLiquidityRewardResolvers({
+export function getAddLiquidityRewardResolverIds({
   hyperdriveAddress,
   chainId,
   appConfig,
@@ -86,16 +81,11 @@ export function getAddLiquidityRewardResolvers({
   hyperdriveAddress: Address;
   chainId: number;
   appConfig: AppConfig;
-}): RewardsResolver[] | undefined {
-  const addLiquidityRewardId = getAddLiquidityRewardId({
+}): RewardResolverKey[] | undefined {
+  const addLiquidityId = getAddLiquidityRewardId({
     chainId,
     hyperdriveAddress,
   });
 
-  const resolvers = appConfig.rewards[addLiquidityRewardId];
-  if (!resolvers) {
-    return;
-  }
-
-  return resolvers.map((resolver) => rewardResolvers[resolver]);
+  return appConfig.rewards[addLiquidityId];
 }

--- a/packages/hyperdrive-appconfig/src/yieldSources/selectors.ts
+++ b/packages/hyperdrive-appconfig/src/yieldSources/selectors.ts
@@ -1,0 +1,12 @@
+import { AppConfig } from "src/appconfig/AppConfig";
+import { YieldSourceConfig, YieldSourceId } from "src/yieldSources/types";
+
+export function getYieldSourceConfig({
+  appConfig,
+  yieldSourceId,
+}: {
+  yieldSourceId: YieldSourceId;
+  appConfig: AppConfig;
+}): YieldSourceConfig {
+  return appConfig.yieldSources[yieldSourceId];
+}


### PR DESCRIPTION
Rewards in the UI are now being read from the `appconfig.rewards` object for open short and add liquidity.

Once this lands, I'll:
- clean up the remaining deprecated callers (mostly `useYieldSourceRate`)
- remove any unused appconfig selectors and hooks
- remove any deprecated appconfig fields on `HyperdriveConfig` and `YieldSourceConfig` to complete the migration to the new rewards system