### PR TITLE
Fix total lp value in portfolio

### DIFF
--- a/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/TotalLpValue.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/TotalLpValue.tsx
@@ -53,8 +53,7 @@ export function TotalLpValue({
           `$${formatBalance({
             balance: fiatPrice
               ? fixed(totalOpenLpPositions ?? 0n, baseToken.decimals).mul(
-                  fiatPrice,
-                  baseToken.decimals,
+                  fiatPrice, // fiat price is always 18 decimals
                 ).bigint
               : 0n,
             decimals: hyperdrive.decimals,


### PR DESCRIPTION
Fixes the total LP value in the portfolio for tokens with less than 18 decimals.

Fiat prices are always returned with the default decimals (`18`):
https://github.com/delvtech/hyperdrive-frontend/blob/4ea34c01ccab21571d8b47df2afd1daffe30f993/packages/hyperdrive-appconfig/src/tokens/priceOracles/defillama.ts#L31

But we were using the base token decimals when using it to determine price:
https://github.com/delvtech/hyperdrive-frontend/blob/4ea34c01ccab21571d8b47df2afd1daffe30f993/apps/hyperdrive-trading/src/ui/portfolio/lp/LpAndWithdrawalSharesTable/TotalLpValue.tsx#L57

This was inflating the value for USDC pools:
<img width="1110" alt="Pasted image 20250201175004" src="https://github.com/user-attachments/assets/f1fe27ca-33c7-4253-8601-d81597d053c1" />