### PR TITLE
Fix resolver for Big Short Energy rewards

### DIFF
--- a/apps/hyperdrive-trading/src/rewards/getYieldSourceRate.ts
+++ b/apps/hyperdrive-trading/src/rewards/getYieldSourceRate.ts
@@ -3,8 +3,8 @@ import { fixed } from "@delvtech/fixed-point-wasm";
 import {
   AppConfig,
   getHyperdriveConfig,
+  getOpenShortRewardConfigs,
   getYieldSource,
-  getYieldSourceRewardConfigs,
   HyperdriveConfig,
 } from "@delvtech/hyperdrive-appconfig";
 import { ReadHyperdrive } from "@delvtech/hyperdrive-js";
@@ -92,8 +92,8 @@ async function calcNetRate(
 ) {
   let netRate = rate;
 
-  const rewardConfigs = getYieldSourceRewardConfigs({
-    yieldSourceId: hyperdrive.yieldSource,
+  const rewardConfigs = getOpenShortRewardConfigs({
+    hyperdriveAddress: hyperdrive.address,
     chainId: hyperdrive.chainId,
     appConfig,
   });

--- a/packages/hyperdrive-appconfig/src/rewards/resolvers/bigShortEnergy.ts
+++ b/packages/hyperdrive-appconfig/src/rewards/resolvers/bigShortEnergy.ts
@@ -69,11 +69,10 @@ function getAprAndBaseToken(data: MerklV3RewardsResult): {
     .value();
 
   return {
-    apr: parseFixed(
+    apr: parseFixed(apr)
       // the apr is returned from merkl already formatted as a percent, so we
       // need to divide by 100
-      apr / 100,
-    ).bigint,
+      .div(100, 0).bigint,
     baseToken,
   };
 }

--- a/packages/hyperdrive-appconfig/src/rewards/resolvers/bigShortEnergy.ts
+++ b/packages/hyperdrive-appconfig/src/rewards/resolvers/bigShortEnergy.ts
@@ -33,7 +33,7 @@ export const fetchBigShortEnergyRewards: RewardResolver = async (
     {
       chainId,
       type: "apy",
-      apy: BigInt(apr),
+      apy: apr,
       tokenAddress: baseToken,
     },
   ];
@@ -68,5 +68,12 @@ function getAprAndBaseToken(data: MerklV3RewardsResult): {
     .first()
     .value();
 
-  return { apr: parseFixed(apr).bigint, baseToken };
+  return {
+    apr: parseFixed(
+      // the apr is returned from merkl already formatted as a percent, so we
+      // need to divide by 100
+      apr / 100,
+    ).bigint,
+    baseToken,
+  };
 }


### PR DESCRIPTION
Use the correct reward resolver and fix the math so that we're correctly handling percents we get back from Merkl.

<img width="1086" alt="image" src="https://github.com/user-attachments/assets/bc5c2459-d06d-465c-8bce-1792ee4ef484" />
