### PR TITLE
Add dispatch trigger to release workflow

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -12,9 +12,5 @@
   "privatePackages": {
     "version": false
   },
-  "ignore": [
-    "@delvtech/hyperdrive-js",
-    "@delvtech/hyperdrive-js-core",
-    "@delvtech/hyperdrive-viem"
-  ]
+  "ignore": ["@delvtech/hyperdrive-js-core"]
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
So we can manually trigger the release workflow (which will do nothing if everything is up to date).