### PR TITLE
Don't require allowance to close long if not zapping

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongForm/CloseLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/CloseLongForm/CloseLongForm.tsx
@@ -200,7 +200,8 @@ export function CloseLongForm({
   const spender = isZapping ? zapsConfig.address : hyperdrive.address;
 
   // ETH doesn't require allowance
-  const requiresAllowance = activeWithdrawToken.address !== ETH_MAGIC_NUMBER;
+  const requiresAllowance =
+    activeWithdrawToken.address !== ETH_MAGIC_NUMBER && isZapping;
   const { tokenAllowance: bondAllowance } = useTokenAllowance({
     account,
     spender,


### PR DESCRIPTION
If we're not zapping, don't show the allowance step for close Long