### PR TITLE
Catch error when requesting third party rewards

### DIFF
--- a/apps/hyperdrive-trading/src/ui/rewards/hooks/getRewardResolverQuery.ts
+++ b/apps/hyperdrive-trading/src/ui/rewards/hooks/getRewardResolverQuery.ts
@@ -40,7 +40,15 @@ export function getRewardResolverQuery({
       const publicClient = getPublicClient(wagmiConfig as any, {
         chainId,
       }) as PublicClient;
-      return rewardConfig.resolver(publicClient);
+      let rewards: AnyReward[] = [];
+      try {
+        // We use try/catch here because some reward resolvers might throw an
+        // error intermittently, and we don't want to stop the entire query
+        rewards = await rewardConfig.resolver(publicClient);
+      } catch (e) {
+        console.warn("Error loading rewards", e);
+      }
+      return rewards;
     },
   };
 }


### PR DESCRIPTION
We can't rely on third-party reward resolvers to not throw errors on occassion, but that shouldn't be cause to not render the UI normally.