### PR TITLE
Show end date of Big Short Energy rewards in tooltip

### DIFF
--- a/apps/hyperdrive-trading/src/ui/rewards/RewardsTooltip/RewardsTooltipContent.tsx
+++ b/apps/hyperdrive-trading/src/ui/rewards/RewardsTooltip/RewardsTooltipContent.tsx
@@ -7,6 +7,7 @@ import { assertNever } from "src/base/assertNever";
 import { calculateMarketYieldMultiplier } from "src/hyperdrive/calculateMarketYieldMultiplier";
 import { ExternalLink } from "src/ui/analytics/ExternalLink";
 import { useAppConfigForConnectedChain } from "src/ui/appconfig/useAppConfigForConnectedChain";
+import { formatDate } from "src/ui/base/formatting/formatDate";
 import { useIsNewPool } from "src/ui/hyperdrive/hooks/useIsNewPool";
 import { useCurrentLongPrice } from "src/ui/hyperdrive/longs/hooks/useCurrentLongPrice";
 import { useAddLiquidityRewards } from "src/ui/rewards/hooks/useAddLiquidityRewards";
@@ -91,123 +92,139 @@ export function RewardsTooltipContent({
           </p>
         </div>
       </div>
-      {rewards?.map((reward) => {
-        switch (reward.type) {
-          case "info":
-            // info rewards are rendered below the net rewards row at the end
-            return null;
-          case "apy": {
-            // safe to cast because we assume all rewards tokens are
-            // available in appConfig
-            const token = getToken({
-              tokenAddress: reward.tokenAddress,
-              chainId: reward.chainId,
-              appConfig,
-            })!;
-
-            const formattedApy = fixed(reward.apy).format({
-              percent: true,
-              decimals: 2,
-            });
-
-            return (
-              <div
-                key={reward.tokenAddress}
-                className="flex items-center justify-between border-b border-neutral-content/30 p-3 [&:nth-last-child(2)]:border-none"
-              >
-                <div className="flex items-center gap-1">
-                  <img
-                    src={token.iconUrl}
-                    alt={`${token.name} logo`}
-                    className="h-4"
-                  />
-                  {token.name}
-                </div>
-
-                <div className="grid justify-items-end">
-                  {reward.moreInfoUrl ? (
-                    <ExternalLink
-                      className="daisy-link-hover flex items-center gap-1"
-                      href={reward.moreInfoUrl}
-                      newTab
-                      icon
-                      analyticsName={`Rewards info: ${token.name}`}
-                    >
-                      +{formattedApy}
-                    </ExternalLink>
-                  ) : (
-                    <p className="flex items-center gap-1">+{formattedApy}</p>
-                  )}
-                </div>
-              </div>
-            );
+      {rewards
+        ?.filter((reward) => {
+          if (!reward?.endTimestamp) {
+            return true;
           }
-          case "tokenAmount": {
-            // safe to cast because we assume all rewards tokens are
-            // available in appConfig
-            const token = getToken({
-              tokenAddress: reward.tokenAddress,
-              chainId: reward.chainId,
-              appConfig,
-            })!;
-            return (
-              <div
-                key={reward.tokenAddress}
-                className="flex items-center justify-between border-b border-neutral-content/30 p-3 [&:nth-last-child(2)]:border-none"
-              >
-                <div className="flex items-center gap-1">
-                  <img
-                    src={appConfig.protocols.morpho.iconUrl}
-                    className="h-4"
-                  />
-                  {token.name}
-                </div>
+          return Date.now() < reward.endTimestamp * 1000;
+        })
+        .map((reward) => {
+          switch (reward.type) {
+            case "info":
+              // info rewards are rendered below the net rewards row at the end
+              return null;
+            case "apy": {
+              // safe to cast because we assume all rewards tokens are
+              // available in appConfig
+              const token = getToken({
+                tokenAddress: reward.tokenAddress,
+                chainId: reward.chainId,
+                appConfig,
+              })!;
 
-                <div className="grid justify-items-end">
-                  <p className="flex items-center gap-1">
-                    +
-                    {fixed(reward.tokensPerThousandUsd).format({
-                      decimals: token.places,
-                    })}
-                  </p>
-                  <p className="text-2xs text-neutral-content">
-                    per $1000 / yr
-                  </p>
+              const formattedApy = fixed(reward.apy).format({
+                percent: true,
+                decimals: 2,
+              });
+
+              return (
+                <div
+                  key={reward.tokenAddress}
+                  className="flex flex-col items-center justify-between border-b border-neutral-content/30 p-3 [&:nth-last-child(2)]:border-none"
+                >
+                  <div className="flex w-full justify-between">
+                    <div className="flex items-center gap-1">
+                      <img
+                        src={token.iconUrl}
+                        alt={`${token.name} logo`}
+                        className="h-4"
+                      />
+                      {token.name}
+                    </div>
+
+                    <div className="grid justify-items-end">
+                      {reward.moreInfoUrl ? (
+                        <ExternalLink
+                          className="daisy-link-hover flex items-center gap-1"
+                          href={reward.moreInfoUrl}
+                          newTab
+                          icon
+                          analyticsName={`Rewards info: ${token.name}`}
+                        >
+                          +{formattedApy}
+                        </ExternalLink>
+                      ) : (
+                        <p className="flex items-center gap-1">
+                          +{formattedApy}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                  {reward.endTimestamp ? (
+                    <span className="ml-10 mt-1 w-full text-left text-sm text-neutral-content">
+                      Ends on {formatDate(reward.endTimestamp * 1000)}
+                    </span>
+                  ) : null}
                 </div>
-              </div>
-            );
+              );
+            }
+            case "tokenAmount": {
+              // safe to cast because we assume all rewards tokens are
+              // available in appConfig
+              const token = getToken({
+                tokenAddress: reward.tokenAddress,
+                chainId: reward.chainId,
+                appConfig,
+              })!;
+              return (
+                <div
+                  key={reward.tokenAddress}
+                  className="flex items-center justify-between border-b border-neutral-content/30 p-3 [&:nth-last-child(2)]:border-none"
+                >
+                  <div className="flex items-center gap-1">
+                    <img
+                      src={appConfig.protocols.morpho.iconUrl}
+                      className="h-4"
+                    />
+                    {token.name}
+                  </div>
+
+                  <div className="grid justify-items-end">
+                    <p className="flex items-center gap-1">
+                      +
+                      {fixed(reward.tokensPerThousandUsd).format({
+                        decimals: token.places,
+                      })}
+                    </p>
+                    <p className="text-2xs text-neutral-content">
+                      per $1000 / yr
+                    </p>
+                  </div>
+                </div>
+              );
+            }
+
+            case "pointMultiplier":
+              return (
+                <div
+                  key={reward.pointTokenLabel}
+                  className="flex items-center justify-between border-b border-neutral-content/30 p-3 [&:nth-last-child(2)]:border-none"
+                >
+                  <div className="flex items-center gap-1">
+                    <img
+                      src={reward.iconUrl}
+                      alt={`${reward.pointTokenLabel} logo`}
+                      className="h-4"
+                    />
+                    {reward.pointTokenLabel}
+                  </div>
+
+                  <div className="grid justify-items-end">
+                    <p className="flex items-center gap-1">
+                      {multiplier
+                        ?.mul(parseFixed(reward.pointMultiplier))
+                        .format({ decimals: 0 })}
+                      x
+                    </p>
+                  </div>
+                </div>
+              );
+
+            default:
+              assertNever(reward);
           }
-
-          case "pointMultiplier":
-            return (
-              <div
-                key={reward.pointTokenLabel}
-                className="flex items-center justify-between border-b border-neutral-content/30 p-3 [&:nth-last-child(2)]:border-none"
-              >
-                <div className="flex items-center gap-1">
-                  <img
-                    src={reward.iconUrl}
-                    alt={`${reward.pointTokenLabel} logo`}
-                    className="h-4"
-                  />
-                  {reward.pointTokenLabel}
-                </div>
-
-                <div className="grid justify-items-end">
-                  <p className="flex items-center gap-1">
-                    {multiplier
-                      ?.mul(parseFixed(reward.pointMultiplier))
-                      .format({ decimals: 0 })}
-                    x
-                  </p>
-                </div>
-              </div>
-            );
-
-          default:
-            assertNever(reward);
-        }
-      })}
+        })}
       <div className="flex items-center justify-between border-b border-neutral-content/30 p-3 [&:last-child]:border-none">
         <div className="flex items-center gap-1">
           <SparklesIcon className="h-4" />

--- a/packages/hyperdrive-appconfig/src/rewards/resolvers/hypervueMiles.ts
+++ b/packages/hyperdrive-appconfig/src/rewards/resolvers/hypervueMiles.ts
@@ -13,9 +13,15 @@ export const fetchHypervueMilesLpRewards: RewardResolver = async () => {
     },
   ];
 };
+
+/**
+ * Hypervue Miles are rewarded to all chains that Hyperdrive is deployed on.
+ * They can be collected off of gnosischain.
+ */
+const chainIds = [mainnet.id, gnosis.id, linea.id, base.id];
 export const hypervueMilesLpRewards: RewardConfig = {
   id: "hypervueMilesLpRewards",
-  chainIds: [mainnet.id, gnosis.id, linea.id, base.id],
+  chainIds,
   resolver: fetchHypervueMilesLpRewards,
 };
 
@@ -30,6 +36,6 @@ export const fetchHypervueMilesShortRewards: RewardResolver = async () => {
 };
 export const hypervueMilesShortRewards: RewardConfig = {
   id: "hypervueMilesShortRewards",
-  chainIds: [mainnet.id, gnosis.id, linea.id, base.id],
+  chainIds,
   resolver: fetchHypervueMilesShortRewards,
 };

--- a/packages/hyperdrive-appconfig/src/rewards/types.ts
+++ b/packages/hyperdrive-appconfig/src/rewards/types.ts
@@ -6,6 +6,16 @@ interface BaseReward {
    * The URL to link to for more information about the reward.
    */
   moreInfoUrl?: string;
+
+  /**
+   * When the reward period starts, in seconds
+   */
+  startTimestamp?: number;
+
+  /**
+   * When the reward period ends, in seconds
+   */
+  endTimestamp?: number;
 }
 
 /**

--- a/packages/hyperdrive-appconfig/src/rewards/types.ts
+++ b/packages/hyperdrive-appconfig/src/rewards/types.ts
@@ -1,11 +1,18 @@
 import { RewardConfigId } from "src/rewards/resolvers";
 import { Address, PublicClient } from "viem";
 
+interface BaseReward {
+  /**
+   * The URL to link to for more information about the reward.
+   */
+  moreInfoUrl?: string;
+}
+
 /**
  * Transferable token rewards apply to tokens with a known fiat price,
  * allowing their APY to be added to the hyperdrive pool’s overall APY.
  */
-export interface ApyReward {
+export interface ApyReward extends BaseReward {
   type: "apy";
   /**
    * The apy of the token reward in 18-decimal precision
@@ -20,7 +27,7 @@ export interface ApyReward {
  * or are non-transferable. They display the number of tokens rewarded per
  * thousand dollars deposited. For example: 36.23 tokens per $1k/year.
  */
-export interface TokenAmountReward {
+export interface TokenAmountReward extends BaseReward {
   type: "tokenAmount";
   tokenAddress: Address;
   tokensPerThousandUsd: bigint;
@@ -28,7 +35,7 @@ export interface TokenAmountReward {
   chainId: number;
 }
 
-export interface PointMultiplierReward {
+export interface PointMultiplierReward extends BaseReward {
   type: "pointMultiplier";
   /**
    * The multiplier for the point reward, eg: 2n means "2x"
@@ -46,23 +53,17 @@ export interface PointMultiplierReward {
  * Info rewards are used when reward details are unclear. They display a message
  * to the user, such as "This pool is eligible for L-XPL Rewards."
  */
-export interface InfoReward {
+export interface InfoReward extends BaseReward {
   type: "info";
   message: string;
   iconUrl: string;
 }
 
-export type AnyReward = (
+export type AnyReward =
   | ApyReward
   | TokenAmountReward
   | PointMultiplierReward
-  | InfoReward
-) & {
-  /**
-   * The URL to link to for more information about the reward.
-   */
-  moreInfoUrl?: string;
-};
+  | InfoReward;
 
 export type RewardResolver = (
   publicClient: PublicClient,


### PR DESCRIPTION
Adds the `startTimestamp` and `endTimestamp` to the base reward type, and populates it for Big Short Energy from the Merkl API.

We show the end date of the reward program if we have it.

<img width="299" alt="image" src="https://github.com/user-attachments/assets/5095a225-c415-416e-aca7-71e2ed614da4" />
