### PR TITLE
Move account address into route for portfolio page

### DIFF
--- a/apps/hyperdrive-trading/src/routeTree.gen.ts
+++ b/apps/hyperdrive-trading/src/routeTree.gen.ts
@@ -10,229 +10,229 @@
 
 // Import Routes
 
-import { Route as rootRoute } from "./ui/routes/__root";
-import { Route as ChainlogImport } from "./ui/routes/chainlog";
-import { Route as ErrorImport } from "./ui/routes/error";
-import { Route as IndexImport } from "./ui/routes/index";
-import { Route as IneligibleImport } from "./ui/routes/ineligible";
-import { Route as MarketChainIdAddressImport } from "./ui/routes/market.$chainId.$address";
-import { Route as MintImport } from "./ui/routes/mint";
-import { Route as PointsmarketsImport } from "./ui/routes/points_markets";
-import { Route as PortfolioImport } from "./ui/routes/portfolio";
-import { Route as RestrictedcountriesImport } from "./ui/routes/restricted_countries";
+import { Route as rootRoute } from './ui/routes/__root'
+import { Route as RestrictedcountriesImport } from './ui/routes/restricted_countries'
+import { Route as PortfolioImport } from './ui/routes/portfolio'
+import { Route as PointsmarketsImport } from './ui/routes/points_markets'
+import { Route as MintImport } from './ui/routes/mint'
+import { Route as IneligibleImport } from './ui/routes/ineligible'
+import { Route as ErrorImport } from './ui/routes/error'
+import { Route as ChainlogImport } from './ui/routes/chainlog'
+import { Route as IndexImport } from './ui/routes/index'
+import { Route as MarketChainIdAddressImport } from './ui/routes/market.$chainId.$address'
 
 // Create/Update Routes
 
 const RestrictedcountriesRoute = RestrictedcountriesImport.update({
-  id: "/restricted_countries",
-  path: "/restricted_countries",
+  id: '/restricted_countries',
+  path: '/restricted_countries',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const PortfolioRoute = PortfolioImport.update({
-  id: "/portfolio",
-  path: "/portfolio",
+  id: '/portfolio',
+  path: '/portfolio',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const PointsmarketsRoute = PointsmarketsImport.update({
-  id: "/points_markets",
-  path: "/points_markets",
+  id: '/points_markets',
+  path: '/points_markets',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const MintRoute = MintImport.update({
-  id: "/mint",
-  path: "/mint",
+  id: '/mint',
+  path: '/mint',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const IneligibleRoute = IneligibleImport.update({
-  id: "/ineligible",
-  path: "/ineligible",
+  id: '/ineligible',
+  path: '/ineligible',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const ErrorRoute = ErrorImport.update({
-  id: "/error",
-  path: "/error",
+  id: '/error',
+  path: '/error',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const ChainlogRoute = ChainlogImport.update({
-  id: "/chainlog",
-  path: "/chainlog",
+  id: '/chainlog',
+  path: '/chainlog',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const IndexRoute = IndexImport.update({
-  id: "/",
-  path: "/",
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const MarketChainIdAddressRoute = MarketChainIdAddressImport.update({
-  id: "/market/$chainId/$address",
-  path: "/market/$chainId/$address",
+  id: '/market/$chainId/$address',
+  path: '/market/$chainId/$address',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 // Populate the FileRoutesByPath interface
 
-declare module "@tanstack/react-router" {
+declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    "/": {
-      id: "/";
-      path: "/";
-      fullPath: "/";
-      preLoaderRoute: typeof IndexImport;
-      parentRoute: typeof rootRoute;
-    };
-    "/chainlog": {
-      id: "/chainlog";
-      path: "/chainlog";
-      fullPath: "/chainlog";
-      preLoaderRoute: typeof ChainlogImport;
-      parentRoute: typeof rootRoute;
-    };
-    "/error": {
-      id: "/error";
-      path: "/error";
-      fullPath: "/error";
-      preLoaderRoute: typeof ErrorImport;
-      parentRoute: typeof rootRoute;
-    };
-    "/ineligible": {
-      id: "/ineligible";
-      path: "/ineligible";
-      fullPath: "/ineligible";
-      preLoaderRoute: typeof IneligibleImport;
-      parentRoute: typeof rootRoute;
-    };
-    "/mint": {
-      id: "/mint";
-      path: "/mint";
-      fullPath: "/mint";
-      preLoaderRoute: typeof MintImport;
-      parentRoute: typeof rootRoute;
-    };
-    "/points_markets": {
-      id: "/points_markets";
-      path: "/points_markets";
-      fullPath: "/points_markets";
-      preLoaderRoute: typeof PointsmarketsImport;
-      parentRoute: typeof rootRoute;
-    };
-    "/portfolio": {
-      id: "/portfolio";
-      path: "/portfolio";
-      fullPath: "/portfolio";
-      preLoaderRoute: typeof PortfolioImport;
-      parentRoute: typeof rootRoute;
-    };
-    "/restricted_countries": {
-      id: "/restricted_countries";
-      path: "/restricted_countries";
-      fullPath: "/restricted_countries";
-      preLoaderRoute: typeof RestrictedcountriesImport;
-      parentRoute: typeof rootRoute;
-    };
-    "/market/$chainId/$address": {
-      id: "/market/$chainId/$address";
-      path: "/market/$chainId/$address";
-      fullPath: "/market/$chainId/$address";
-      preLoaderRoute: typeof MarketChainIdAddressImport;
-      parentRoute: typeof rootRoute;
-    };
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexImport
+      parentRoute: typeof rootRoute
+    }
+    '/chainlog': {
+      id: '/chainlog'
+      path: '/chainlog'
+      fullPath: '/chainlog'
+      preLoaderRoute: typeof ChainlogImport
+      parentRoute: typeof rootRoute
+    }
+    '/error': {
+      id: '/error'
+      path: '/error'
+      fullPath: '/error'
+      preLoaderRoute: typeof ErrorImport
+      parentRoute: typeof rootRoute
+    }
+    '/ineligible': {
+      id: '/ineligible'
+      path: '/ineligible'
+      fullPath: '/ineligible'
+      preLoaderRoute: typeof IneligibleImport
+      parentRoute: typeof rootRoute
+    }
+    '/mint': {
+      id: '/mint'
+      path: '/mint'
+      fullPath: '/mint'
+      preLoaderRoute: typeof MintImport
+      parentRoute: typeof rootRoute
+    }
+    '/points_markets': {
+      id: '/points_markets'
+      path: '/points_markets'
+      fullPath: '/points_markets'
+      preLoaderRoute: typeof PointsmarketsImport
+      parentRoute: typeof rootRoute
+    }
+    '/portfolio': {
+      id: '/portfolio'
+      path: '/portfolio'
+      fullPath: '/portfolio'
+      preLoaderRoute: typeof PortfolioImport
+      parentRoute: typeof rootRoute
+    }
+    '/restricted_countries': {
+      id: '/restricted_countries'
+      path: '/restricted_countries'
+      fullPath: '/restricted_countries'
+      preLoaderRoute: typeof RestrictedcountriesImport
+      parentRoute: typeof rootRoute
+    }
+    '/market/$chainId/$address': {
+      id: '/market/$chainId/$address'
+      path: '/market/$chainId/$address'
+      fullPath: '/market/$chainId/$address'
+      preLoaderRoute: typeof MarketChainIdAddressImport
+      parentRoute: typeof rootRoute
+    }
   }
 }
 
 // Create and export the route tree
 
 export interface FileRoutesByFullPath {
-  "/": typeof IndexRoute;
-  "/chainlog": typeof ChainlogRoute;
-  "/error": typeof ErrorRoute;
-  "/ineligible": typeof IneligibleRoute;
-  "/mint": typeof MintRoute;
-  "/points_markets": typeof PointsmarketsRoute;
-  "/portfolio": typeof PortfolioRoute;
-  "/restricted_countries": typeof RestrictedcountriesRoute;
-  "/market/$chainId/$address": typeof MarketChainIdAddressRoute;
+  '/': typeof IndexRoute
+  '/chainlog': typeof ChainlogRoute
+  '/error': typeof ErrorRoute
+  '/ineligible': typeof IneligibleRoute
+  '/mint': typeof MintRoute
+  '/points_markets': typeof PointsmarketsRoute
+  '/portfolio': typeof PortfolioRoute
+  '/restricted_countries': typeof RestrictedcountriesRoute
+  '/market/$chainId/$address': typeof MarketChainIdAddressRoute
 }
 
 export interface FileRoutesByTo {
-  "/": typeof IndexRoute;
-  "/chainlog": typeof ChainlogRoute;
-  "/error": typeof ErrorRoute;
-  "/ineligible": typeof IneligibleRoute;
-  "/mint": typeof MintRoute;
-  "/points_markets": typeof PointsmarketsRoute;
-  "/portfolio": typeof PortfolioRoute;
-  "/restricted_countries": typeof RestrictedcountriesRoute;
-  "/market/$chainId/$address": typeof MarketChainIdAddressRoute;
+  '/': typeof IndexRoute
+  '/chainlog': typeof ChainlogRoute
+  '/error': typeof ErrorRoute
+  '/ineligible': typeof IneligibleRoute
+  '/mint': typeof MintRoute
+  '/points_markets': typeof PointsmarketsRoute
+  '/portfolio': typeof PortfolioRoute
+  '/restricted_countries': typeof RestrictedcountriesRoute
+  '/market/$chainId/$address': typeof MarketChainIdAddressRoute
 }
 
 export interface FileRoutesById {
-  __root__: typeof rootRoute;
-  "/": typeof IndexRoute;
-  "/chainlog": typeof ChainlogRoute;
-  "/error": typeof ErrorRoute;
-  "/ineligible": typeof IneligibleRoute;
-  "/mint": typeof MintRoute;
-  "/points_markets": typeof PointsmarketsRoute;
-  "/portfolio": typeof PortfolioRoute;
-  "/restricted_countries": typeof RestrictedcountriesRoute;
-  "/market/$chainId/$address": typeof MarketChainIdAddressRoute;
+  __root__: typeof rootRoute
+  '/': typeof IndexRoute
+  '/chainlog': typeof ChainlogRoute
+  '/error': typeof ErrorRoute
+  '/ineligible': typeof IneligibleRoute
+  '/mint': typeof MintRoute
+  '/points_markets': typeof PointsmarketsRoute
+  '/portfolio': typeof PortfolioRoute
+  '/restricted_countries': typeof RestrictedcountriesRoute
+  '/market/$chainId/$address': typeof MarketChainIdAddressRoute
 }
 
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath;
+  fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
-    | "/"
-    | "/chainlog"
-    | "/error"
-    | "/ineligible"
-    | "/mint"
-    | "/points_markets"
-    | "/portfolio"
-    | "/restricted_countries"
-    | "/market/$chainId/$address";
-  fileRoutesByTo: FileRoutesByTo;
+    | '/'
+    | '/chainlog'
+    | '/error'
+    | '/ineligible'
+    | '/mint'
+    | '/points_markets'
+    | '/portfolio'
+    | '/restricted_countries'
+    | '/market/$chainId/$address'
+  fileRoutesByTo: FileRoutesByTo
   to:
-    | "/"
-    | "/chainlog"
-    | "/error"
-    | "/ineligible"
-    | "/mint"
-    | "/points_markets"
-    | "/portfolio"
-    | "/restricted_countries"
-    | "/market/$chainId/$address";
+    | '/'
+    | '/chainlog'
+    | '/error'
+    | '/ineligible'
+    | '/mint'
+    | '/points_markets'
+    | '/portfolio'
+    | '/restricted_countries'
+    | '/market/$chainId/$address'
   id:
-    | "__root__"
-    | "/"
-    | "/chainlog"
-    | "/error"
-    | "/ineligible"
-    | "/mint"
-    | "/points_markets"
-    | "/portfolio"
-    | "/restricted_countries"
-    | "/market/$chainId/$address";
-  fileRoutesById: FileRoutesById;
+    | '__root__'
+    | '/'
+    | '/chainlog'
+    | '/error'
+    | '/ineligible'
+    | '/mint'
+    | '/points_markets'
+    | '/portfolio'
+    | '/restricted_countries'
+    | '/market/$chainId/$address'
+  fileRoutesById: FileRoutesById
 }
 
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute;
-  ChainlogRoute: typeof ChainlogRoute;
-  ErrorRoute: typeof ErrorRoute;
-  IneligibleRoute: typeof IneligibleRoute;
-  MintRoute: typeof MintRoute;
-  PointsmarketsRoute: typeof PointsmarketsRoute;
-  PortfolioRoute: typeof PortfolioRoute;
-  RestrictedcountriesRoute: typeof RestrictedcountriesRoute;
-  MarketChainIdAddressRoute: typeof MarketChainIdAddressRoute;
+  IndexRoute: typeof IndexRoute
+  ChainlogRoute: typeof ChainlogRoute
+  ErrorRoute: typeof ErrorRoute
+  IneligibleRoute: typeof IneligibleRoute
+  MintRoute: typeof MintRoute
+  PointsmarketsRoute: typeof PointsmarketsRoute
+  PortfolioRoute: typeof PortfolioRoute
+  RestrictedcountriesRoute: typeof RestrictedcountriesRoute
+  MarketChainIdAddressRoute: typeof MarketChainIdAddressRoute
 }
 
 const rootRouteChildren: RootRouteChildren = {
@@ -245,11 +245,11 @@ const rootRouteChildren: RootRouteChildren = {
   PortfolioRoute: PortfolioRoute,
   RestrictedcountriesRoute: RestrictedcountriesRoute,
   MarketChainIdAddressRoute: MarketChainIdAddressRoute,
-};
+}
 
 export const routeTree = rootRoute
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>();
+  ._addFileTypes<FileRouteTypes>()
 
 /* ROUTE_MANIFEST_START
 {

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongForm/CloseLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongForm/CloseLongForm.tsx
@@ -36,21 +36,22 @@ import {
   ZapsTokenPicker,
 } from "src/ui/token/TokenPicker";
 import { useTokenList } from "src/ui/tokenlist/useTokenList";
-import { formatUnits, parseUnits } from "viem";
-import { useAccount, useChainId } from "wagmi";
+import { Address, formatUnits, parseUnits } from "viem";
+import { useChainId } from "wagmi";
 
 interface CloseLongFormProps {
   hyperdrive: HyperdriveConfig;
   long: Long;
+  account: Address | undefined;
   onCloseLong?: (e: MouseEvent<HTMLButtonElement>) => void;
 }
 
 export function CloseLongForm({
   hyperdrive,
+  account,
   long,
   onCloseLong,
 }: CloseLongFormProps): ReactElement {
-  const { address: account } = useAccount();
   const connectedChainId = useChainId();
   const defaultItems: TokenConfig[] = [];
   const appConfig = useAppConfigForConnectedChain();

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongModalButton/CloseLongModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongModalButton/CloseLongModalButton.tsx
@@ -10,15 +10,18 @@ import { useAppConfigForConnectedChain } from "src/ui/appconfig/useAppConfigForC
 import { Modal } from "src/ui/base/components/Modal/Modal";
 import { ModalHeader } from "src/ui/base/components/Modal/ModalHeader";
 import { CloseLongForm } from "src/ui/hyperdrive/longs/CloseLongForm/CloseLongForm";
+import { Address } from "viem";
 
 export interface CloseLongModalButtonProps {
   modalId: string;
   hyperdrive: HyperdriveConfig;
+  account: Address | undefined;
   long: Long;
 }
 export function CloseLongModalButton({
   modalId,
   long,
+  account,
   hyperdrive,
 }: CloseLongModalButtonProps): ReactElement {
   const appConfig = useAppConfigForConnectedChain();
@@ -45,6 +48,7 @@ export function CloseLongModalButton({
         <div>
           <CloseLongForm
             hyperdrive={hyperdrive}
+            account={account}
             long={long}
             onCloseLong={(e) => {
               // preventDefault since we don't want to close the modal while the

--- a/apps/hyperdrive-trading/src/ui/portfolio/Portfolio.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/Portfolio.tsx
@@ -17,7 +17,7 @@ export function Portfolio(): ReactElement {
   const activeTab = position ?? "longs";
 
   const { address: connectedAccount } = useAccount();
-  const account = accountFromRoute ?? connectedAccount;
+  const account = (accountFromRoute ?? connectedAccount) as Address | undefined;
   const navigate = useNavigate({ from: PORTFOLIO_ROUTE });
 
   const { isFlagEnabled: isPortfolioRewardsFeatureFlagEnabled } =
@@ -25,11 +25,11 @@ export function Portfolio(): ReactElement {
   const tabs = [
     {
       id: "longs",
-      content: <OpenLongsContainer account={account as Address} />,
+      content: <OpenLongsContainer account={account} />,
       label: "Long",
       onClick: () => {
         navigate({
-          search: () => ({ position: "longs" }),
+          search: (prev) => ({ ...prev, position: "longs" }),
         });
       },
     },
@@ -39,7 +39,7 @@ export function Portfolio(): ReactElement {
       label: "Short",
       onClick: () => {
         navigate({
-          search: () => ({ position: "shorts" }),
+          search: (prev) => ({ ...prev, position: "shorts" }),
         });
       },
     },
@@ -49,7 +49,7 @@ export function Portfolio(): ReactElement {
       label: "LP",
       onClick: () => {
         navigate({
-          search: () => ({ position: "lp" }),
+          search: (prev) => ({ ...prev, position: "lp" }),
         });
       },
     },
@@ -61,7 +61,7 @@ export function Portfolio(): ReactElement {
       label: "Rewards",
       onClick: () => {
         navigate({
-          search: () => ({ position: "rewards" }),
+          search: (prev) => ({ ...prev, position: "rewards" }),
         });
       },
     });

--- a/apps/hyperdrive-trading/src/ui/portfolio/Portfolio.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/Portfolio.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useSearch } from "@tanstack/react-router";
+import { Navigate, useNavigate, useSearch } from "@tanstack/react-router";
 import { ReactElement } from "react";
 import { Tabs } from "src/ui/base/components/Tabs/Tabs";
 import { useFeatureFlag } from "src/ui/base/featureFlags/featureFlags";
@@ -7,17 +7,25 @@ import { LpAndWithdrawalSharesContainer } from "src/ui/portfolio/lp/LpAndWithdra
 import { RewardsContainer } from "src/ui/portfolio/rewards/RewardsContainer";
 import { PORTFOLIO_ROUTE } from "src/ui/portfolio/routes";
 import { OpenShortsContainer } from "src/ui/portfolio/shorts/ShortsContainer";
+import { Address } from "viem";
+import { useAccount } from "wagmi";
 
 export function Portfolio(): ReactElement {
-  const { position } = useSearch({ from: PORTFOLIO_ROUTE });
-  const navigate = useNavigate({ from: PORTFOLIO_ROUTE });
+  const { position, account: accountFromRoute } = useSearch({
+    from: PORTFOLIO_ROUTE,
+  });
   const activeTab = position ?? "longs";
+
+  const { address: connectedAccount } = useAccount();
+  const account = accountFromRoute ?? connectedAccount;
+  const navigate = useNavigate({ from: PORTFOLIO_ROUTE });
+
   const { isFlagEnabled: isPortfolioRewardsFeatureFlagEnabled } =
     useFeatureFlag("portfolio-rewards");
   const tabs = [
     {
       id: "longs",
-      content: <OpenLongsContainer />,
+      content: <OpenLongsContainer account={account as Address} />,
       label: "Long",
       onClick: () => {
         navigate({
@@ -60,6 +68,12 @@ export function Portfolio(): ReactElement {
   }
   return (
     <div className="flex w-full flex-col items-center bg-base-100 py-8">
+      {!accountFromRoute && connectedAccount ? (
+        <Navigate
+          from={PORTFOLIO_ROUTE}
+          search={(prev) => ({ ...prev, account })}
+        />
+      ) : null}
       <Tabs activeTabId={activeTab} tabs={tabs} />
     </div>
   );

--- a/apps/hyperdrive-trading/src/ui/portfolio/longs/LongsContainer.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/longs/LongsContainer.tsx
@@ -14,7 +14,7 @@ import { OpenLongsTableDesktop } from "./OpenLongsTable/OpenLongsTableDesktop";
 export function OpenLongsContainer({
   account,
 }: {
-  account?: Address;
+  account: Address | undefined;
 }): ReactElement {
   const appConfig = useAppConfigForConnectedChain();
   const { openLongPositions, openLongPositionsStatus } = usePortfolioLongsData({
@@ -73,7 +73,11 @@ export function OpenLongsContainer({
     <PositionContainer className="mt-10">
       {Object.entries(hyperdrivesByChainAndYieldSource).map(
         ([key, hyperdrives]) => (
-          <OpenLongsTableDesktop hyperdrives={hyperdrives} key={key} />
+          <OpenLongsTableDesktop
+            key={key}
+            hyperdrives={hyperdrives}
+            account={account}
+          />
         ),
       )}
     </PositionContainer>

--- a/apps/hyperdrive-trading/src/ui/portfolio/longs/LongsContainer.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/longs/LongsContainer.tsx
@@ -8,14 +8,19 @@ import { NonIdealState } from "src/ui/base/components/NonIdealState";
 import { usePortfolioLongsData } from "src/ui/portfolio/longs/usePortfolioLongsData";
 import { NoWalletConnected } from "src/ui/portfolio/NoWalletConnected";
 import { PositionContainer } from "src/ui/portfolio/PositionContainer";
-import { useAccount } from "wagmi";
+import { Address } from "viem";
 import { OpenLongsTableDesktop } from "./OpenLongsTable/OpenLongsTableDesktop";
 
-export function OpenLongsContainer(): ReactElement {
-  const { address: account } = useAccount();
-  const { openLongPositions, openLongPositionsStatus } =
-    usePortfolioLongsData();
+export function OpenLongsContainer({
+  account,
+}: {
+  account?: Address;
+}): ReactElement {
   const appConfig = useAppConfigForConnectedChain();
+  const { openLongPositions, openLongPositionsStatus } = usePortfolioLongsData({
+    account,
+  });
+
   const hyperdrivesByChainAndYieldSource = groupBy(
     appConfig.hyperdrives,
     (hyperdrive) => `${hyperdrive.chainId}-${hyperdrive.yieldSource}`,

--- a/apps/hyperdrive-trading/src/ui/portfolio/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
@@ -33,16 +33,17 @@ import { ManageLongsButton } from "src/ui/portfolio/longs/OpenLongsTable/ManageL
 import { TotalOpenLongsValue } from "src/ui/portfolio/longs/TotalOpenLongsValue/TotalOpenLongsValue";
 import { usePortfolioLongsDataFromHyperdrives } from "src/ui/portfolio/longs/usePortfolioLongsData";
 import { PositionTableHeading } from "src/ui/portfolio/PositionTableHeading";
-import { useAccount } from "wagmi";
+import { Address } from "viem";
 
 export function OpenLongsTableDesktop({
   hyperdrives,
+  account,
 }: {
   hyperdrives: HyperdriveConfig[];
+  account: Address | undefined;
 }): ReactElement | null {
-  const { address: account } = useAccount();
   const { openLongPositions, openLongPositionsStatus } =
-    usePortfolioLongsDataFromHyperdrives(hyperdrives);
+    usePortfolioLongsDataFromHyperdrives({ hyperdrives, account });
   const openLongPositionsExist = openLongPositions?.some(
     (position) => position.details !== undefined,
   );
@@ -94,6 +95,7 @@ export function OpenLongsTableDesktop({
         hyperdrive={hyperdrives[0]}
         rightElement={
           <TotalOpenLongsValue
+            account={account}
             hyperdrives={hyperdrives}
             openLongs={openLongPositions}
           />
@@ -112,6 +114,7 @@ export function OpenLongsTableDesktop({
           return (
             <CloseLongModalButton
               key={modalId}
+              account={account}
               hyperdrive={original.hyperdrive}
               modalId={modalId}
               long={{

--- a/apps/hyperdrive-trading/src/ui/portfolio/longs/TotalOpenLongsValue/TotalOpenLongsValue.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/longs/TotalOpenLongsValue/TotalOpenLongsValue.tsx
@@ -7,19 +7,19 @@ import { useAppConfigForConnectedChain } from "src/ui/appconfig/useAppConfigForC
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { useTotalOpenLongsValueTwo } from "src/ui/hyperdrive/longs/hooks/useTotalOpenLongsValue";
 import { useTokenFiatPrice } from "src/ui/token/hooks/useTokenFiatPrice";
-import { useAccount } from "wagmi";
+import { Address } from "viem";
 
 export function TotalOpenLongsValue({
   hyperdrives,
   openLongs,
+  account,
 }: {
   hyperdrives: HyperdriveConfig[];
+  account: Address | undefined;
   openLongs:
     | (OpenLongPositionReceived & { hyperdrive: HyperdriveConfig })[]
     | undefined;
 }): ReactElement {
-  const { address: account } = useAccount();
-
   const { totalOpenLongsValue, isLoading } = useTotalOpenLongsValueTwo({
     account,
     longs: openLongs,

--- a/apps/hyperdrive-trading/src/ui/portfolio/longs/usePortfolioLongsData.ts
+++ b/apps/hyperdrive-trading/src/ui/portfolio/longs/usePortfolioLongsData.ts
@@ -7,6 +7,7 @@ import { useQuery } from "@tanstack/react-query";
 import { makeQueryKey, makeQueryKey2 } from "src/base/makeQueryKey";
 import { getDrift } from "src/drift/getDrift";
 import { useAppConfigForConnectedChain } from "src/ui/appconfig/useAppConfigForConnectedChain";
+import { Address } from "viem";
 import { useAccount } from "wagmi";
 
 export type OpenLongPositionsData = {
@@ -14,11 +15,16 @@ export type OpenLongPositionsData = {
   openLongs: OpenLongPositionReceived[];
 }[];
 
-export function usePortfolioLongsData(): {
+export function usePortfolioLongsData({
+  account: accountFromProps,
+}: {
+  account?: Address;
+}): {
   openLongPositions: OpenLongPositionsData | undefined;
   openLongPositionsStatus: "error" | "success" | "loading";
 } {
-  const { address: account } = useAccount();
+  const { address: connectedAccount } = useAccount();
+  const account = accountFromProps ?? connectedAccount;
   const appConfigForConnectedChain = useAppConfigForConnectedChain();
   const queryEnabled = !!account && !!appConfigForConnectedChain;
 
@@ -44,7 +50,7 @@ export function usePortfolioLongsData(): {
                     ...long,
                     details: await readHyperdrive.getOpenLongDetails({
                       assetId: long.assetId,
-                      account: account,
+                      account,
                     }),
                   })),
                 );

--- a/apps/hyperdrive-trading/src/ui/portfolio/longs/usePortfolioLongsData.ts
+++ b/apps/hyperdrive-trading/src/ui/portfolio/longs/usePortfolioLongsData.ts
@@ -8,7 +8,6 @@ import { makeQueryKey, makeQueryKey2 } from "src/base/makeQueryKey";
 import { getDrift } from "src/drift/getDrift";
 import { useAppConfigForConnectedChain } from "src/ui/appconfig/useAppConfigForConnectedChain";
 import { Address } from "viem";
-import { useAccount } from "wagmi";
 
 export type OpenLongPositionsData = {
   hyperdrive: HyperdriveConfig;
@@ -16,15 +15,13 @@ export type OpenLongPositionsData = {
 }[];
 
 export function usePortfolioLongsData({
-  account: accountFromProps,
+  account,
 }: {
-  account?: Address;
+  account: Address | undefined;
 }): {
   openLongPositions: OpenLongPositionsData | undefined;
   openLongPositionsStatus: "error" | "success" | "loading";
 } {
-  const { address: connectedAccount } = useAccount();
-  const account = accountFromProps ?? connectedAccount;
   const appConfigForConnectedChain = useAppConfigForConnectedChain();
   const queryEnabled = !!account && !!appConfigForConnectedChain;
 
@@ -70,15 +67,18 @@ export function usePortfolioLongsData({
   };
 }
 
-export function usePortfolioLongsDataFromHyperdrives(
-  hyperdrives: HyperdriveConfig[],
-): {
+export function usePortfolioLongsDataFromHyperdrives({
+  hyperdrives,
+  account,
+}: {
+  hyperdrives: HyperdriveConfig[];
+  account: Address | undefined;
+}): {
   openLongPositions:
     | (OpenLongPositionReceived & { hyperdrive: HyperdriveConfig })[]
     | undefined;
   openLongPositionsStatus: "error" | "success" | "loading";
 } {
-  const { address: account } = useAccount();
   const queryEnabled = !!account && !!hyperdrives.length;
 
   const { data: openLongPositions, status: openLongPositionsStatus } = useQuery(
@@ -111,6 +111,7 @@ export function usePortfolioLongsDataFromHyperdrives(
                     }),
                   })),
                 );
+                console.log("openLongs", openLongs);
 
                 return openLongs;
               }),

--- a/apps/hyperdrive-trading/src/ui/routes/portfolio.tsx
+++ b/apps/hyperdrive-trading/src/ui/routes/portfolio.tsx
@@ -11,5 +11,6 @@ export const Route = createFileRoute(PORTFOLIO_ROUTE)({
   ),
   validateSearch: z.object({
     position: z.enum(["longs", "shorts", "lp", "rewards"]).optional(),
+    account: z.string().optional(),
   }),
 });


### PR DESCRIPTION
Moving the `account` into the url search params so that we can view any wallet's portfolio we want, not just the connected wallet.

This PR adds the new routing logic for the `account` param, and wires up the Longs tab. Other tabs to follow in the next PR.