### PR TITLE
remove zapContractAddress from totals hooks

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useTotalOpenLongsValue.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useTotalOpenLongsValue.ts
@@ -47,14 +47,13 @@ export function useTotalOpenLongsValueTwo({
                 address: long.hyperdrive.address,
                 drift: getDrift({ chainId: long.hyperdrive.chainId }),
                 earliestBlock: long.hyperdrive.initializationBlock,
-                zapContractAddress:
-                  appConfig.zaps[long.hyperdrive.chainId].address,
               });
               const preview = await readHyperdrive.previewCloseLong({
                 maturityTime: long.details?.maturity || 0n,
                 bondAmountIn: long.details?.bondAmount || 0n,
                 asBase: true,
               });
+              console.log(preview.amountOut, "preview.amountOut");
               return preview.amountOut;
             }),
           );

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useTotalOpenLongsValue.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/hooks/useTotalOpenLongsValue.ts
@@ -53,7 +53,6 @@ export function useTotalOpenLongsValueTwo({
                 bondAmountIn: long.details?.bondAmount || 0n,
                 asBase: true,
               });
-              console.log(preview.amountOut, "preview.amountOut");
               return preview.amountOut;
             }),
           );

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useTotalOpenLpPositions.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/hooks/useTotalOpenLpPositions.ts
@@ -51,8 +51,6 @@ export function useTotalOpenLpPositions({
                 address: position.hyperdrive.address,
                 drift: getDrift({ chainId: position.hyperdrive.chainId }),
                 earliestBlock: position.hyperdrive.initializationBlock,
-                zapContractAddress:
-                  appConfig.zaps[position.hyperdrive.chainId].address,
               });
               const openLpPosition = await readHyperdrive.getOpenLpPosition({
                 account,

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useTotalOpenShortsValue.ts
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/hooks/useTotalOpenShortsValue.ts
@@ -35,8 +35,6 @@ export function useTotalOpenShortsValue({
                 address: short.hyperdrive.address,
                 drift: getDrift({ chainId: short.hyperdrive.chainId }),
                 earliestBlock: short.hyperdrive.initializationBlock,
-                zapContractAddress:
-                  appConfig.zaps[short.hyperdrive.chainId].address,
               });
               const preview = await readHyperdrive.previewCloseShort({
                 maturityTime: short.maturity,


### PR DESCRIPTION
This PR removes the zap contract address from getHyperdrive on the totals hooks. This isn't required here even with Zaps fully implemented since they are only reading open positions which will be using base/shares tokens. There isn't a need to talk to the zap contract.