### PR TITLE
Remove buttons from pool rows, switch to Short APR

### DIFF
--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongForm/OpenLongForm.tsx
@@ -469,7 +469,7 @@ export function OpenLongForm({
               onOpenLong?.(e);
             }}
           >
-            Open Long
+            Buy Fixed
           </button>
         );
       })()}

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongStats.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/longs/OpenLongPreview/OpenLongStats.tsx
@@ -16,6 +16,7 @@ import { convertSharesToBase } from "src/hyperdrive/convertSharesToBase";
 import { getDepositAssets } from "src/hyperdrive/getDepositAssets";
 import { useAppConfigForConnectedChain } from "src/ui/appconfig/useAppConfigForConnectedChain";
 import { PrimaryStat } from "src/ui/base/components/PrimaryStat";
+import { Tooltip } from "src/ui/base/components/Tooltip/Tooltip";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { formatDate } from "src/ui/base/formatting/formatDate";
 import { useFixedRate } from "src/ui/hyperdrive/longs/hooks/useFixedRate";
@@ -153,7 +154,15 @@ export function OpenLongStats({
                 "text-base-content/80": !amountPaid,
               })}
             >
-              <img src={baseToken.iconUrl} className="mr-1 h-8 rounded-full" />
+              <Tooltip
+                tooltip={baseToken.symbol}
+                className="self-center font-normal"
+              >
+                <img
+                  src={baseToken.iconUrl}
+                  className="mr-1.5 size-7 rounded-full"
+                />
+              </Tooltip>
               {`${formatBalance({
                 balance: amountPaidInBase + yieldAtMaturity,
                 decimals: baseToken.decimals,
@@ -162,7 +171,6 @@ export function OpenLongStats({
             </span>
           )
         }
-        valueUnit={`${baseToken.symbol}`}
         subValue={
           // Defillama fetches the token price via {chain}:{tokenAddress}. Since the token address differs on testnet, term length is displayed instead.
 

--- a/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
+++ b/apps/hyperdrive-trading/src/ui/hyperdrive/shorts/OpenShortForm/OpenShortForm.tsx
@@ -448,7 +448,7 @@ export function OpenShortForm({
               subValue={
                 <Tooltip
                   position="top"
-                  tooltip="Short positions provide the fixed rate yield to Long positions. Opening a Short is a one-time cost."
+                  tooltip="Short positions provide the fixed rate yield in exchange for the variable. Opening a Short is a one-time cost."
                   className="gap-1 before:text-left"
                 >
                   What am I paying for?{" "}

--- a/apps/hyperdrive-trading/src/ui/markets/PoolRow/FixedAprCta.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PoolRow/FixedAprCta.tsx
@@ -1,19 +1,15 @@
-import { fixed } from "@delvtech/fixed-point-wasm";
 import { HyperdriveConfig } from "@delvtech/hyperdrive-appconfig";
-import { Link } from "@tanstack/react-router";
 import { ReactElement } from "react";
 import { formatRate } from "src/base/formatRate";
 import { useFixedRate } from "src/ui/hyperdrive/longs/hooks/useFixedRate";
 import { PercentLabel } from "src/ui/markets/PoolRow/PercentLabel";
 import { PoolStat } from "src/ui/markets/PoolRow/PoolStat";
-import { useAccount } from "wagmi";
 
 interface FixedAprCtaProps {
   hyperdrive: HyperdriveConfig;
 }
 
 export function FixedAprCta({ hyperdrive }: FixedAprCtaProps): ReactElement {
-  const { address: account } = useAccount();
   const { fixedApr, fixedRateStatus } = useFixedRate({
     chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
@@ -38,32 +34,6 @@ export function FixedAprCta({ hyperdrive }: FixedAprCtaProps): ReactElement {
         )
       }
       isLoading={fixedRateStatus === "loading"}
-      action={
-        <Link
-          to="/market/$chainId/$address"
-          params={{
-            address: hyperdrive.address,
-            chainId: hyperdrive.chainId.toString(),
-          }}
-          search={{ position: "long" }}
-          className="daisy-btn h-10 min-h-10 w-full rounded-full bg-gray-500 sm:daisy-btn-sm hover:bg-gray-400 sm:h-8 sm:bg-gray-600 sm:hover:bg-gray-500 md:w-28"
-          onClick={(e) => {
-            e.stopPropagation();
-            window.plausible("positionCtaClick", {
-              props: {
-                chainId: hyperdrive.chainId,
-                poolAddress: hyperdrive.address,
-                positionType: "long",
-                statName: label,
-                statValue: fixedApr ? fixed(fixedApr.apr, 18).toString() : "",
-                connectedWallet: account,
-              },
-            });
-          }}
-        >
-          Open Long
-        </Link>
-      }
     />
   );
 }

--- a/apps/hyperdrive-trading/src/ui/markets/PoolRow/LpApyCta.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PoolRow/LpApyCta.tsx
@@ -1,6 +1,4 @@
-import { fixed } from "@delvtech/fixed-point-wasm";
 import { HyperdriveConfig } from "@delvtech/hyperdrive-appconfig";
-import { Link } from "@tanstack/react-router";
 import { ReactElement } from "react";
 import { useLpApy } from "src/ui/hyperdrive/lp/hooks/useLpApy";
 import { LpApyStat } from "src/ui/markets/PoolRow/LpApyStat";
@@ -40,34 +38,6 @@ export function LpApyCta({ hyperdrive }: LpApyCtaProps): ReactElement {
           chainId={hyperdrive.chainId}
           hyperdriveAddress={hyperdrive.address}
         />
-      }
-      action={
-        <Link
-          to="/market/$chainId/$address"
-          params={{
-            address: hyperdrive.address,
-            chainId: hyperdrive.chainId.toString(),
-          }}
-          search={{ position: "lp" }}
-          className="daisy-btn h-10 min-h-10 w-full rounded-full bg-gray-500 sm:daisy-btn-sm hover:bg-gray-400 sm:h-8 sm:bg-gray-600 sm:hover:bg-gray-500 md:w-32"
-          onClick={(e) => {
-            e.stopPropagation();
-            window.plausible("positionCtaClick", {
-              props: {
-                chainId: hyperdrive.chainId,
-                poolAddress: hyperdrive.address,
-                positionType: "lp",
-                statName: label,
-                statValue: lpApy?.netLpApy
-                  ? fixed(lpApy.netLpApy).toString()
-                  : "",
-                connectedWallet: account,
-              },
-            });
-          }}
-        >
-          Add Liquidity
-        </Link>
       }
     />
   );

--- a/apps/hyperdrive-trading/src/ui/markets/PoolRow/LpApyCta.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PoolRow/LpApyCta.tsx
@@ -4,14 +4,12 @@ import { useLpApy } from "src/ui/hyperdrive/lp/hooks/useLpApy";
 import { LpApyStat } from "src/ui/markets/PoolRow/LpApyStat";
 import { PoolStat } from "src/ui/markets/PoolRow/PoolStat";
 import { RewardsTooltipContent } from "src/ui/rewards/RewardsTooltip/RewardsTooltipContent";
-import { useAccount } from "wagmi";
 
 interface LpApyCtaProps {
   hyperdrive: HyperdriveConfig;
 }
 
 export function LpApyCta({ hyperdrive }: LpApyCtaProps): ReactElement {
-  const { address: account } = useAccount();
   const { lpApy, lpApyStatus } = useLpApy({
     hyperdriveAddress: hyperdrive.address,
     chainId: hyperdrive.chainId,

--- a/apps/hyperdrive-trading/src/ui/markets/PoolRow/PoolRow.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PoolRow/PoolRow.tsx
@@ -174,14 +174,14 @@ export function PoolRow({ hyperdrive }: PoolRowProps): ReactElement {
         </div>
 
         {/* Right side */}
-        <div className="flex flex-col items-center justify-between gap-6 sm:flex-row sm:gap-12 lg:items-end lg:justify-start">
-          <div className="w-full lg:w-[112px]">
+        <div className="flex flex-col items-center justify-between gap-6 sm:flex-row sm:gap-12 lg:items-start lg:justify-start">
+          <div className="size-full border-r border-gray-500/20 lg:w-[112px]">
             <FixedAprCta hyperdrive={hyperdrive} />
           </div>
-          <div className="w-full lg:w-[181px]">
+          <div className="size-full border-r border-gray-500/20 lg:w-[181px]">
             <VariableApyCta hyperdrive={hyperdrive} />
           </div>
-          <div className="w-full lg:w-[122px]">
+          <div className="size-full lg:w-[122px]">
             <LpApyCta hyperdrive={hyperdrive} />
           </div>
         </div>

--- a/apps/hyperdrive-trading/src/ui/markets/PoolRow/PoolStat.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PoolRow/PoolStat.tsx
@@ -14,7 +14,6 @@ export interface PoolStatProps {
   isLoading?: boolean;
   isNew?: boolean;
   variant?: "default" | "gradient";
-  action?: ReactNode;
 }
 
 export function PoolStat({
@@ -24,7 +23,6 @@ export function PoolStat({
   isNew = false,
   variant = "default",
   isLoading = false,
-  action,
 }: PoolStatProps): ReactElement {
   let displayValue;
   if (isLoading) {
@@ -45,7 +43,6 @@ export function PoolStat({
       >
         {displayValue}
       </div>
-      {action}
     </div>
   );
 

--- a/apps/hyperdrive-trading/src/ui/markets/PoolRow/VariableApyCta.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PoolRow/VariableApyCta.tsx
@@ -1,14 +1,10 @@
 import { HyperdriveConfig } from "@delvtech/hyperdrive-appconfig";
-import { Link } from "@tanstack/react-router";
 import { ReactElement } from "react";
-import { calculateMarketYieldMultiplier } from "src/hyperdrive/calculateMarketYieldMultiplier";
-import { useCurrentLongPrice } from "src/ui/hyperdrive/longs/hooks/useCurrentLongPrice";
 import { PoolStat } from "src/ui/markets/PoolRow/PoolStat";
 import { VariableApyStat } from "src/ui/markets/PoolRow/VariableApyStat";
 import { useOpenShortRewards } from "src/ui/rewards/hooks/useOpenShortRewards";
 import { RewardsTooltipContent } from "src/ui/rewards/RewardsTooltip/RewardsTooltipContent";
 import { useYieldSourceRate } from "src/ui/vaults/useYieldSourceRate";
-import { useAccount } from "wagmi";
 
 interface YieldMultiplierCtaProps {
   hyperdrive: HyperdriveConfig;
@@ -17,13 +13,7 @@ interface YieldMultiplierCtaProps {
 export function VariableApyCta({
   hyperdrive,
 }: YieldMultiplierCtaProps): ReactElement {
-  const { address: account } = useAccount();
-
   const { vaultRate: yieldSourceRate } = useYieldSourceRate({
-    chainId: hyperdrive.chainId,
-    hyperdriveAddress: hyperdrive.address,
-  });
-  const { longPrice, longPriceStatus } = useCurrentLongPrice({
     chainId: hyperdrive.chainId,
     hyperdriveAddress: hyperdrive.address,
   });
@@ -32,10 +22,6 @@ export function VariableApyCta({
   const label = yieldSourceRate
     ? `Variable APY (${yieldSourceRate.ratePeriodDays}d)`
     : "Variable APY";
-  const multiplier =
-    longPriceStatus === "success" && longPrice
-      ? calculateMarketYieldMultiplier(longPrice)
-      : undefined;
 
   return (
     <PoolStat
@@ -56,32 +42,6 @@ export function VariableApyCta({
           hyperdriveAddress={hyperdrive.address}
           chainId={hyperdrive.chainId}
         />
-      }
-      action={
-        <Link
-          to="/market/$chainId/$address"
-          params={{
-            address: hyperdrive.address,
-            chainId: hyperdrive.chainId.toString(),
-          }}
-          search={{ position: "short" }}
-          className="daisy-btn h-10 min-h-10 w-full rounded-full bg-gray-500 sm:daisy-btn-sm hover:bg-gray-400 sm:h-8 sm:bg-gray-600 sm:hover:bg-gray-500 md:w-28"
-          onClick={(e) => {
-            e.stopPropagation();
-            window.plausible("positionCtaClick", {
-              props: {
-                chainId: hyperdrive.chainId,
-                poolAddress: hyperdrive.address,
-                positionType: "short",
-                statName: label,
-                statValue: multiplier ? multiplier.toString() : "",
-                connectedWallet: account,
-              },
-            });
-          }}
-        >
-          Open Short
-        </Link>
       }
     />
   );

--- a/apps/hyperdrive-trading/src/ui/markets/PoolRow/VariableApyStat.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PoolRow/VariableApyStat.tsx
@@ -4,7 +4,6 @@ import Skeleton from "react-loading-skeleton";
 import { formatRate } from "src/base/formatRate";
 import { calculateMarketYieldMultiplier } from "src/hyperdrive/calculateMarketYieldMultiplier";
 import { useAppConfigForConnectedChain } from "src/ui/appconfig/useAppConfigForConnectedChain";
-import { GradientBadge } from "src/ui/base/components/GradientBadge";
 import { useCurrentLongPrice } from "src/ui/hyperdrive/longs/hooks/useCurrentLongPrice";
 import { PercentLabel } from "src/ui/markets/PoolRow/PercentLabel";
 import { useOpenShortRewards } from "src/ui/rewards/hooks/useOpenShortRewards";
@@ -36,38 +35,25 @@ export function VariableApyStat({
 
   const multiplierLabel =
     longPriceStatus === "success" && longPrice
-      ? `${calculateMarketYieldMultiplier(longPrice).format({ decimals: 1 })}x`
+      ? `${calculateMarketYieldMultiplier(longPrice).format({ decimals: 0 })}x`
       : undefined;
 
   if (yieldSourceRateStatus !== "success") {
     return <Skeleton width={100} />;
   }
-  if (!rewards?.length && multiplierLabel && yieldSourceRate) {
-    return (
-      <div className="flex items-center gap-2 whitespace-nowrap">
-        <PercentLabel
-          value={formatRate({
-            rate: yieldSourceRate.netVaultRate,
-            includePercentSign: false,
-          })}
-          className="mr-1 text-h4"
-        />
-        <GradientBadge>{multiplierLabel}</GradientBadge>
-      </div>
-    );
-  }
 
   return (
-    <div className="flex">
-      <PercentLabel
-        value={formatRate({
-          rate: yieldSourceRate?.netVaultRate ?? 0n,
-          includePercentSign: false,
-        })}
-        className="mr-2 text-h4"
-      />
-      <GradientBadge>{multiplierLabel}</GradientBadge>
-      <span className="mx-1">⚡</span>
+    <div className="flex flex-col gap-1.5">
+      <div className="flex">
+        <PercentLabel
+          value={formatRate({
+            rate: yieldSourceRate?.netVaultRate ?? 0n,
+            includePercentSign: false,
+          })}
+        />
+        {rewards?.length ? <span className="mx-1">⚡</span> : null}
+      </div>
+      <span className="gradient-text text-left font-inter text-md font-medium">{`Up to ${multiplierLabel} exposure`}</span>
     </div>
   );
 }

--- a/apps/hyperdrive-trading/src/ui/markets/PositionPicker.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PositionPicker.tsx
@@ -26,7 +26,7 @@ export function PositionPicker({
   const poolAddress = hyperdrive.address;
 
   return (
-    <div className="flex gap-2.5">
+    <div className="flex gap-4">
       {/* TODO: Implement the term picker button */}
       <button
         className={classNames(
@@ -96,7 +96,7 @@ export function PositionPicker({
           });
         }}
       >
-        Variable
+        Short
       </Link>
       <Link
         className={classNames(

--- a/apps/hyperdrive-trading/src/ui/markets/PositionPicker.tsx
+++ b/apps/hyperdrive-trading/src/ui/markets/PositionPicker.tsx
@@ -26,7 +26,7 @@ export function PositionPicker({
   const poolAddress = hyperdrive.address;
 
   return (
-    <div className="flex gap-4">
+    <div className="flex gap-2.5">
       {/* TODO: Implement the term picker button */}
       <button
         className={classNames(
@@ -67,7 +67,7 @@ export function PositionPicker({
           });
         }}
       >
-        Long
+        Fixed
       </Link>
       <Link
         className={classNames(
@@ -96,7 +96,7 @@ export function PositionPicker({
           });
         }}
       >
-        Short
+        Variable
       </Link>
       <Link
         className={classNames(

--- a/apps/hyperdrive-trading/src/ui/onboarding/faqData2.tsx
+++ b/apps/hyperdrive-trading/src/ui/onboarding/faqData2.tsx
@@ -1,22 +1,21 @@
 export const faqData2 = [
   {
-    question: "How can I get fixed rates?",
+    question: "How do fixed rates work?",
     answer: (
       <>
-        <p>Open a Long and hold it to maturity.</p>
         <p>
-          When you open a Long in Hyperdrive, you&apos;re buying tokens at a
-          discount. These tokens are redeemable at maturity for their full
-          value, giving you a fixed return.
+          When you open a fixed rate position in Hyperdrive, you&apos;re buying
+          tokens at a discount. These tokens are redeemable at maturity for
+          their full value, giving you a fixed return.
         </p>
         <p>
-          Opening Longs has an immediate impact on the market. If more people
-          open Longs, the fixed rate goes down. If they close Longs, the fixed
-          rate goes up.
+          Opening a fixed rate position has an immediate impact on the market.
+          If more people buy the fixed rate, the fixed rate goes down. If they
+          close their position, the fixed rate goes up.
         </p>
         <p>
-          Users can also take speculative Long positions where they bet on the
-          short-term movement of rates. Read our docs to learn more about{" "}
+          Users can also take speculative fixed rate positions where they bet on
+          the short-term movement of rates. Read our docs to learn more about{" "}
           <a
             className="daisy-link hover:text-white"
             rel="noreferrer"

--- a/apps/hyperdrive-trading/src/ui/portfolio/Portfolio.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/Portfolio.tsx
@@ -36,7 +36,7 @@ export function Portfolio(): ReactElement {
       {
         id: "longs",
         content: <OpenLongsContainer account={account} />,
-        label: "Long",
+        label: "Fixed Rates",
         onClick: () => {
           navigate({
             search: (prev) => ({ ...prev, position: "longs" }),

--- a/apps/hyperdrive-trading/src/ui/portfolio/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
+++ b/apps/hyperdrive-trading/src/ui/portfolio/longs/OpenLongsTable/OpenLongsTableDesktop.tsx
@@ -332,15 +332,15 @@ function getColumns({
         );
       },
     }),
-    columnHelper.accessor("assetId", {
+    columnHelper.display({
       id: "go-to-market",
-      cell: ({ row, getValue }) => {
+      cell: ({ row }) => {
         return (
           <ManageLongsButton
-            assetId={getValue()}
+            assetId={row.original.assetId}
             account={account}
             hyperdrive={row.original.hyperdrive}
-            key={getValue()}
+            key={row.original.assetId}
           />
         );
       },


### PR DESCRIPTION
As discussed, we're switching to displaying the implied APR for the variable rate in order to make the upside more clear and ease the transition into simpler "Fixed" and "Variable" terminology instead of "Long" and "Short".