### PR TITLE
Add link to BSE info in pool row tooltip

### DIFF
--- a/.changeset/odd-ears-teach.md
+++ b/.changeset/odd-ears-teach.md
@@ -1,0 +1,5 @@
+---
+"@delvtech/hyperdrive-appconfig": patch
+---
+
+Added optional `moreInfoUrl` to `AnyRewards`

--- a/apps/hyperdrive-trading/src/ui/analytics/ExternalLink.tsx
+++ b/apps/hyperdrive-trading/src/ui/analytics/ExternalLink.tsx
@@ -1,3 +1,5 @@
+import { ArrowTopRightOnSquareIcon } from "@heroicons/react/16/solid";
+import classNames from "classnames";
 import { ComponentPropsWithoutRef, ReactElement, useRef } from "react";
 import { useAccount } from "wagmi";
 
@@ -7,6 +9,11 @@ interface ExternalLinkProps extends ComponentPropsWithoutRef<"a"> {
    * A convenience prop to set the `target` attribute to `_blank` if `true`.
    */
   newTab?: boolean;
+  /**
+   * The icon to display next to the link text or `true` to use the default
+   * external link icon.
+   */
+  icon?: ReactElement | boolean;
 }
 
 /**
@@ -21,9 +28,11 @@ interface ExternalLinkProps extends ComponentPropsWithoutRef<"a"> {
 export function ExternalLink({
   target,
   newTab = target === "_blank",
+  icon,
   rel = "",
   onClick,
   children,
+  className,
   ...rest
 }: ExternalLinkProps): ReactElement {
   const ref = useRef<HTMLAnchorElement>(null);
@@ -45,8 +54,14 @@ export function ExternalLink({
         });
         onClick?.(e);
       }}
+      className={classNames("group", className)}
     >
       {children}
+      {icon === true ? (
+        <ArrowTopRightOnSquareIcon className="size-4 opacity-60 group-hover:opacity-100" />
+      ) : (
+        icon && icon
+      )}
     </a>
   );
 }

--- a/apps/hyperdrive-trading/src/ui/analytics/ExternalLink.tsx
+++ b/apps/hyperdrive-trading/src/ui/analytics/ExternalLink.tsx
@@ -14,6 +14,11 @@ interface ExternalLinkProps extends ComponentPropsWithoutRef<"a"> {
    * external link icon.
    */
   icon?: ReactElement | boolean;
+  /**
+   * The name to use for the Plausible analytics event. Defaults to the link
+   * text.
+   */
+  analyticsName?: string;
 }
 
 /**
@@ -29,6 +34,7 @@ export function ExternalLink({
   target,
   newTab = target === "_blank",
   icon,
+  analyticsName,
   rel = "",
   onClick,
   children,
@@ -47,7 +53,7 @@ export function ExternalLink({
       onClick={(e) => {
         window.plausible("externalLinkClick", {
           props: {
-            name: ref.current?.textContent ?? undefined,
+            name: analyticsName ?? ref.current?.textContent ?? undefined,
             url: rest.href,
             connectedWallet,
           },

--- a/apps/hyperdrive-trading/src/ui/analytics/ExternalLink.tsx
+++ b/apps/hyperdrive-trading/src/ui/analytics/ExternalLink.tsx
@@ -10,8 +10,7 @@ interface ExternalLinkProps extends ComponentPropsWithoutRef<"a"> {
    */
   newTab?: boolean;
   /**
-   * The icon to display next to the link text or `true` to use the default
-   * external link icon.
+   * The icon to display next to the link text or `true` for the default icon.
    */
   icon?: ReactElement | boolean;
   /**

--- a/apps/hyperdrive-trading/src/ui/markets/PoolsList/PoolsList.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PoolsList/PoolsList.tsx
@@ -75,7 +75,7 @@ export function PoolsList(): ReactElement {
         ) : pools ? (
           <>
             {/* List controls */}
-            <div className="relative z-20 flex items-stretch justify-between gap-2">
+            <div className="relative z-20 flex items-stretch justify-between gap-2 sm:items-center">
               {/* Filters */}
               <div className="flex items-stretch gap-2">
                 <AdjustmentsHorizontalIcon className="hidden size-5 sm:mr-1 sm:block" />

--- a/apps/hyperdrive-trading/src/ui/markets/PoolsList/PoolsList.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PoolsList/PoolsList.tsx
@@ -77,7 +77,7 @@ export function PoolsList(): ReactElement {
             {/* List controls */}
             <div className="relative z-20 flex items-stretch justify-between gap-2 sm:items-center">
               {/* Filters */}
-              <div className="flex items-stretch gap-2">
+              <div className="flex items-stretch gap-2 sm:items-center">
                 <AdjustmentsHorizontalIcon className="hidden size-5 sm:mr-1 sm:block" />
                 {/* Chain filter */}
                 {filters && filters.chains.length > 1 && (

--- a/apps/hyperdrive-trading/src/ui/rewards/RewardsTooltip/RewardsTooltipContent.tsx
+++ b/apps/hyperdrive-trading/src/ui/rewards/RewardsTooltip/RewardsTooltipContent.tsx
@@ -5,6 +5,7 @@ import { ChartBarIcon } from "@heroicons/react/24/solid";
 import { ReactElement } from "react";
 import { assertNever } from "src/base/assertNever";
 import { calculateMarketYieldMultiplier } from "src/hyperdrive/calculateMarketYieldMultiplier";
+import { ExternalLink } from "src/ui/analytics/ExternalLink";
 import { useAppConfigForConnectedChain } from "src/ui/appconfig/useAppConfigForConnectedChain";
 import { useIsNewPool } from "src/ui/hyperdrive/hooks/useIsNewPool";
 import { useCurrentLongPrice } from "src/ui/hyperdrive/longs/hooks/useCurrentLongPrice";
@@ -104,6 +105,11 @@ export function RewardsTooltipContent({
               appConfig,
             })!;
 
+            const formattedApy = fixed(reward.apy).format({
+              percent: true,
+              decimals: 2,
+            });
+
             return (
               <div
                 key={reward.tokenAddress}
@@ -119,13 +125,18 @@ export function RewardsTooltipContent({
                 </div>
 
                 <div className="grid justify-items-end">
-                  <p className="flex items-center gap-1">
-                    +
-                    {fixed(reward.apy).format({
-                      percent: true,
-                      decimals: 2,
-                    })}
-                  </p>
+                  {reward.moreInfoUrl ? (
+                    <ExternalLink
+                      className="daisy-link-hover flex items-center gap-1"
+                      href={reward.moreInfoUrl}
+                      newTab
+                      icon
+                    >
+                      +{formattedApy}
+                    </ExternalLink>
+                  ) : (
+                    <p className="flex items-center gap-1">+{formattedApy}</p>
+                  )}
                 </div>
               </div>
             );

--- a/apps/hyperdrive-trading/src/ui/rewards/RewardsTooltip/RewardsTooltipContent.tsx
+++ b/apps/hyperdrive-trading/src/ui/rewards/RewardsTooltip/RewardsTooltipContent.tsx
@@ -131,6 +131,7 @@ export function RewardsTooltipContent({
                       href={reward.moreInfoUrl}
                       newTab
                       icon
+                      analyticsName={`Rewards info: ${token.name}`}
                     >
                       +{formattedApy}
                     </ExternalLink>

--- a/apps/hyperdrive-trading/src/ui/rewards/RewardsTooltip/RewardsTooltipContent.tsx
+++ b/apps/hyperdrive-trading/src/ui/rewards/RewardsTooltip/RewardsTooltipContent.tsx
@@ -53,7 +53,11 @@ export function RewardsTooltipContent({
       ? calculateMarketYieldMultiplier(longPrice)
       : null;
   return (
-    <>
+    <div
+      onClick={(e) => {
+        e.stopPropagation();
+      }}
+    >
       <div className="flex justify-between border-b border-neutral-content/30 p-3">
         <p className="gradient-text text-lg">Rate & Rewards</p>
       </div>
@@ -192,7 +196,7 @@ export function RewardsTooltipContent({
             assertNever(reward);
         }
       })}
-      <div className="flex items-center justify-between border-b border-neutral-content/30 p-3 [&:nth-last-child(2)]:border-none">
+      <div className="flex items-center justify-between border-b border-neutral-content/30 p-3 [&:last-child]:border-none">
         <div className="flex items-center gap-1">
           <SparklesIcon className="h-4" />
           Net APY
@@ -213,7 +217,7 @@ export function RewardsTooltipContent({
           return (
             <div
               key={reward.iconUrl}
-              className="flex flex-col items-start justify-start gap-2 border-b border-neutral-content/30 p-3 [&:nth-last-child(2)]:border-none"
+              className="flex flex-col items-start justify-start gap-2 border-b border-neutral-content/30 p-3 [&:last-child]:border-none"
             >
               <div className="flex items-center gap-4">
                 <img
@@ -226,6 +230,6 @@ export function RewardsTooltipContent({
             </div>
           );
         })}
-    </>
+    </div>
   );
 }

--- a/packages/hyperdrive-appconfig/src/rewards/resolvers/bigShortEnergy.ts
+++ b/packages/hyperdrive-appconfig/src/rewards/resolvers/bigShortEnergy.ts
@@ -35,6 +35,7 @@ export const fetchBigShortEnergyRewards: RewardResolver = async (
       type: "apy",
       apy: apr,
       tokenAddress: baseToken,
+      moreInfoUrl: "https://blog.delv.tech/big-short-energy-2/",
     },
   ];
 };

--- a/packages/hyperdrive-appconfig/src/rewards/types.ts
+++ b/packages/hyperdrive-appconfig/src/rewards/types.ts
@@ -52,11 +52,17 @@ export interface InfoReward {
   iconUrl: string;
 }
 
-export type AnyReward =
+export type AnyReward = (
   | ApyReward
   | TokenAmountReward
   | PointMultiplierReward
-  | InfoReward;
+  | InfoReward
+) & {
+  /**
+   * The URL to link to for more information about the reward.
+   */
+  moreInfoUrl?: string;
+};
 
 export type RewardResolver = (
   publicClient: PublicClient,


### PR DESCRIPTION
- Adds a link to more info about BSE in the pool row rewards tooltips.
- Adds an optional `moreInfoUrl` property to the `AnyRewards` type in appconfig
- Prevents click propagation on pool info tooltips
- Adds optional `icon` and `analyticsName` props to `ExternalLink` component

![image](https://github.com/user-attachments/assets/33ffa233-9e78-4762-b5e8-c17094db5014)

