### PR TITLE
Fixed Morpho reward resolver

### DIFF
--- a/apps/hyperdrive-trading/src/ui/markets/PoolsList/PoolsList.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PoolsList/PoolsList.tsx
@@ -225,7 +225,12 @@ export function PoolsList(): ReactElement {
               </Fade>
             )}
           </>
-        ) : null}
+        ) : (
+          <NonIdealState
+            heading="Error loading pools"
+            text="Please try again"
+          />
+        )}
       </div>
     </>
   );


### PR DESCRIPTION
The `supplyApr` from morpho might come back as a javascript number with more than 18 numbers after the decimal place. This causes an error which break showing the list of pools, as the morpho rewards are required in the APY calculation displayed in the Pool rows.