### PR TITLE
Wire up remaining portfolio components to account from route

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortForm/CloseShortForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortForm/CloseShortForm.tsx
@@ -24,21 +24,22 @@ import { useTokenBalance } from "src/ui/token/hooks/useTokenBalance";
 import { useTokenFiatPrice } from "src/ui/token/hooks/useTokenFiatPrice";
 import { TokenInput } from "src/ui/token/TokenInput";
 import { TokenChoice, TokenPicker } from "src/ui/token/TokenPicker";
-import { formatUnits, parseUnits } from "viem";
-import { useAccount, useChainId } from "wagmi";
+import { Address, formatUnits, parseUnits } from "viem";
+import { useChainId } from "wagmi";
 
 interface CloseShortFormProps {
   hyperdrive: HyperdriveConfig;
   // TODO: Refactor this to only need the positionSize and maturity time
   short: OpenShort;
+  account: Address | undefined;
   onCloseShort?: (e: MouseEvent<HTMLButtonElement>) => void;
 }
 
 export function CloseShortForm({
   hyperdrive,
+  account,
   short,
 }: CloseShortFormProps): ReactElement {
-  const { address: account } = useAccount();
   const connectedChainId = useChainId();
   const defaultItems = [];
   const appConfig = useAppConfigForConnectedChain();

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortModalButton/CloseShortModalButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/CloseShortModalButton/CloseShortModalButton.tsx
@@ -10,15 +10,18 @@ import { useAppConfigForConnectedChain } from "src/ui/appconfig/useAppConfigForC
 import { Modal } from "src/ui/base/components/Modal/Modal";
 import { ModalHeader } from "src/ui/base/components/Modal/ModalHeader";
 import { CloseShortForm } from "src/ui/hyperdrive/shorts/CloseShortForm/CloseShortForm";
+import { Address } from "viem";
 
 export interface CloseShortModalButtonProps {
   modalId: string;
   hyperdrive: HyperdriveConfig;
+  account: Address | undefined;
   short: OpenShort;
 }
 export function CloseShortModalButton({
   modalId,
   short,
+  account,
   hyperdrive,
 }: CloseShortModalButtonProps): ReactElement {
   const appConfig = useAppConfigForConnectedChain();
@@ -44,6 +47,7 @@ export function CloseShortModalButton({
       modalId={modalId}
       modalContent={
         <CloseShortForm
+          account={account}
           hyperdrive={hyperdrive}
           short={short}
           onCloseShort={(e) => {

--- a/apps/hyperdrive-trading/src/ui/portfolio/Portfolio.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/Portfolio.tsx
@@ -57,7 +57,7 @@ export function Portfolio(): ReactElement {
   if (isPortfolioRewardsFeatureFlagEnabled) {
     tabs.push({
       id: "rewards",
-      content: <RewardsContainer />,
+      content: <RewardsContainer account={account} />,
       label: "Rewards",
       onClick: () => {
         navigate({

--- a/apps/hyperdrive-trading/src/ui/portfolio/Portfolio.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/Portfolio.tsx
@@ -35,7 +35,7 @@ export function Portfolio(): ReactElement {
     },
     {
       id: "shorts",
-      content: <OpenShortsContainer />,
+      content: <OpenShortsContainer account={account} />,
       label: "Short",
       onClick: () => {
         navigate({

--- a/apps/hyperdrive-trading/src/ui/portfolio/Portfolio.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/Portfolio.tsx
@@ -45,7 +45,7 @@ export function Portfolio(): ReactElement {
     },
     {
       id: "lp",
-      content: <LpAndWithdrawalSharesContainer />,
+      content: <LpAndWithdrawalSharesContainer account={account} />,
       label: "LP",
       onClick: () => {
         navigate({

--- a/apps/hyperdrive-trading/src/ui/portfolio/longs/OpenLongsTable/ManageLongsButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/longs/OpenLongsTable/ManageLongsButton.tsx
@@ -4,15 +4,20 @@ import { Link } from "@tanstack/react-router";
 import { ReactElement, useRef, useState } from "react";
 import { useClickAway } from "react-use";
 import { MARKET_DETAILS_ROUTE } from "src/ui/markets/routes";
+import { Address } from "viem";
+import { useAccount } from "wagmi";
 
 export function ManageLongsButton({
   hyperdrive,
   assetId,
+  account: accountFromProps,
 }: {
   hyperdrive: HyperdriveConfig;
+  account: Address | undefined;
   assetId: bigint;
 }): ReactElement {
   const [isOpen, setIsOpen] = useState(false);
+  const { address: connectedAccount } = useAccount();
   const dropdownRef = useRef<HTMLDivElement>(null);
   useClickAway(dropdownRef, () => setIsOpen(false));
   return (
@@ -29,17 +34,19 @@ export function ManageLongsButton({
       </button>
       {isOpen && (
         <ul className="absolute right-6 top-full z-50 mt-4 w-[300px] rounded-box border border-neutral-content/20 bg-neutral px-4 py-1">
-          <button
-            className="m-0 flex h-[52px] w-full flex-row items-center justify-start border-b-2 border-b-neutral-content/20 p-0 text-start hover:bg-neutral hover:text-neutral-content"
-            onClick={() => {
-              const modalId = `${assetId}`;
-              (
-                document.getElementById(modalId) as HTMLDialogElement
-              ).showModal();
-            }}
-          >
-            Close Long
-          </button>
+          {accountFromProps !== connectedAccount ? null : (
+            <button
+              className="m-0 flex h-[52px] w-full flex-row items-center justify-start border-b-2 border-b-neutral-content/20 p-0 text-start hover:bg-neutral hover:text-neutral-content"
+              onClick={() => {
+                const modalId = `${assetId}`;
+                (
+                  document.getElementById(modalId) as HTMLDialogElement
+                ).showModal();
+              }}
+            >
+              Close Long
+            </button>
+          )}
           <Link
             className="m-0 flex h-[52px] w-full flex-row items-center justify-start p-0 text-start hover:bg-neutral hover:text-neutral-content"
             to={MARKET_DETAILS_ROUTE}

--- a/apps/hyperdrive-trading/src/ui/portfolio/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
@@ -50,8 +50,8 @@ export function OpenLongsTableDesktop({
 
   const appConfig = useAppConfigForConnectedChain();
   const columns = useMemo(() => {
-    return getColumns({ hyperdrives, appConfig });
-  }, [hyperdrives]);
+    return getColumns({ account, hyperdrives, appConfig });
+  }, [hyperdrives, account]);
   const tableInstance = useReactTable({
     columns: columns,
     data: openLongPositions || [],
@@ -236,9 +236,11 @@ const columnHelper = createColumnHelper<
 
 function getColumns({
   hyperdrives,
+  account,
   appConfig,
 }: {
   hyperdrives: HyperdriveConfig[];
+  account: Address | undefined;
   appConfig: AppConfig;
 }) {
   const baseToken = getBaseToken({
@@ -339,6 +341,7 @@ function getColumns({
         return (
           <ManageLongsButton
             assetId={getValue()}
+            account={account}
             hyperdrive={row.original.hyperdrive}
             key={getValue()}
           />

--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesContainer.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesContainer.tsx
@@ -9,10 +9,15 @@ import { OpenLpTableDesktop } from "src/ui/portfolio/lp/LpAndWithdrawalSharesTab
 import { usePortfolioLpData } from "src/ui/portfolio/lp/usePortfolioLpData";
 import { NoWalletConnected } from "src/ui/portfolio/NoWalletConnected";
 import { PositionContainer } from "src/ui/portfolio/PositionContainer";
-import { useAccount } from "wagmi";
-export function LpAndWithdrawalSharesContainer(): ReactElement {
-  const { openLpPositions, openLpPositionStatus } = usePortfolioLpData();
-  const { address: account } = useAccount();
+import { Address } from "viem";
+export function LpAndWithdrawalSharesContainer({
+  account,
+}: {
+  account: Address | undefined;
+}): ReactElement {
+  const { openLpPositions, openLpPositionStatus } = usePortfolioLpData({
+    account,
+  });
   const appConfig = useAppConfigForConnectedChain();
   const hyperdrivesByChainAndYieldSource = groupBy(
     appConfig.hyperdrives,
@@ -80,7 +85,11 @@ export function LpAndWithdrawalSharesContainer(): ReactElement {
     <PositionContainer className="mt-10">
       {Object.entries(hyperdrivesByChainAndYieldSource).map(
         ([key, hyperdrives]) => (
-          <OpenLpTableDesktop hyperdrives={hyperdrives} key={key} />
+          <OpenLpTableDesktop
+            account={account}
+            hyperdrives={hyperdrives}
+            key={key}
+          />
         ),
       )}
     </PositionContainer>

--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable.tsx
@@ -22,19 +22,20 @@ import { TotalLpValue } from "src/ui/portfolio/lp/LpAndWithdrawalSharesTable/Tot
 import { WithdrawalQueueCell } from "src/ui/portfolio/lp/LpAndWithdrawalSharesTable/WithdrawalQueueCell";
 import { usePortfolioLpDataFromHyperdrives } from "src/ui/portfolio/lp/usePortfolioLpData";
 import { PositionTableHeading } from "src/ui/portfolio/PositionTableHeading";
-import { useAccount } from "wagmi";
+import { Address } from "viem";
 
 export function OpenLpTableDesktop({
   hyperdrives,
+  account,
 }: {
   hyperdrives: HyperdriveConfig[];
+  account: Address | undefined;
 }): ReactElement | null {
-  const { address: account } = useAccount();
   const { openLpPositions } = usePortfolioLpDataFromHyperdrives(hyperdrives);
   const appConfig = useAppConfigForConnectedChain();
   const columns = useMemo(
-    () => getColumns({ hyperdrives, appConfig }),
-    [hyperdrives],
+    () => getColumns({ account, hyperdrives, appConfig }),
+    [hyperdrives, account],
   );
 
   const tableData = useMemo(
@@ -75,6 +76,7 @@ export function OpenLpTableDesktop({
         hyperdrive={hyperdrives[0]}
         rightElement={
           <TotalLpValue
+            account={account}
             hyperdrive={hyperdrives[0]}
             openLpPositions={openLpPositions}
           />
@@ -173,9 +175,11 @@ const columnHelper = createColumnHelper<{
 
 function getColumns({
   hyperdrives,
+  account,
   appConfig,
 }: {
   hyperdrives: HyperdriveConfig[];
+  account: Address | undefined;
   appConfig: AppConfig;
 }) {
   const baseToken = getBaseToken({
@@ -215,6 +219,7 @@ function getColumns({
       header: `Value (${baseToken?.symbol})`,
       cell: ({ row }) => (
         <LpCurrentValueCell
+          account={account}
           hyperdrive={row.original.hyperdrive}
           lpShares={row.original.lpShares}
         />
@@ -224,13 +229,17 @@ function getColumns({
       id: "withdrawalQueue",
       header: `Withdrawal Queue`,
       cell: ({ row }) => (
-        <WithdrawalQueueCell hyperdrive={row.original.hyperdrive} />
+        <WithdrawalQueueCell
+          account={account}
+          hyperdrive={row.original.hyperdrive}
+        />
       ),
     }),
     columnHelper.display({
       id: "manage",
       cell: ({ row }) => (
         <ManageLpAndWithdrawalSharesButton
+          account={account}
           hyperdrive={row.original.hyperdrive}
         />
       ),

--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/LpAndWithdrawalSharesTable.tsx
@@ -31,7 +31,10 @@ export function OpenLpTableDesktop({
   hyperdrives: HyperdriveConfig[];
   account: Address | undefined;
 }): ReactElement | null {
-  const { openLpPositions } = usePortfolioLpDataFromHyperdrives(hyperdrives);
+  const { openLpPositions } = usePortfolioLpDataFromHyperdrives({
+    hyperdrives,
+    account,
+  });
   const appConfig = useAppConfigForConnectedChain();
   const columns = useMemo(
     () => getColumns({ account, hyperdrives, appConfig }),

--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/LpCurrentValueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/LpCurrentValueCell.tsx
@@ -10,16 +10,17 @@ import { Tooltip } from "src/ui/base/components/Tooltip/Tooltip";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { useOpenLpPosition } from "src/ui/hyperdrive/lp/hooks/useOpenLpPosition";
 import { usePreviewRemoveLiquidity } from "src/ui/hyperdrive/lp/hooks/usePreviewRemoveLiquidity";
-import { useAccount } from "wagmi";
+import { Address } from "viem";
 
 export function LpCurrentValueCell({
   hyperdrive,
+  account,
   lpShares,
 }: {
   hyperdrive: HyperdriveConfig;
+  account: Address | undefined;
   lpShares: bigint;
 }): ReactElement {
-  const { address: account } = useAccount();
   const appConfig = useAppConfigForConnectedChain();
   const baseToken = getBaseToken({
     hyperdriveAddress: hyperdrive.address,

--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/ManageLpAndWithdrawalSharesButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/ManageLpAndWithdrawalSharesButton.tsx
@@ -19,17 +19,18 @@ import { usePreviewRedeemWithdrawalShares } from "src/ui/hyperdrive/lp/hooks/use
 import { useWithdrawalShares } from "src/ui/hyperdrive/lp/hooks/useWithdrawalShares";
 import { RedeemWithdrawalSharesForm } from "src/ui/hyperdrive/withdrawalShares/RedeemWithdrawalSharesForm/RedeemWithdrawalSharesForm";
 import { MARKET_DETAILS_ROUTE } from "src/ui/markets/routes";
-import { useAccount } from "wagmi";
+import { Address } from "viem";
 export function ManageLpAndWithdrawalSharesButton({
   hyperdrive,
+  account,
 }: {
   hyperdrive: HyperdriveConfig;
+  account: Address | undefined;
 }): ReactElement {
   // This is a controlled component because the default daisy-ui dropdown classes seem to interfere with focus elements in manage position modals.
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   useClickAway(dropdownRef, () => setIsOpen(false));
-  const { address: account } = useAccount();
   const appConfig = useAppConfigForConnectedChain();
   const baseToken = getBaseToken({
     hyperdriveChainId: hyperdrive.chainId,

--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/TotalLpValue.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/TotalLpValue.tsx
@@ -7,14 +7,16 @@ import { useAppConfigForConnectedChain } from "src/ui/appconfig/useAppConfigForC
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { useTotalOpenLpPositions } from "src/ui/hyperdrive/lp/hooks/useTotalOpenLpPositions";
 import { useTokenFiatPrice } from "src/ui/token/hooks/useTokenFiatPrice";
-import { useAccount } from "wagmi";
+import { Address } from "viem";
 import { sepolia } from "wagmi/chains";
 
 export function TotalLpValue({
   hyperdrive,
+  account,
   openLpPositions,
 }: {
   hyperdrive: HyperdriveConfig;
+  account: Address | undefined;
   openLpPositions:
     | {
         hyperdrive: HyperdriveConfig;
@@ -23,7 +25,6 @@ export function TotalLpValue({
       }[]
     | undefined;
 }): ReactElement {
-  const { address: account } = useAccount();
   const { totalOpenLpPositions, isLoading: isLoadingTotalOpenLpPositions } =
     useTotalOpenLpPositions({
       account,

--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/WithdrawalQueueCell.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/WithdrawalQueueCell.tsx
@@ -5,14 +5,15 @@ import { usePoolInfo } from "src/ui/hyperdrive/hooks/usePoolInfo";
 import { usePreviewRedeemWithdrawalShares } from "src/ui/hyperdrive/lp/hooks/usePreviewRedeemWithdrawalShares";
 import { useWithdrawalShares } from "src/ui/hyperdrive/lp/hooks/useWithdrawalShares";
 import { getWithdrawalSharesCurrentValue } from "src/ui/hyperdrive/withdrawalShares/getWithdrawalSharesCurrentValue";
-import { useAccount } from "wagmi";
+import { Address } from "viem";
 
 export function WithdrawalQueueCell({
   hyperdrive,
+  account,
 }: {
   hyperdrive: HyperdriveConfig;
+  account: Address | undefined;
 }): JSX.Element {
-  const { address: account } = useAccount();
   const appConfig = useAppConfigForConnectedChain();
   const baseToken = getBaseToken({
     hyperdriveChainId: hyperdrive.chainId,

--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/usePortfolioLpData.ts
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/usePortfolioLpData.ts
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { makeQueryKey } from "src/base/makeQueryKey";
 import { getDrift } from "src/drift/getDrift";
 import { useAppConfigForConnectedChain } from "src/ui/appconfig/useAppConfigForConnectedChain";
+import { Address } from "viem";
 import { useAccount } from "wagmi";
 
 type LpPosition = {
@@ -63,11 +64,14 @@ export function usePortfolioLpDataFromHyperdrives(
 }
 
 // TODO: This eventually will need to be removed but it's currently being used at the top level of the LP Portfolio container to determine if there are any LP positions to display.
-export function usePortfolioLpData(): {
+export function usePortfolioLpData({
+  account,
+}: {
+  account: Address | undefined;
+}): {
   openLpPositions: LpPosition[] | undefined;
   openLpPositionStatus: "error" | "success" | "loading";
 } {
-  const { address: account } = useAccount();
   const appConfigForConnectedChain = useAppConfigForConnectedChain();
   const queryEnabled =
     !!account && !!appConfigForConnectedChain.hyperdrives.length;

--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/usePortfolioLpData.ts
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/usePortfolioLpData.ts
@@ -5,7 +5,6 @@ import { makeQueryKey } from "src/base/makeQueryKey";
 import { getDrift } from "src/drift/getDrift";
 import { useAppConfigForConnectedChain } from "src/ui/appconfig/useAppConfigForConnectedChain";
 import { Address } from "viem";
-import { useAccount } from "wagmi";
 
 type LpPosition = {
   hyperdrive: HyperdriveConfig;
@@ -13,13 +12,16 @@ type LpPosition = {
   withdrawalShares: bigint;
 };
 
-export function usePortfolioLpDataFromHyperdrives(
-  hyperdrives: HyperdriveConfig[],
-): {
+export function usePortfolioLpDataFromHyperdrives({
+  hyperdrives,
+  account,
+}: {
+  hyperdrives: HyperdriveConfig[];
+  account: Address | undefined;
+}): {
   openLpPositions: LpPosition[] | undefined;
   openLpPositionStatus: "error" | "success" | "loading";
 } {
-  const { address: account } = useAccount();
   const queryEnabled = !!account && !!hyperdrives.length;
   const { data, status } = useQuery({
     queryKey: makeQueryKey("portfolioLp", {

--- a/apps/hyperdrive-trading/src/ui/portfolio/rewards/RewardsContainer.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/rewards/RewardsContainer.tsx
@@ -9,10 +9,13 @@ import { PortfolioTableHeading } from "src/ui/portfolio/PortfolioTableHeading";
 import { PositionContainer } from "src/ui/portfolio/PositionContainer";
 import { RewardsTableDesktop } from "src/ui/portfolio/rewards/RewardsTableDesktop";
 import { usePortfolioRewardsData } from "src/ui/portfolio/rewards/useRewardsData";
-import { useAccount } from "wagmi";
+import { Address } from "viem";
 
-export function RewardsContainer(): ReactElement {
-  const { address: account } = useAccount();
+export function RewardsContainer({
+  account,
+}: {
+  account: Address | undefined;
+}): ReactElement {
   const { rewards, rewardsStatus } = usePortfolioRewardsData({ account });
   const appConfig = useAppConfigForConnectedChain();
   if (!account) {

--- a/apps/hyperdrive-trading/src/ui/portfolio/shorts/OpenShortsTable/ManageShortButton.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/shorts/OpenShortsTable/ManageShortButton.tsx
@@ -4,15 +4,20 @@ import { Link } from "@tanstack/react-router";
 import { ReactElement, useRef, useState } from "react";
 import { useClickAway } from "react-use";
 import { MARKET_DETAILS_ROUTE } from "src/ui/markets/routes";
+import { Address } from "viem";
+import { useAccount } from "wagmi";
 
 export function ManageShortButton({
   hyperdrive,
+  account: accountFromProps,
   assetId,
 }: {
   hyperdrive: HyperdriveConfig;
+  account: Address | undefined;
   assetId: bigint;
 }): ReactElement {
   const [isOpen, setIsOpen] = useState(false);
+  const { address: connectedAccount } = useAccount();
   const dropdownRef = useRef<HTMLDivElement>(null);
   useClickAway(dropdownRef, () => setIsOpen(false));
   return (
@@ -29,17 +34,19 @@ export function ManageShortButton({
       </button>
       {isOpen && (
         <ul className="absolute right-6 top-full z-50 mt-4 w-[300px] rounded-box border border-neutral-content/20 bg-neutral px-4 py-1">
-          <button
-            className="m-0 flex h-[52px] w-full flex-row items-center justify-start border-b-2 border-b-neutral-content/20 p-0 text-start hover:bg-neutral hover:text-neutral-content"
-            onClick={() => {
-              const modalId = `${assetId}`;
-              (
-                document.getElementById(modalId) as HTMLDialogElement
-              ).showModal();
-            }}
-          >
-            Close Short
-          </button>
+          {accountFromProps !== connectedAccount ? null : (
+            <button
+              className="m-0 flex h-[52px] w-full flex-row items-center justify-start border-b-2 border-b-neutral-content/20 p-0 text-start hover:bg-neutral hover:text-neutral-content"
+              onClick={() => {
+                const modalId = `${assetId}`;
+                (
+                  document.getElementById(modalId) as HTMLDialogElement
+                ).showModal();
+              }}
+            >
+              Close Short
+            </button>
+          )}
           <Link
             className="m-0 flex h-[52px] w-full flex-row items-center justify-start p-0 text-start hover:bg-neutral hover:text-neutral-content"
             to={MARKET_DETAILS_ROUTE}

--- a/apps/hyperdrive-trading/src/ui/portfolio/shorts/OpenShortsTable/OpenShortsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/shorts/OpenShortsTable/OpenShortsTableDesktop.tsx
@@ -30,17 +30,18 @@ import { ManageShortButton } from "src/ui/portfolio/shorts/OpenShortsTable/Manag
 import { ShortRateAndSizeCell } from "src/ui/portfolio/shorts/OpenShortsTable/ShortRateAndSizeCell";
 import { TotalOpenShortsValue } from "src/ui/portfolio/shorts/OpenShortsTable/TotalOpenShortsValue";
 import { usePortfolioShortsDataFromHyperdrives } from "src/ui/portfolio/shorts/usePortfolioShortsData";
-import { useAccount } from "wagmi";
+import { Address } from "viem";
 
 export function OpenShortsTableDesktop({
   hyperdrives,
+  account,
 }: {
   hyperdrives: HyperdriveConfig[];
+  account: Address | undefined;
 }): ReactElement | null {
-  const { address: account } = useAccount();
   const appConfig = useAppConfigForConnectedChain();
   const { openShortPositions, openShortPositionsStatus } =
-    usePortfolioShortsDataFromHyperdrives(hyperdrives);
+    usePortfolioShortsDataFromHyperdrives({ hyperdrives, account });
   const openShortPositionsExist =
     openShortPositions && openShortPositions.length > 0;
   const columns = getColumns({ hyperdrives, appConfig });
@@ -87,6 +88,7 @@ export function OpenShortsTableDesktop({
         hyperdrive={hyperdrives[0]}
         rightElement={
           <TotalOpenShortsValue
+            account={account}
             hyperdrives={hyperdrives}
             openShorts={openShortPositions}
           />
@@ -105,6 +107,7 @@ export function OpenShortsTableDesktop({
           return (
             <CloseShortModalButton
               key={modalId}
+              account={account}
               hyperdrive={row.original.hyperdrive}
               modalId={modalId}
               short={row.original}

--- a/apps/hyperdrive-trading/src/ui/portfolio/shorts/OpenShortsTable/OpenShortsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/shorts/OpenShortsTable/OpenShortsTableDesktop.tsx
@@ -44,7 +44,7 @@ export function OpenShortsTableDesktop({
     usePortfolioShortsDataFromHyperdrives({ hyperdrives, account });
   const openShortPositionsExist =
     openShortPositions && openShortPositions.length > 0;
-  const columns = getColumns({ hyperdrives, appConfig });
+  const columns = getColumns({ account, hyperdrives, appConfig });
   const tableInstance = useReactTable({
     columns,
     data: openShortPositions || [],
@@ -223,9 +223,11 @@ const columnHelper = createColumnHelper<
 >();
 
 function getColumns({
+  account,
   hyperdrives,
   appConfig,
 }: {
+  account: Address | undefined;
   hyperdrives: HyperdriveConfig[];
   appConfig: AppConfig;
 }) {
@@ -295,6 +297,7 @@ function getColumns({
       cell: ({ row }) => {
         return (
           <ManageShortButton
+            account={account}
             hyperdrive={row.original.hyperdrive}
             assetId={row.original.assetId}
           />

--- a/apps/hyperdrive-trading/src/ui/portfolio/shorts/OpenShortsTable/TotalOpenShortsValue.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/shorts/OpenShortsTable/TotalOpenShortsValue.tsx
@@ -6,18 +6,19 @@ import { useAppConfigForConnectedChain } from "src/ui/appconfig/useAppConfigForC
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { useTotalOpenShortsValue } from "src/ui/hyperdrive/shorts/hooks/useTotalOpenShortsValue";
 import { useTokenFiatPrice } from "src/ui/token/hooks/useTokenFiatPrice";
+import { Address } from "viem";
 import { sepolia } from "viem/chains";
-import { useAccount } from "wagmi";
 
 export function TotalOpenShortsValue({
+  account,
   hyperdrives,
   openShorts,
 }: {
   hyperdrives: HyperdriveConfig[];
+  account: Address | undefined;
   openShorts: (OpenShort & { hyperdrive: HyperdriveConfig })[] | undefined;
 }): ReactElement {
   const appConfig = useAppConfigForConnectedChain();
-  const { address: account } = useAccount();
 
   const { totalOpenShortsValue, isLoading } = useTotalOpenShortsValue({
     account,

--- a/apps/hyperdrive-trading/src/ui/portfolio/shorts/ShortsContainer.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/shorts/ShortsContainer.tsx
@@ -9,12 +9,15 @@ import { NoWalletConnected } from "src/ui/portfolio/NoWalletConnected";
 import { PositionContainer } from "src/ui/portfolio/PositionContainer";
 import { OpenShortsTableDesktop } from "src/ui/portfolio/shorts/OpenShortsTable/OpenShortsTableDesktop";
 import { usePortfolioShortsData } from "src/ui/portfolio/shorts/usePortfolioShortsData";
-import { useAccount } from "wagmi";
+import { Address } from "viem";
 
-export function OpenShortsContainer(): ReactElement | null {
-  const { address: account } = useAccount();
+export function OpenShortsContainer({
+  account,
+}: {
+  account: Address | undefined;
+}): ReactElement | null {
   const { openShortPositions, openShortPositionsStatus } =
-    usePortfolioShortsData();
+    usePortfolioShortsData({ account });
   const appConfig = useAppConfigForConnectedChain();
   const hyperdrivesByChainAndYieldSource = groupBy(
     appConfig.hyperdrives,
@@ -70,7 +73,11 @@ export function OpenShortsContainer(): ReactElement | null {
     <PositionContainer className="mt-10">
       {Object.entries(hyperdrivesByChainAndYieldSource).map(
         ([key, hyperdrives]) => (
-          <OpenShortsTableDesktop hyperdrives={hyperdrives} key={key} />
+          <OpenShortsTableDesktop
+            account={account}
+            hyperdrives={hyperdrives}
+            key={key}
+          />
         ),
       )}
     </PositionContainer>

--- a/apps/hyperdrive-trading/src/ui/portfolio/shorts/usePortfolioShortsData.ts
+++ b/apps/hyperdrive-trading/src/ui/portfolio/shorts/usePortfolioShortsData.ts
@@ -4,18 +4,21 @@ import { useQuery } from "@tanstack/react-query";
 import { makeQueryKey, makeQueryKey2 } from "src/base/makeQueryKey";
 import { getDrift } from "src/drift/getDrift";
 import { useAppConfigForConnectedChain } from "src/ui/appconfig/useAppConfigForConnectedChain";
-import { useAccount } from "wagmi";
+import { Address } from "viem";
 
 export type OpenShortPositionsData = {
   hyperdrive: HyperdriveConfig;
   openShorts: OpenShort[];
 }[];
 
-export function usePortfolioShortsData(): {
+export function usePortfolioShortsData({
+  account,
+}: {
+  account: Address | undefined;
+}): {
   openShortPositions: OpenShortPositionsData | undefined;
   openShortPositionsStatus: "error" | "success" | "loading";
 } {
-  const { address: account } = useAccount();
   const appConfigForConnectedChain = useAppConfigForConnectedChain();
   const queryEnabled = !!account && !!appConfigForConnectedChain;
 
@@ -49,15 +52,18 @@ export function usePortfolioShortsData(): {
   };
 }
 
-export function usePortfolioShortsDataFromHyperdrives(
-  hyperdrives: HyperdriveConfig[],
-): {
+export function usePortfolioShortsDataFromHyperdrives({
+  hyperdrives,
+  account,
+}: {
+  hyperdrives: HyperdriveConfig[];
+  account: Address | undefined;
+}): {
   openShortPositions:
     | (OpenShort & { hyperdrive: HyperdriveConfig })[]
     | undefined;
   openShortPositionsStatus: "error" | "success" | "loading";
 } {
-  const { address: account } = useAccount();
   const queryEnabled = !!account && !!hyperdrives.length;
   const { data: openShortPositions, status: openShortPositionsStatus } =
     useQuery({


### PR DESCRIPTION
Follow-up to #1744: This PR updates the Portfolio to read the `account` address from the route search params instead of  `useAccount`