### PR TITLE
Show max long in terms of active token

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
@@ -422,11 +422,14 @@ export function OpenLongForm({
             <InvalidTransactionButton wide>
               Pool limit exceeded. Max long is{" "}
               {formatBalance({
-                balance: maxBondsOut || 0n,
+                balance:
+                  activeToken.address === sharesToken?.address
+                    ? maxSharesIn || 0n
+                    : maxBaseIn || 0n,
                 decimals: baseToken.decimals,
                 places: baseToken.places,
               })}{" "}
-              hy{baseToken.symbol}
+              {activeToken.symbol}
             </InvalidTransactionButton>
           );
         }


### PR DESCRIPTION
The Pool Limited Exceeded is now shown in terms of the deposit token, not the max bonds. 

<img width="596" alt="image" src="https://github.com/user-attachments/assets/a1deb337-7d9b-4489-9ce2-a58a26f6e7c5" />
