### PR TITLE
Add hash router

### DIFF
--- a/apps/hyperdrive-trading/src/ui/app/App/App.tsx
+++ b/apps/hyperdrive-trading/src/ui/app/App/App.tsx
@@ -1,6 +1,10 @@
 import { ReactElement, StrictMode } from "react";
 
-import { createRouter, RouterProvider } from "@tanstack/react-router";
+import {
+  createHashHistory,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
 
 // Import the generated route tree
 import { routeTree } from "src/routeTree.gen";
@@ -11,6 +15,7 @@ import { useAccount, useAccountEffect } from "wagmi";
 const router = createRouter({
   routeTree,
   basepath: import.meta.env.VITE_BASE_PATH,
+  history: createHashHistory(),
 });
 
 // Register the router instance for type safety


### PR DESCRIPTION
This fixes 404 errors trying to load subpaths in GitHub pages by switching to [Hash Routing](https://tanstack.com/router/v1/docs/framework/react/guide/history-types#hash-routing).