### PR TITLE
Remove auto url param on portfolio

### DIFF
--- a/apps/hyperdrive-trading/src/ui/portfolio/Portfolio.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/Portfolio.tsx
@@ -1,4 +1,4 @@
-import { Navigate, useNavigate, useSearch } from "@tanstack/react-router";
+import { useNavigate, useSearch } from "@tanstack/react-router";
 import { ReactElement } from "react";
 import { Tabs } from "src/ui/base/components/Tabs/Tabs";
 import { OpenLongsContainer } from "src/ui/portfolio/longs/LongsContainer";
@@ -72,12 +72,6 @@ export function Portfolio(): ReactElement {
 
   return (
     <div className="flex w-full flex-col items-center bg-base-100 py-8">
-      {!accountFromRoute && connectedAccount ? (
-        <Navigate
-          from={PORTFOLIO_ROUTE}
-          search={(prev) => ({ ...prev, account: connectedAccount })}
-        />
-      ) : null}
       <Tabs activeTabId={activeTab} tabs={tabs} />
     </div>
   );

--- a/apps/hyperdrive-trading/src/ui/portfolio/Portfolio.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/Portfolio.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useSearch } from "@tanstack/react-router";
+import { Navigate, useNavigate, useSearch } from "@tanstack/react-router";
 import { ReactElement } from "react";
 import { Tabs } from "src/ui/base/components/Tabs/Tabs";
 import { OpenLongsContainer } from "src/ui/portfolio/longs/LongsContainer";
@@ -72,6 +72,12 @@ export function Portfolio(): ReactElement {
 
   return (
     <div className="flex w-full flex-col items-center bg-base-100 py-8">
+      {!accountFromRoute && connectedAccount ? (
+        <Navigate
+          from={PORTFOLIO_ROUTE}
+          search={(prev) => ({ ...prev, account: connectedAccount })}
+        />
+      ) : null}
       <Tabs activeTabId={activeTab} tabs={tabs} />
     </div>
   );


### PR DESCRIPTION
Since the account already defaults to the connected one, we don't need to auto-add it to the URL. This helps ensure the account isn't stuck when switching wallets.