### PR TITLE
Add latest position blocks to portfolio queries

### DIFF
--- a/apps/hyperdrive-trading/src/base/latestBlocks.ts
+++ b/apps/hyperdrive-trading/src/base/latestBlocks.ts
@@ -1,0 +1,30 @@
+type PositionType = "long" | "short" | "lp";
+
+export const LATEST_POSITION_BLOCKS_BY_CHAIN_ID: Record<
+  number,
+  Record<PositionType, bigint>
+> = {
+  1: {
+    long: 22090872n,
+    short: 21391567n,
+    lp: 22108665n,
+  },
+  // Gnosis
+  100: {
+    long: 39086666n,
+    short: 39145215n,
+    lp: 39083204n,
+  },
+  // Linea
+  59144: {
+    long: 10622294n,
+    short: 10621975n,
+    lp: 15639198n,
+  },
+  // Base
+  8453: {
+    long: 28017409n,
+    short: 26080016n,
+    lp: 27852111n,
+  },
+};

--- a/apps/hyperdrive-trading/src/ui/portfolio/longs/usePortfolioLongsData.ts
+++ b/apps/hyperdrive-trading/src/ui/portfolio/longs/usePortfolioLongsData.ts
@@ -78,7 +78,7 @@ export function usePortfolioLongsData({
                   );
                   return {
                     hyperdrive,
-                    openLongs: [] as OpenLongPositionReceived[],
+                    openLongs: [],
                   };
                 }
               }),


### PR DESCRIPTION
Partial patch to the portfolio queries which limits the "toBlock" of event queries for the longs and shorts. Some of the queries are still failing and will need to be broken up into smaller queries, but this gets us half way there so at least some positions will show up.