### PR TITLE
Exclude BSE from LP Apy

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/lp/AddLiquidityForm/AddLiquidityForm.tsx
@@ -129,7 +129,7 @@ export function AddLiquidityForm({
   const lpSharePrice = !isBaseActiveToken
     ? fixed(poolInfo?.lpSharePrice || 0n, baseToken.decimals).div(
         poolInfo?.vaultSharePrice || 0n,
-        baseToken.decimals
+        baseToken.decimals,
       ).bigint
     : poolInfo?.lpSharePrice || 0n;
 
@@ -219,7 +219,7 @@ export function AddLiquidityForm({
                   balance:
                     activeTokenPrice && depositAmountAsBigInt
                       ? fixed(depositAmountAsBigInt, activeToken.decimals).mul(
-                          activeTokenPrice
+                          activeTokenPrice,
                         ).bigint
                       : 0n,
                   decimals: activeToken.decimals,
@@ -318,7 +318,7 @@ export function AddLiquidityForm({
       disclaimer={(() => {
         if (
           previewAddLiquidityError?.message.includes(
-            "Not enough lp shares minted."
+            "Not enough lp shares minted.",
           )
         ) {
           return (
@@ -505,6 +505,7 @@ function LpApyStat({ hyperdrive }: { hyperdrive: HyperdriveConfig }) {
   const { vaultRate, vaultRateStatus } = useYieldSourceRate({
     hyperdriveAddress: hyperdrive.address,
     chainId: hyperdrive.chainId,
+    excludeBigShortEnergy: true,
   });
 
   const yieldSource = getYieldSource({

--- a/apps/hyperdrive-trading/src/ui/vaults/queryKeys.ts
+++ b/apps/hyperdrive-trading/src/ui/vaults/queryKeys.ts
@@ -5,6 +5,7 @@ interface VaultQueryKeys {
   vaultRate: {
     chainId: number;
     hyperdriveAddress: Address | undefined;
+    excludeBigShortEnergy: boolean;
   };
 }
 

--- a/apps/hyperdrive-trading/src/ui/vaults/useYieldSourceRate.ts
+++ b/apps/hyperdrive-trading/src/ui/vaults/useYieldSourceRate.ts
@@ -9,8 +9,10 @@ import { Address } from "viem";
 export function useYieldSourceRate({
   chainId,
   hyperdriveAddress,
+  excludeBigShortEnergy = false,
 }: {
   chainId: number;
+  excludeBigShortEnergy?: boolean;
   hyperdriveAddress: Address | undefined;
 }): {
   vaultRate:
@@ -36,7 +38,7 @@ export function useYieldSourceRate({
     queryKey: makeQueryKey2({
       namespace: "vaults",
       queryId: "vaultRate",
-      params: { chainId, hyperdriveAddress },
+      params: { chainId, hyperdriveAddress, excludeBigShortEnergy },
     }),
     enabled: queryEnabled,
     queryFn: queryEnabled
@@ -44,6 +46,7 @@ export function useYieldSourceRate({
           const { rate, ratePeriodDays, netRate } = await getYieldSourceRate({
             readHyperdrive,
             appConfig,
+            excludeBigShortEnergy,
           });
           return {
             vaultRate: rate,


### PR DESCRIPTION
Quick hack to not include the BSE rewards in the LP apy. I'm implementing it once the silly way to see out how to implement it the serious way. Probably adding a field to `RewardConfig` that specifies if the LPs have exposure to the reward or something.. still not sure