### PR TITLE
Prevent jitter in LoadingState component

### DIFF
--- a/apps/hyperdrive-trading/src/ui/base/components/LoadingState.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/LoadingState.tsx
@@ -11,7 +11,7 @@ export default function LoadingState({
     <div className="mx-10 my-28 flex flex-col items-center justify-center">
       <NonIdealState
         heading={heading}
-        icon={
+        action={
           <div className="daisy-loading daisy-loading-spinner daisy-loading-lg text-primary" />
         }
         text={text || null}

--- a/apps/hyperdrive-trading/src/ui/base/components/LoadingState.tsx
+++ b/apps/hyperdrive-trading/src/ui/base/components/LoadingState.tsx
@@ -12,6 +12,8 @@ export default function LoadingState({
       <NonIdealState
         heading={heading}
         action={
+          // Use the action prop to position the spinner below the heading, preventing layout shifts.
+          // This ensures a smooth transition when LoadingState is replaced by NonIdealState due to an empty request result.
           <div className="daisy-loading daisy-loading-spinner daisy-loading-lg text-primary" />
         }
         text={text || null}


### PR DESCRIPTION
Moving the spinner below the header to avoid jitter when loading states resolve and are replaced with a NonIdealState